### PR TITLE
#63 Publish guides based on repository name

### DIFF
--- a/scripts/build_clone_guides.rb
+++ b/scripts/build_clone_guides.rb
@@ -1,0 +1,42 @@
+# This script is to automate the publication of guides to 
+# openliberty.io and the staging site (openlibertydev.mybluemix.net)
+#
+# The assumption is that guides that are ready for openliberty.io 
+# have a GitHub repository name starting with:
+#       guide* or iguide*
+#
+# The assumption is that a guide that are still being development, 
+# but need to be on the test website have a GitHub repository name starting with:
+#       draft-guide*
+require 'json'
+
+# This variable is to determine if we want to clone the "still in progress"
+# guides that are not ready to be on openliberty.io
+cloneDraftGuides = ARGV[0]
+
+# Get all the Open Liberty repositories
+response = `curl https://api.github.com/orgs/OpenLiberty/repos?access_token=$PAT`
+json = JSON.parse(response)
+
+# Exceptions due to adopting of this new automated integration of guides
+# There are two guides that are currently still in draft mode but do not have "draft-" in their repository name.
+# To avoid unneeded trouble of renaming them, lets just mark the guides as draft with special code.
+# The end goal is this array to _always_ be empty.
+draftRepos = ["guide-microprofile-config", "iguide-microprofile-config"]
+
+# Filter for Open Liberty guide repositories
+guides = []
+json.each do |element|
+    repo_name = element['name']
+    if cloneDraftGuides == "draft-guide"
+        if repo_name.start_with?('draft-guide') or draftRepos.include?(repo_name)
+            # Clone guides that are still being drafted and are only for the staging website
+            `git clone https://github.com/OpenLiberty/#{repo_name}.git src/main/content/guides/#{repo_name}`
+        end
+    else
+        if (repo_name.start_with?('guide') or repo_name.start_with?('iguide')) and not draftRepos.include?(repo_name)
+            # Clone guides that are ready to be published to openliberty.io
+            `git clone https://github.com/OpenLiberty/#{repo_name}.git src/main/content/guides/#{repo_name}`
+        end
+    end
+end

--- a/scripts/build_jekyll_maven.sh
+++ b/scripts/build_jekyll_maven.sh
@@ -5,21 +5,12 @@ echo "Installing ruby packages..."
 gem install jekyll bundler jekyll-feed jekyll-asciidoc coderay uglifier octopress-minify-html
 gem install jekyll-assets -v 2.4.0
 
-# List of static guides
-echo "Cloning guides..."
-git clone "https://github.com/OpenLiberty/guides-common.git" src/main/content/guides/guides-common
-git clone "https://github.com/OpenLiberty/guide-rest-intro.git" src/main/content/guides/guide_rest_intro
-git clone "https://github.com/OpenLiberty/guide-maven-intro.git" src/main/content/guides/guide_maven_intro
-git clone "https://github.com/OpenLiberty/guide-microprofile-intro.git" src/main/content/guides/guide_microprofile_intro
-git clone "https://github.com/OpenLiberty/guide-rest-hateoas.git" src/main/content/guides/guide_rest_hateoas
-git clone "https://github.com/OpenLiberty/guide-rest-client-java.git" src/main/content/guides/guide_rest_client_java
-git clone "https://github.com/OpenLiberty/guide-maven-multimodules.git" src/main/content/guides/guide_maven_multimodules
-git clone "https://github.com/OpenLiberty/guide-cors.git" src/main/content/guides/guide_cors
-git clone "https://github.com/OpenLiberty/guide-rest-client-angularjs.git" src/main/content/guides/guide-rest-client-angularjs
+echo "Ruby version:"
+echo `ruby -v`
 
-# List of interactive guides
-git clone "https://github.com/OpenLiberty/iguides-common.git" --branch master --single-branch src/main/content/guides/iguides-common
-git clone "https://github.com/OpenLiberty/iguide-circuit-breaker.git" --branch master --single-branch src/main/content/guides/iguide-circuit-breaker
+# Guides that are ready to be published to openliberty.io
+echo "Cloning repositories with name starting with guide or iguide..."
+ruby ./scripts/build_clone_guides.rb
 
 # Development environment only actions
 if [ "$JEKYLL_ENV" != "production" ]; then
@@ -28,8 +19,7 @@ if [ "$JEKYLL_ENV" != "production" ]; then
     cp robots.txt src/main/content/robots.txt
     
     echo "Clone guides that are only for test site..."
-    git clone "https://github.com/OpenLiberty/guide-microprofile-config.git" src/main/content/guides/guide_microprofile_config
-    git clone "https://github.com/OpenLiberty/iguide-microprofile-config.git" src/main/content/guides/iguide-microprofile-config
+    ruby ./scripts/build_clone_guides.rb "draft-guide"
 fi
 
 # Move any js/css files from guides to the _assets folder for jekyll-assets minification.


### PR DESCRIPTION
- A new ruby script to clone Open Liberty repositories with names that start with guide, iguide, or draft-guide