### PR TITLE
Code block style

### DIFF
--- a/src/main/content/_assets/css/guide.css
+++ b/src/main/content/_assets/css/guide.css
@@ -76,6 +76,12 @@
     padding: 30px;
 }
 
+#guide_content .no_copy pre {
+    background-color: #FFFFFF;
+    border:5px solid #e8eaee;
+    border-radius:3px;
+}
+
 #guide_content .sect1 > .sectionbody {
     padding-top: 19px;
 }


### PR DESCRIPTION
Fixes #123 

Non-copiable code blocks now look like this:
![image](https://user-images.githubusercontent.com/689163/35585827-9e35b99c-05be-11e8-9fde-5ddfe1533e93.png)
