### PR TITLE
Update latest version to 17.0.0.4

### DIFF
--- a/src/main/content/latestVersion.js
+++ b/src/main/content/latestVersion.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *******************************************************************************/
 
 var latestReleasedVersion = {
-    version: '17.0.0.3',
+    version: '17.0.0.4',
     productName : 'Open Liberty Runtime',
     availableFrom : 'https://openliberty.io/downloads?welcome'
 };


### PR DESCRIPTION
Update latestVersion.js to indicate that 17.0.0.4 is the latest version.  Without this update, the welcome page of a 17004 OpenLiberty install will show a banner indicating that an update is available, even though the currently running server is fully up to date.

