### PR TITLE
Fix casing on guides and remove interactive link for now

### DIFF
--- a/src/main/content/docs.html
+++ b/src/main/content/docs.html
@@ -29,15 +29,10 @@ permalink: /docs/
             <div id="all_guides_title">Open Liberty Guides</div>
             <p id="all_guides_description">Our guides are the best way to learn and explore Open Liberty. All guides keep the code at the forefront,
                 so you can get what you need and get back to work.</p>
-            <a href="/guides" id="all_guides_link">View all Open Liberty Guides</a>
+            <a href="/guides" id="all_guides_link">View all Open Liberty guides</a>
         </div>
         <div class="col-md-6">
-            <div id="code_block">
-                <a href="/guides/?search=Interactive&key=tag" id="all_interactive_guides_link">
-                    <img id="all_guides_lighting_bolt" src="{{ "/img/docs_lightningbolt.svg" | relative }}" class="img-responsive" alt="">
-                    <p id="interactive_guides_description">Check out the <span class="bold">interactive guides</span> with live code examples for hands-on learning</p>
-                </a>
-            </div>
+            <div id="code_block"></div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Design wants us to remove the interactive guides link for now since the location doesn't look good. 
Fixed the casing on 'View all Open Liberty guides".