### PR TITLE
Floating table of content for desktop view

### DIFF
--- a/src/main/content/_assets/css/guide.css
+++ b/src/main/content/_assets/css/guide.css
@@ -89,6 +89,7 @@
 #background_container {
     padding-top: 100px;
     min-height: 600px;
+    /* if you change the 200px, please also change backgroundSizeAdjustment in guide.js */ 
     background-size: 100% calc(100% - 200px);
     background-repeat: no-repeat;
     margin-bottom: 100px;

--- a/src/main/content/_assets/js/guide.js
+++ b/src/main/content/_assets/js/guide.js
@@ -9,6 +9,89 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
+// The background is shortened by 200px
+var backgroundSizeAdjustment = 200;
+
+function heightOfVisibleBackground() {
+    var result;
+    if(isBackgroundBottomVisible()) {
+        var scrollTop = $(window).scrollTop();
+        result = getBackgroundBottomPosition() - scrollTop;
+    } else {
+        // Assume the background is filling up the entire viewport
+        result = $(window).height();
+    }
+    return result;
+}
+
+function getBackgroundBottomPosition() {
+    var background = $('#background_container'),
+    elementTop = background.offset().top,
+    elementBottomPosition = elementTop + (background.outerHeight() - backgroundSizeAdjustment);
+    return elementBottomPosition;
+}
+
+// Determine if the bottom of the visible dark background is now visible 
+// in the browser's viewport.
+function isBackgroundBottomVisible() {
+    var background = $('#background_container'),
+        currentTopPosition = $(window).scrollTop(),
+        currentBottomPosition = currentTopPosition + $(window).height(),
+        elementBottomPosition = getBackgroundBottomPosition(),
+        visibleBottom = currentBottomPosition > elementBottomPosition;
+    return visibleBottom;
+}
+
+// Handle when to float the table of content
+function handleFloatingTableOfContent() {
+    if($(window).width() > 769) { // bootstrap grid size for sm column
+        // CURRENTLY IN DESKTOP VIEW
+        if($(window).scrollTop() > $('#toc_column').offset().top) {
+            // The top of the TOC is scrolling off the screen, enable floating TOC.
+
+            // Get the initial width of the TOC before applying position:fixed
+            var toc_width = $('#toc_inner').width();
+            
+            // position:fixed loses the original TOC width.  Restore original width when
+            // applying position fixed.
+            $('#toc_inner').width(toc_width);
+            if(isBackgroundBottomVisible()) {
+                handleTOCScolling();
+            } else {
+                // The entire viewport is filled with the background, so
+                // do not need to worry about the TOC flowing out of the background.
+                $('#toc_inner').css({"position":"fixed", "top":"0"});
+            }
+        } else {
+            // TOC no longer needs to float,
+            // remove all the custom styling for floating TOC
+            disableFloatingTOC();
+        }
+    } else {
+        // CURRENTLY IN MOBILE VIEW
+        // Remove any floating TOC when on mobile
+        disableFloatingTOC();
+    }
+}
+
+function disableFloatingTOC() {
+    $('#toc_inner').width("").css({"position": "", "top": ""});
+}
+
+// Handle when the table of content (TOC) is too small to fit completely in the dark background.
+// We want to give the end result of the bottom of the TOC sticks to the bottom of the dark background
+// and the top of the TOC scrolls off screen.
+function handleTOCScolling() {
+    var visible_background_height = heightOfVisibleBackground();
+    var toc_height = $('#toc_inner').height();
+    if(toc_height > visible_background_height) {
+        // The TOC cannot fit in the dark background, allow the TOC to scroll out of viewport
+        // to avoid the TOC overflowing out of the dark background
+        var negativeNumber = visible_background_height - toc_height;
+        $('#toc_inner').css({"position":"fixed", "top":negativeNumber});
+    }
+}
+
 $(document).ready(function() {
 
     var offset;
@@ -64,9 +147,21 @@ $(document).ready(function() {
 
     });
 
+    // RELATED GUIDES
+    //
+    // Add Related guides link to the table of contents, if needed
+    //
     if( $('#related-guides').length ) {
         // Add _one_ Related guides link to the very bottom of the table of contents.
         // The assumption is that the TOC only contains one `sectlevel1` class.
         $('#toc_container ul.sectlevel1').append('<li><a href="#related-guides">Related guides</a></li>')
     }
+
+    // TABLE OF CONTENT
+    //
+    // Keep the table of content (TOC) in view while scrolling (Desktop only)
+    //
+    $(window).scroll(function() {
+        handleFloatingTableOfContent();
+    });
 });

