### PR TITLE
Use default transparent background-color for code inside pre blocks.

### DIFF
--- a/src/main/content/_assets/css/guide.css
+++ b/src/main/content/_assets/css/guide.css
@@ -82,6 +82,10 @@
     border-radius:3px;
 }
 
+#guide_content .no_copy pre code {
+    background-color: transparent;
+}
+
 #guide_content .sect1 > .sectionbody {
     padding-top: 19px;
 }


### PR DESCRIPTION
Fixes #123 - new issue found for `<code>` inside a non-copiable `<pre>` block

Removes our custom background-color for `<code>` styling when it is inside a non-copiable `<pre>` block - use the default bootstrap background-color of transparent instead.