### PR TITLE
Fix long URLs overflowing past content width.

### DIFF
--- a/src/main/content/_assets/css/guide.css
+++ b/src/main/content/_assets/css/guide.css
@@ -53,6 +53,8 @@
     font-weight: 500;
     color: #E3700D;
     transition: color .2s;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
 }
 
 #guide_content a:hover {


### PR DESCRIPTION
Fixes #119 

This fix isn't as clean as Firefox's default implementation, as it breaks the line mid-word, but it prevents the long URLs from breaking out of the container.

Before the fix:
![linkoverflow](https://user-images.githubusercontent.com/689163/35462558-0d530c68-02b2-11e8-9e0c-28cfd7a0159b.gif)


After fix:
![image](https://user-images.githubusercontent.com/689163/35462415-6d88a468-02b1-11e8-898f-65d36c67397e.png)

