### PR TITLE
#51 New custom CodeRay styling and line wrapping fix

### DIFF
--- a/src/main/content/_assets/css/coderay-custom.css
+++ b/src/main/content/_assets/css/coderay-custom.css
@@ -1,0 +1,141 @@
+/*
+  This basis of this stylesheet was genereated with CodeRay 1.1.2 
+  using command line: coderay stylesheet
+
+  There are custom modifications to color and font-weight.
+*/
+.CodeRay {
+  background-color: hsl(0,0%,95%);
+  border: 1px solid silver;
+  color: black;
+}
+.CodeRay pre {
+  margin: 0px;
+}
+
+span.CodeRay { white-space: pre; border: 0px; padding: 2px; }
+
+table.CodeRay { border-collapse: collapse; width: 100%; padding: 2px; }
+table.CodeRay td { padding: 2px 4px; vertical-align: top; }
+
+.CodeRay .line-numbers {
+  background-color: hsl(180,65%,90%);
+  color: gray;
+  text-align: right;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+}
+.CodeRay .line-numbers a {
+  background-color: hsl(180,65%,90%) !important;
+  color: gray !important;
+  text-decoration: none !important;
+}
+.CodeRay .line-numbers pre {
+  word-break: normal;
+}
+.CodeRay .line-numbers a:target { color: blue !important; }
+.CodeRay .line-numbers .highlighted { color: red !important; }
+.CodeRay .line-numbers .highlighted a { color: red !important; }
+.CodeRay span.line-numbers { padding: 0px 4px; }
+.CodeRay .line { display: block; float: left; width: 100%; }
+.CodeRay .code { width: 100%; }
+
+.CodeRay .debug { color: white !important; background: blue !important; }
+
+.CodeRay .annotation { color:#043377 }
+.CodeRay .attribute-name { color:#47526A }
+.CodeRay .attribute-value { color:#700 }
+.CodeRay .binary { color:#549 }
+.CodeRay .binary .char { color:#325 }
+.CodeRay .binary .delimiter { color:#325 }
+.CodeRay .char { color:#D20 }
+.CodeRay .char .content { color:#D20 }
+.CodeRay .char .delimiter { color:#710 }
+.CodeRay .class { color:#995613; font-weight:500 }
+.CodeRay .class-variable { color:#369 }
+.CodeRay .color { color:#0A0 }
+.CodeRay .comment { color:#777 }
+.CodeRay .comment .char { color:#444 }
+.CodeRay .comment .delimiter { color:#444 }
+.CodeRay .constant { color:#036; font-weight:500 }
+.CodeRay .decorator { color:#B0B }
+.CodeRay .definition { color:#099; font-weight:500 }
+.CodeRay .delimiter { color:black }
+.CodeRay .directive { color:#0E670F; font-weight:500 }
+.CodeRay .docstring { color:#D42; }
+.CodeRay .doctype { color:#34b }
+.CodeRay .done { text-decoration: line-through; color: gray }
+.CodeRay .entity { color:#800; font-weight:500 }
+.CodeRay .error { color:#F00; background-color:#FAA }
+.CodeRay .escape  { color:#666 }
+.CodeRay .exception { color:#554499; font-weight:500 }
+.CodeRay .float { color:#60E }
+.CodeRay .function { color:#06B; font-weight:500 }
+.CodeRay .function .delimiter { color:#059 }
+.CodeRay .function .content { color:#037 }
+.CodeRay .global-variable { color:#d70 }
+.CodeRay .hex { color:#02b }
+.CodeRay .id  { color:#33D; font-weight:500 }
+.CodeRay .include { color:#554099; font-weight:500 }
+.CodeRay .inline { background-color: hsla(0,0%,0%,0.07); color: black }
+.CodeRay .inline-delimiter { font-weight: 500; color: #666 }
+.CodeRay .instance-variable { color:#33B }
+.CodeRay .integer  { color:#00D }
+.CodeRay .imaginary { color:#f00 }
+.CodeRay .important { color:#D00 }
+.CodeRay .key { color: #554499 }
+.CodeRay .key .char { color: #554499 }
+.CodeRay .key .delimiter { color: #554499}
+.CodeRay .keyword { color:#033077; font-weight:500 }
+.CodeRay .label { color:#970; font-weight:500 }
+.CodeRay .local-variable { color:#0A62BC; font-weight:500 }
+.CodeRay .map .content { color:#808 }
+.CodeRay .map .delimiter { color:#40A}
+.CodeRay .map { background-color:hsla(200,100%,50%,0.06); }
+.CodeRay .namespace { color:#554099; font-weight:500 }
+.CodeRay .octal { color:#40E }
+.CodeRay .operator { }
+.CodeRay .predefined { color:#369; font-weight:500 }
+.CodeRay .predefined-constant { color:#069 }
+.CodeRay .predefined-type { color:#566D17; font-weight:500 }
+.CodeRay .preprocessor { color:#579 }
+.CodeRay .pseudo-class { color:#00C; font-weight:500 }
+.CodeRay .regexp { background-color:hsla(300,100%,50%,0.06); }
+.CodeRay .regexp .content { color:#808 }
+.CodeRay .regexp .delimiter { color:#404 }
+.CodeRay .regexp .modifier { color:#C2C }
+.CodeRay .reserved { color:#080; font-weight:500 }
+.CodeRay .shell { background-color:hsla(120,100%,50%,0.06); }
+.CodeRay .shell .content { color:#2B2 }
+.CodeRay .shell .delimiter { color:#161 }
+.CodeRay .string { background-color: unset }
+.CodeRay .string .char { color: #b0b }
+
+.CodeRay .string .content,
+.CodeRay .string .delimiter {
+  color: #383599
+}
+
+.CodeRay .string .modifier { color: #E40 }
+.CodeRay .symbol { color:#A60 }
+.CodeRay .symbol .content { color:#A60 }
+.CodeRay .symbol .delimiter { color:#740 }
+.CodeRay .tag { color:#070; font-weight:500 }
+.CodeRay .type { color:#332C9A; font-weight:500 }
+.CodeRay .value { color: #088 }
+.CodeRay .variable { color:#037 }
+
+.CodeRay .insert { background: hsla(120,100%,50%,0.12) }
+.CodeRay .delete { background: hsla(0,100%,50%,0.12) }
+.CodeRay .change { color: #bbf; background: #007 }
+.CodeRay .head { color: #f8f; background: #505 }
+.CodeRay .head .filename { color: white; }
+
+.CodeRay .delete .eyecatcher { background-color: hsla(0,100%,50%,0.2); border: 1px solid hsla(0,100%,45%,0.5); margin: -1px; border-bottom: none; border-top-left-radius: 5px; border-top-right-radius: 5px; }
+.CodeRay .insert .eyecatcher { background-color: hsla(120,100%,50%,0.2); border: 1px solid hsla(120,100%,25%,0.5); margin: -1px; border-top: none; border-bottom-left-radius: 5px; border-bottom-right-radius: 5px; }
+
+.CodeRay .insert .insert { color: #0c0; background:transparent; font-weight:500 }
+.CodeRay .delete .delete { color: #c00; background:transparent; font-weight:500 }
+.CodeRay .change .change { color: #88f }
+.CodeRay .head .head { color: #f4f }

--- a/src/main/content/_assets/css/guide.css
+++ b/src/main/content/_assets/css/guide.css
@@ -55,12 +55,22 @@
     color: #F4914D;
 }
 
+#guide_content code,
+#guide_content pre  {
+    /* Bootstrap override */
+    background-color: #F3F4F7;
+    color: #5e6b8d;
+}
+
+#guide_content code {
+    /* Bootstrap override */
+    word-wrap: break-word;
+}
+
 #guide_content pre {
     border-radius: 0;
     border: none;
     padding: 30px;
-    background-color: #eeeff3;
-    color: #5e6b8d;
 }
 
 #guide_content table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}

--- a/src/main/content/_config.yml
+++ b/src/main/content/_config.yml
@@ -13,7 +13,7 @@ asciidoctor:
   attributes:
     - icons=font
     - source-highlighter=coderay
-    - coderay-css=style
+    - coderay-css=class
     - allow-uri-read
 
 google_tag_manager: GTM-TKP3KJ7

--- a/src/main/content/_includes/head.html
+++ b/src/main/content/_includes/head.html
@@ -9,6 +9,7 @@
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
   {% css openliberty %}
+  {% css coderay-custom %}
 
   {% for css_name in page.css %}
     {% css {{css_name}} %}


### PR DESCRIPTION
- Enable custom CodeRay stylesheet in the build configuration
- Use the colors provided by design for the code blocks with syntax highlighting enabled.
- Fix the problem where the code blocks were not line wrapping on mobile.