### PR TITLE
Update README with IBM Cloud brand name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![](src/main/content/img/logo.png)
 
 # Introduction
-Openliberty.io is a portable, mobile enabled web application hosted on [Bluemix](https://console.bluemix.net/). It features [Jekyll](https://jekyllrb.com/) based templates with [Asciidoctor](http://asciidoctor.org/) support. New content, such as blog posts and guides, can be easily added in HTML, markdown or asciidoc format. Build process integration provides access to the latest releases and development builds for Open Liberty as well as Eclipse tools. Built-in gitHub integration allows browsing open issues from within the site. A continuous delivery process using [Bluemix DevOps Toolchains](https://www.ibm.com/devops/method/category/tools/) makes it possible to instantly update the application by pushing changes to the repository. 
+Openliberty.io is a portable, mobile enabled web application hosted on [IBM Cloud](https://console.bluemix.net/). It features [Jekyll](https://jekyllrb.com/) based templates with [Asciidoctor](http://asciidoctor.org/) support. New content, such as blog posts and guides, can be easily added in HTML, markdown or asciidoc format. Build process integration provides access to the latest releases and development builds for Open Liberty as well as Eclipse tools. Built-in gitHub integration allows browsing open issues from within the site. A continuous delivery process using [IBM Cloud DevOps Toolchains](https://www.ibm.com/devops/method/category/tools/) makes it possible to instantly update the application by pushing changes to the repository. 
 
 ## Portability
 The graphical user interface is built to work consistently across all major web browsers, including Chrome, Edge, Internet Explorer, Firefox and Safari.


### PR DESCRIPTION
Bluemix is now called IBM Cloud
https://www.ibm.com/blogs/bluemix/2017/10/bluemix-is-now-ibm-cloud/