### PR TITLE
Remove exception code from build script

### DIFF
--- a/scripts/build_clone_guides.rb
+++ b/scripts/build_clone_guides.rb
@@ -18,30 +18,28 @@ cloneDraftGuides = ARGV[0]
 response = `curl https://api.github.com/orgs/OpenLiberty/repos?access_token=$PAT`
 json = JSON.parse(response)
 
-# Exceptions due to adopting of this new automated integration of guides
-# There are two guides that are currently still in draft mode but do not have "draft-" in their repository name.
-# To avoid unneeded trouble of renaming them, lets just mark the guides as draft with special code.
-# The end goal is this array to _always_ be empty.
-draftRepos = ["guide-microprofile-config"]
-
 # Filter for Open Liberty guide repositories
 guides = []
 json.each do |element|
     repo_name = element['name']
     if cloneDraftGuides == "draft-guide"
+        ##################
+        # DRAFT GUIDES
         # Clone guides that are still being drafted and are only for the staging website
         if repo_name.start_with?('draft-iguide')
             # Always clone the master branch for interactive guides
             `git clone https://github.com/OpenLiberty/#{repo_name}.git --branch master --single-branch src/main/content/guides/#{repo_name}`
-        elsif repo_name.start_with?('draft-guide') or draftRepos.include?(repo_name)
+        elsif repo_name.start_with?('draft-guide')
             `git clone https://github.com/OpenLiberty/#{repo_name}.git src/main/content/guides/#{repo_name}`
         end
     else
+        ##################
+        # PUBLISHED GUIDES
+        # Clone interactive guides that are ready to be published to openliberty.io
         if repo_name.start_with?('iguide')
-            # Clone interactive guides that are ready to be published to openliberty.io
             # Always clone the master branch for interactive guides
             `git clone https://github.com/OpenLiberty/#{repo_name}.git --branch master --single-branch src/main/content/guides/#{repo_name}`
-        elsif repo_name.start_with?('guide') and not draftRepos.include?(repo_name)
+        elsif repo_name.start_with?('guide')
             # Clone static guides that are ready to be published to openliberty.io
             `git clone https://github.com/OpenLiberty/#{repo_name}.git src/main/content/guides/#{repo_name}`
         end


### PR DESCRIPTION
Remove the special code to treat `guide-microprofile-config` repo as `draft-guide-microprofile-config`.  The guide team has renamed `guide-microprofile-config` `draft-guide-microprofile-config`.  See https://github.com/OpenLiberty/draft-guide-microprofile-config