### PR TITLE
Fix ManagedExecutorService-related element names

### DIFF
--- a/src/main/content/_posts/2017-12-21-jsf-implementation-open-liberty-17004.adoc
+++ b/src/main/content/_posts/2017-12-21-jsf-implementation-open-liberty-17004.adoc
@@ -79,8 +79,8 @@ Managed executors can be configured to use the concurrency policy as follows:
 
 [source,xml]
 ----
-<managedExecutor jndiName="concurrent/executor1" concurrencyPolicyRef="max10"/>
-<managedSchduledExecutor jndiName="concurrent/executor2" concurrencyPolicyRef="max10"/>
+<managedExecutorService jndiName="concurrent/executor1" concurrencyPolicyRef="max10"/>
+<managedScheduledExecutorService jndiName="concurrent/executor2" concurrencyPolicyRef="max10"/>
 ----
 
 For more info, see the WebSphere Liberty Knowledge Center docs on https://www.ibm.com/support/knowledgecenter/SSEQTP_liberty/com.ibm.websphere.liberty.autogen.base.doc/ae/rwlp_config_managedExecutorService.html[Configuring the managed executor service] and https://www.ibm.com/support/knowledgecenter/SSEQTP_liberty/com.ibm.websphere.liberty.autogen.base.doc/ae/rwlp_config_managedScheduledExecutorService.html[Configuring the managed scheduled executor service].


### PR DESCRIPTION
It's `managedExecutorService` not `managedExecutor`.