### PR TITLE
add allow-uri-read attribute to asciidoc

### DIFF
--- a/src/main/content/_config.yml
+++ b/src/main/content/_config.yml
@@ -14,6 +14,7 @@ asciidoctor:
     - icons=font
     - source-highlighter=coderay
     - coderay-css=style
+    - allow-uri-read
 
 google_tag_manager: GTM-TKP3KJ7
 #google_analytics: UA-104349928-1


### PR DESCRIPTION
For future guides, we can set the common-include to an url `:common-includes: https://raw.githubusercontent.com/OpenLiberty/guides-common/master` instead of using relative path`:common-includes: ../guides-common/` .

I would suggest to remove the `git clone "https://github.com/OpenLiberty/guides-common.git" src/main/content/guides/guides-common` line in the `scripts/build.sh` once the update is done for all guides.