### PR TITLE
Add robot.txt to development environments

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /
+Noindex: /

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,24 +7,6 @@ rvm requirements
 rvm install 2.4.1
 rvm use 2.4.1 --default
 sudo apt-get -y install nodejs
-gem install jekyll bundler jekyll-feed jekyll-asciidoc coderay jekyll-assets uglifier octopress-minify-html
-git clone "https://github.com/OpenLiberty/guides-common.git" src/main/content/guides/guides-common
-git clone "https://github.com/OpenLiberty/guide-rest-intro.git" src/main/content/guides/guide_rest_intro
-git clone "https://github.com/OpenLiberty/guide-maven-intro.git" src/main/content/guides/guide_maven_intro
-git clone "https://github.com/OpenLiberty/guide-microprofile-intro.git" src/main/content/guides/guide_microprofile_intro
-git clone "https://github.com/OpenLiberty/guide-rest-hateoas.git" src/main/content/guides/guide_rest_hateoas
-git clone "https://github.com/OpenLiberty/guide-rest-client-java" src/main/content/guides/guide_rest_client_java
-git clone "https://github.com/OpenLiberty/guide-maven-multimodules" src/main/content/guides/guide_maven_multimodules
-git clone "https://github.com/OpenLiberty/guide-cors" src/main/content/guides/guide_cors
 
-# Clone the circuit breaker interactive guide.
-git clone "https://github.com/OpenLiberty/iguides-common" --branch master --single-branch src/main/content/guides/iguides-common
-git clone "https://github.com/OpenLiberty/iguide-circuit-breaker" --branch master --single-branch src/main/content/guides/iguide-circuit-breaker
-# Move any js/css files from guides to the _assets folder for jekyll-assets minification.
-find src/main/content/guides/iguide* -d -name js -exec cp -R '{}' src/main/content/_assets \;
-find src/main/content/guides/iguide* -d -name css -exec cp -R '{}' src/main/content/_assets \;
-
-mkdir target
-mkdir target/jekyll-webapp
-jekyll build --source src/main/content --destination target/jekyll-webapp
-mvn -B package
+SCRIPT_DIR=$(dirname $0)
+source $SCRIPT_DIR/build_jekyll.sh

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,3 +1,6 @@
+# These are steps needed when hosting the website on IBM Cloud (once known as IBM Bluemix)
+#
+#
 sudo apt-get update
 sudo apt-get install libgdbm-dev libncurses5-dev automake libtool bison libffi-dev -y
 gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
@@ -9,4 +12,4 @@ rvm use 2.4.1 --default
 sudo apt-get -y install nodejs
 
 SCRIPT_DIR=$(dirname $0)
-source $SCRIPT_DIR/build_jekyll.sh
+source $SCRIPT_DIR/build_jekyll_maven.sh

--- a/scripts/build_jekyll.sh
+++ b/scripts/build_jekyll.sh
@@ -15,6 +15,12 @@ git clone "https://github.com/OpenLiberty/iguide-circuit-breaker" --branch maste
 find src/main/content/guides/iguide* -d -name js -exec cp -R '{}' src/main/content/_assets \;
 find src/main/content/guides/iguide* -d -name css -exec cp -R '{}' src/main/content/_assets \;
 
+# if DEVELOPMENT environment, copy robots.txt
+if [ ${ENVIRONMENT} = "DEVELOPMENT" ]; then
+    echo "Development environment - adding robots.txt"
+    cp robots.txt src/main/content/robots.txt
+fi
+
 mkdir target
 mkdir target/jekyll-webapp
 jekyll build --source src/main/content --destination target/jekyll-webapp

--- a/scripts/build_jekyll.sh
+++ b/scripts/build_jekyll.sh
@@ -1,0 +1,21 @@
+gem install jekyll bundler jekyll-feed jekyll-asciidoc coderay jekyll-assets uglifier octopress-minify-html
+git clone "https://github.com/OpenLiberty/guides-common.git" src/main/content/guides/guides-common
+git clone "https://github.com/OpenLiberty/guide-rest-intro.git" src/main/content/guides/guide_rest_intro
+git clone "https://github.com/OpenLiberty/guide-maven-intro.git" src/main/content/guides/guide_maven_intro
+git clone "https://github.com/OpenLiberty/guide-microprofile-intro.git" src/main/content/guides/guide_microprofile_intro
+git clone "https://github.com/OpenLiberty/guide-rest-hateoas.git" src/main/content/guides/guide_rest_hateoas
+git clone "https://github.com/OpenLiberty/guide-rest-client-java" src/main/content/guides/guide_rest_client_java
+git clone "https://github.com/OpenLiberty/guide-maven-multimodules" src/main/content/guides/guide_maven_multimodules
+git clone "https://github.com/OpenLiberty/guide-cors" src/main/content/guides/guide_cors
+
+# Clone the circuit breaker interactive guide.
+git clone "https://github.com/OpenLiberty/iguides-common" --branch master --single-branch src/main/content/guides/iguides-common
+git clone "https://github.com/OpenLiberty/iguide-circuit-breaker" --branch master --single-branch src/main/content/guides/iguide-circuit-breaker
+# Move any js/css files from guides to the _assets folder for jekyll-assets minification.
+find src/main/content/guides/iguide* -d -name js -exec cp -R '{}' src/main/content/_assets \;
+find src/main/content/guides/iguide* -d -name css -exec cp -R '{}' src/main/content/_assets \;
+
+mkdir target
+mkdir target/jekyll-webapp
+jekyll build --source src/main/content --destination target/jekyll-webapp
+mvn -B package

--- a/scripts/build_jekyll_maven.sh
+++ b/scripts/build_jekyll_maven.sh
@@ -1,3 +1,6 @@
+#  This script contains the end-to-end steps for building the website with Jekyll and using Maven to package
+#
+#
 gem install jekyll bundler jekyll-feed jekyll-asciidoc coderay jekyll-assets uglifier octopress-minify-html
 git clone "https://github.com/OpenLiberty/guides-common.git" src/main/content/guides/guides-common
 git clone "https://github.com/OpenLiberty/guide-rest-intro.git" src/main/content/guides/guide_rest_intro
@@ -24,4 +27,6 @@ fi
 mkdir target
 mkdir target/jekyll-webapp
 jekyll build --source src/main/content --destination target/jekyll-webapp
+
+# Maven packaging
 mvn -B package


### PR DESCRIPTION
1.  `build.sh` is split into two files.  One file `build.sh` contains commands that are used to setup the Bluemix environment.  `build_jekyll.sh` contains commands specific to the `jekyll` build environment.  The motivation is to allow others to build the website using other tools besides Bluemix.

2.  For development environments, include a `robots.txt` in the website `war` so that web crawlers know to avoid indexing the development environments. 

We confirmed that the robots.txt worked using Google's tester.
https://support.google.com/webmasters/answer/6062598?hl=en&ref_topic=6061961