### PR TITLE
Start using the builtin _drafts in Jekyll

### DIFF
--- a/scripts/build_jekyll_maven.sh
+++ b/scripts/build_jekyll_maven.sh
@@ -5,6 +5,8 @@
 # Exit immediately if a simple command exits with a non-zero status.
 set -e
 
+JEKYLL_BUILD_FLAGS=""
+
 echo "Installing ruby packages..."
 gem install jekyll bundler jekyll-feed jekyll-asciidoc coderay uglifier octopress-minify-html
 gem install jekyll-assets -v 2.4.0
@@ -24,6 +26,7 @@ if [ "$JEKYLL_ENV" != "production" ]; then
     
     echo "Clone guides that are only for test site..."
     ruby ./scripts/build_clone_guides.rb "draft-guide"
+    JEKYLL_BUILD_FLAGS="--drafts"
 fi
 
 # Move any js/css files from guides to the _assets folder for jekyll-assets minification.
@@ -36,7 +39,7 @@ echo "Building with jekyll..."
 echo `jekyll -version`
 mkdir target
 mkdir target/jekyll-webapp
-jekyll build --source src/main/content --destination target/jekyll-webapp
+jekyll build $JEKYLL_BUILD_FLAGS --source src/main/content --destination target/jekyll-webapp
 
 # Maven packaging
 mvn -B package

--- a/src/main/content/_drafts/blog_draft.adoc
+++ b/src/main/content/_drafts/blog_draft.adoc
@@ -1,0 +1,8 @@
+---
+layout: post
+author_picture: https://avatars0.githubusercontent.com/u/0
+blog_description: "Blog preview description"
+---
+= Draft blog header
+
+Blog content


### PR DESCRIPTION
Fixes #137 

The _drafts folder will initially contain any blog posts that are still in progress.  We will only render the drafts on the staging site by using the build flag --drafts.


I did a local test by calling `./script/build_jekyll_maven.sh` with and without `JEKYLL_ENV=production` to confirm the `--drafts` flag was being correctly set.  We want to make sure the `--drafts` flag is used on openlibertydev (aka the staging site).

Snapshot of the draft blog in my local environment
![image](https://user-images.githubusercontent.com/31117513/35932193-b2683234-0bfc-11e8-88e7-8fcb82f8b1b5.png)