--- a/src/main/content/_assets/js/guide.js
+++ b/src/main/content/_assets/js/guide.js
@@ -16,7 +16,7 @@ function heightOfVisibleBackground() {
     var result;
     if(isBackgroundBottomVisible()) {
         var scrollTop = $(window).scrollTop();
-        result = getBackgroundBottomPosition() - scrollTop;
+        result = getBackgroundAbsoluteBottomPosition() - scrollTop;
     } else {
         // Assume the background is filling up the entire viewport
         result = $(window).height();
@@ -24,7 +24,9 @@ function heightOfVisibleBackground() {
     return result;
 }
 
-function getBackgroundBottomPosition() {
+// Get the absolute position of the bottom of the dark background regardless
+// of whether the bottom is in the browser's viewport
+function getBackgroundAbsoluteBottomPosition() {
     var background = $('#background_container'),
     elementTop = background.offset().top,
     elementBottomPosition = elementTop + (background.outerHeight() - backgroundSizeAdjustment);
@@ -37,7 +39,7 @@ function isBackgroundBottomVisible() {
     var background = $('#background_container'),
         currentTopPosition = $(window).scrollTop(),
         currentBottomPosition = currentTopPosition + $(window).height(),
-        elementBottomPosition = getBackgroundBottomPosition(),
+        elementBottomPosition = getBackgroundAbsoluteBottomPosition(),
         visibleBottom = currentBottomPosition > elementBottomPosition;
     return visibleBottom;
 }
@@ -60,7 +62,7 @@ function handleFloatingTableOfContent() {
             } else {
                 // The entire viewport is filled with the background, so
                 // do not need to worry about the TOC flowing out of the background.
-                $('#toc_inner').css({"position":"fixed", "top":"0"});
+                enableFloatingTOC();
             }
         } else {
             // TOC no longer needs to float,
@@ -76,6 +78,10 @@ function handleFloatingTableOfContent() {
 
 function disableFloatingTOC() {
     $('#toc_inner').width("").css({"position": "", "top": ""});
+}
+
+function enableFloatingTOC() {
+    $('#toc_inner').css({"position":"fixed", "top":"0"});
 }
 
 // Handle when the table of content (TOC) is too small to fit completely in the dark background.

--- a/src/main/content/_layouts/guide.html
+++ b/src/main/content/_layouts/guide.html
@@ -15,23 +15,25 @@ js: guide
         </div>
         <div class="row">
             <!-- Guide's table of contents section -->
-            <div class="col-sm-3">
-                <a id="all_guides_link" href="/guides">All Guides</a>
-                {% assign toc = page.document | tocify_asciidoc %}
-                {% if toc %}
-                <h3 id="toc_title">Contents</h3>
-                <div id="toc_container">
-                    {{ toc }}
-                </div>
-                {% endif %}
-                {% if page.tags %}
-                    <h3 id="tag_title">Tags</h3>
-                    <div id="tags_container">
-                        {% for tag in page.tags %}
-                            <a href="/guides?search={{ tag }}&key=tag">{{ tag }}</a>
-                        {% endfor %}
+            <div id="toc_column" class="col-sm-3">
+                <div id="toc_inner">
+                    <a id="all_guides_link" href="/guides">All Guides</a>
+                    {% assign toc = page.document | tocify_asciidoc %}
+                    {% if toc %}
+                    <h3 id="toc_title">Contents</h3>
+                    <div id="toc_container">
+                        {{ toc }}
                     </div>
-                {% endif %}
+                    {% endif %}
+                    {% if page.tags %}
+                        <h3 id="tag_title">Tags</h3>
+                        <div id="tags_container">
+                            {% for tag in page.tags %}
+                                <a href="/guides?search={{ tag }}&key=tag">{{ tag }}</a>
+                            {% endfor %}
+                        </div>
+                    {% endif %}
+                </div>
             </div>
             <!-- Entire guide section -->
             <div id="guide_column" class="col-sm-9 position_relative">


### PR DESCRIPTION
Fixes #90 

# Tested
https://openlibertydev.mybluemix.net/guides/
- [x] IE
- [x] Firefox
- [x] Chrome
- [x] Sarafi

# Problem
The background of each guide is a dark color.  At the bottom of the guide page, we have a "white overlapping the dark" background look and feel.  This overlap is achieved by shortening the background by `200px` in guide.css
https://github.com/OpenLiberty/openliberty.io/blob/fc016b1629d1e1cc7ac9b91b5311399e1022684f/src/main/content/_assets/css/guide.css#L92

![screen shot 2018-01-09 at 9 54 40 am](https://user-images.githubusercontent.com/31117513/34729734-243e47f4-f523-11e7-8112-eed0ea322f36.png)

# Solution
- Float the table of content (TOC) when the top of the TOC starts to scroll off.
- If needed, allow the TOC's top scroll off when we are near the bottom.  Take into account the `200px` shortening of the dark background described in the Problem section above.

# Preview of behavior
## Table of content begins floating
![topscroll](https://user-images.githubusercontent.com/31117513/34686422-19a47186-f471-11e7-8f9f-0a03aa593efd.gif)
## Table of content scrolling up when near bottom of page
![bottomscroll](https://user-images.githubusercontent.com/31117513/34686423-19bc62c8-f471-11e7-96e3-c1f4a7a11141.gif)

  
  