### PR TITLE
Always clone the master branch for the interactive guide repositories

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,9 +16,9 @@ git clone "https://github.com/OpenLiberty/guide-rest-hateoas.git" src/main/conte
 git clone "https://github.com/OpenLiberty/guide-rest-client-java" src/main/content/guides/guide_rest_client_java
 git clone "https://github.com/OpenLiberty/guide-maven-multimodules" src/main/content/guides/guide_maven_multimodules
 
-# Clone the circuit breaker interactive guide. 
-git clone "https://github.com/OpenLiberty/iguides-common" src/main/content/guides/iguides-common
-git clone "https://github.com/OpenLiberty/iguide-circuit-breaker" src/main/content/guides/iguide-circuit-breaker
+# Clone the circuit breaker interactive guide.
+git clone "https://github.com/OpenLiberty/iguides-common" --branch master --single-branch src/main/content/guides/iguides-common
+git clone "https://github.com/OpenLiberty/iguide-circuit-breaker" --branch master --single-branch src/main/content/guides/iguide-circuit-breaker
 # Move any js/css files from guides to the _assets folder for jekyll-assets minification.
 find src/main/content/guides/iguide* -d -name js -exec cp -R '{}' src/main/content/_assets \;
 find src/main/content/guides/iguide* -d -name css -exec cp -R '{}' src/main/content/_assets \;


### PR DESCRIPTION
Pull request
----
The interactive guide contributors would like to change the `iguide*` repositories' default branch from `master` to `dev`.  I've researched and tested that `git clone` will clone the default branch set in GitHub.  We want `git clone` to always clone the master branch when building openliberty.io.

**Background info about why the default branches are being changed on the interactive guides repositories**
-----
The `master` branches for the `iguide*` repositories are considered "production ready" code to be published to openliberty.io.  Most of the daily commit activity is on the the `dev` branch.  When we are ready to publish to openliberty.io, the `dev` branch is merged into the `master` branch and automatically built when the openliberty.io bluemix toolchain is run.

When creating pull requests, the default branch is the default target for the pull request.  The developers would like to have the default branch be `dev` since majority of the pull requests are to the `dev` branch and not to the `master` branch.  When we switch the default branch on the repository, we still want to ensure that the `master` branch is what is built with openliberty.io.