### PR TITLE
Changes need to support the new interactive guides.

### DIFF
--- a/src/main/content/_includes/head.html
+++ b/src/main/content/_includes/head.html
@@ -12,6 +12,11 @@
   {% for css in page.css %}
     <link rel="stylesheet" href="{{ "/css/" | append: css | append: '.css' | relative_url }}">
   {% endfor %}
+
+  {% for css in page.guides-css %}
+  <link rel="stylesheet" href="{{ "/guides/" | append: css | append: '.css' }}">
+  {% endfor %}
+
   {% for css in layout.css %}
     <link rel="stylesheet" href="{{ "/css/" | append: css | append: '.css' | relative_url }}">
   {% endfor %}

--- a/src/main/content/_layouts/default.html
+++ b/src/main/content/_layouts/default.html
@@ -21,6 +21,11 @@
     {% for js in page.js %}
       <script src="{{ "/js/" | append: js | append: '.js' | relative_url }}"></script>
     {% endfor %}
+    
+    {% for js in page.guides-js %}
+      <script src="{{ "/guides/" | append: js | append: '.js' }}"></script>
+    {% endfor %}
+
     {% for js in layout.js %}
       <script src="{{ "/js/" | append: js | append: '.js' | relative_url }}"></script>
     {% endfor %}

--- a/src/main/content/_layouts/interactive-guide.html
+++ b/src/main/content/_layouts/interactive-guide.html
@@ -1,0 +1,34 @@
+---
+layout: default
+css: guide
+js: guide
+---
+
+<div id="background_container" class="black_blue_gradient_background">
+    <div class="container">
+        <div id="title_row" class="row">
+            <div class="col-xs-12">
+                <img id="intro_logo" src="{{ "/img/guides_page_title_small.svg" | relative }}" alt="Guides">
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-sm-3">
+                <a id="all_guides_link" href="/guides">All Guides</a>
+                <h3 id="toc_title"></h3>
+                <div id="toc_container">
+                </div>
+                    <h3 id="tag_title">Tags</h3>
+                    <div id="tags_container">
+                        {% for tag in page.tags %}
+                            <a href="/guides?search={{ tag }}&key=tag">{{ tag }}</a>
+                        {% endfor %}
+                    </div>
+            </div>
+            <div id="guide_column" class="col-sm-9 position_relative">
+                <div id="guide_content">
+                    {{ content }}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/main/content/css/guide.css
+++ b/src/main/content/css/guide.css
@@ -44,7 +44,7 @@
     color: #F4914D;
 }
 
-#guide_content pre {
+#guide_content pre:not(.CodeMirror-line) {
     border-radius: 0;
     border: none;
     padding: 30px;


### PR DESCRIPTION
~1.  jQuery needs to be loaded before the interactive guide content.  The interactive guides use jQuery.  Without jQuery higher up in the HTML, the following error is thrown when loading the interactive guides~

~> blueprint.js:1 Uncaught ReferenceError: $ is not defined~
~>     at blueprint.js:1~

1.  Load any custom javascript and css files that are from guide repos

2.  Need to avoid overriding the `<pre>` styling used by third-party library [CodeMirror](https://github.com/codemirror/CodeMirror)  used by the interactive guides.

3.  New interactive guide layout