### PR TITLE
Fix cdi variable mismatch

### DIFF
--- a/src/main/content/_posts/2018-01-31-mpRestClient.adoc
+++ b/src/main/content/_posts/2018-01-31-mpRestClient.adoc
@@ -136,7 +136,7 @@ public class PlaylistServlet extends HttpServlet {
     public void doGet(HttpServletRequest request, HttpServletResponse response)
         throws ServletException, IOException {
 
-        List<String> names = playlistSvc.getPlaylistNames();
+        List<String> names = playlistService.getPlaylistNames();
         ...
     }
 ----


### PR DESCRIPTION
The CDI example declares a field `playlistService` but then references it in code later as `playlistSvc`.  This changes the reference to be `playlistService` to match the field name.