### PR TITLE
Enable IP Anonymization for Google Analytic script

### DIFF
--- a/src/main/content/_includes/google_analytics.html
+++ b/src/main/content/_includes/google_analytics.html
@@ -5,6 +5,7 @@
   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
   ga('create', '{{ site.google_analytics }}', 'auto');
+  ga('set', 'anonymizeIp', true);
   ga('send', 'pageview');
 
 </script>


### PR DESCRIPTION
Related to #83 

My understanding is that we do not use Google Analytics (GA) directly.  We use Google Tag Manager, which feeds data into Google Analytics.  However, I found that we still include GA in our head on openliberty.io.

https://github.com/OpenLiberty/openliberty.io/blob/f3ed22c9367c938c0a33097f9078b99f65c25e97/src/main/content/_includes/head.html#L27

Given that we have this commented out
https://github.com/OpenLiberty/openliberty.io/blob/f3ed22c9367c938c0a33097f9078b99f65c25e97/src/main/content/_config.yml#L20

And we have this check in the head
https://github.com/OpenLiberty/openliberty.io/blob/f3ed22c9367c938c0a33097f9078b99f65c25e97/src/main/content/_includes/head.html#L26

Regardless, I'll go ahead and enable `ga('set', 'anonymizeIp', true);` in our GA script too.  anonymizeIP is already enabled in Google Tag Manager.  See issue #83 for more details on the tag manager work.
