### PR TITLE
Update openliberty.io with #140

### DIFF
--- a/scripts/build_clone_guides.rb
+++ b/scripts/build_clone_guides.rb
@@ -8,19 +8,24 @@
 # The assumption is that a guide that are still being development, 
 # but need to be on the test website have a GitHub repository name starting with:
 #       draft-guide*
-require 'json'
+require 'octokit'
 
 # This variable is to determine if we want to clone the "still in progress"
 # guides that are not ready to be on openliberty.io
 cloneDraftGuides = ARGV[0]
 
+# --------------------------------------------
 # Get all the Open Liberty repositories
-response = `curl https://api.github.com/orgs/OpenLiberty/repos?access_token=$PAT`
-json = JSON.parse(response)
+# --------------------------------------------
+client = Octokit::Client.new :access_token => ENV['PAT']
+client.auto_paginate = true
+repos = client.org_repos('OpenLiberty')
 
+# --------------------------------------------
 # Filter for Open Liberty guide repositories
+# --------------------------------------------
 guides = []
-json.each do |element|
+repos.each do |element|
     repo_name = element['name']
     if cloneDraftGuides == "draft-guide"
         ##################

--- a/scripts/build_jekyll_maven.sh
+++ b/scripts/build_jekyll_maven.sh
@@ -8,7 +8,7 @@ set -e
 JEKYLL_BUILD_FLAGS=""
 
 echo "Installing ruby packages..."
-gem install jekyll bundler jekyll-feed jekyll-asciidoc coderay uglifier octopress-minify-html
+gem install jekyll bundler jekyll-feed jekyll-asciidoc coderay uglifier octopress-minify-html octokit
 gem install jekyll-assets -v 2.4.0
 
 echo "Ruby version:"
@@ -26,11 +26,16 @@ if [ "$JEKYLL_ENV" != "production" ]; then
     
     echo "Clone guides that are only for test site..."
     ruby ./scripts/build_clone_guides.rb "draft-guide"
+    echo "Moving any js and css files from draft interactive guides..."
+    find src/main/content/guides/draft-iguide* -d -name js -exec cp -R '{}' src/main/content/_assets \;
+    find src/main/content/guides/draft-iguide* -d -name css -exec cp -R '{}' src/main/content/_assets \;
+
+    # Include draft blog posts for non production environments
     JEKYLL_BUILD_FLAGS="--drafts"
 fi
 
 # Move any js/css files from guides to the _assets folder for jekyll-assets minification.
-echo "Moving any js and css files..."
+echo "Moving any js and css files published interactive guides..."
 find src/main/content/guides/iguide* -d -name js -exec cp -R '{}' src/main/content/_assets \;
 find src/main/content/guides/iguide* -d -name css -exec cp -R '{}' src/main/content/_assets \;
 


### PR DESCRIPTION
#140 Fix problem with missing guide repositories
- Use GitHub's ruby library octokit
- Use octokit's auto_paginate to get all OpenLiberty repositories in one response