### PR TITLE
Add accessibility to the expand/collapse in javadocs

### DIFF
--- a/src/main/content/_assets/js/javadocs.js
+++ b/src/main/content/_assets/js/javadocs.js
@@ -63,7 +63,7 @@ function addExpandAndCollapseToggleButtons() {
             emptyParagraphElement.hide();
 
             var headerHeight = header.outerHeight(true); // true to include margins too
-            var toggleButton = $('<div class="toggle" collapsed="false"><img src="/img/all_guides_minus.svg" alt="Collapse" aria-label="Collapse"/></div>');
+            var toggleButton = $('<div class="toggle" collapsed="false" tabindex=0><img src="/img/all_guides_minus.svg" alt="Collapse" aria-label="Collapse" /></div>');
             toggleButton.on('click', function(){
                 var collapsed = $(this).attr('collapsed');
                 if(collapsed === "true"){
@@ -82,6 +82,12 @@ function addExpandAndCollapseToggleButtons() {
                     leftBottom.css("height", "86%");
                     $(this).empty().append($('<img src="/img/all_guides_plus.svg" alt="Expand" aria-label="Expand"/>'));
                     $(this).attr('collapsed', true);                    
+                }
+            });
+            toggleButton.on('keypress', function(event){
+                event.stopPropagation();
+                if(event.which === 13){
+                    toggleButton.click();
                 }
             });
             header.append(toggleButton);            
@@ -104,7 +110,7 @@ function addExpandAndCollapseToggleButtons() {
             // for string comparison.
             var header2_text = header2.text().replace('/\s/g',' ').trim();
             if(header2_text === "All Classes") {
-                var toggleButton2 = $('<div class="toggle" collapsed="false"><img src="/img/all_guides_minus.svg" alt="Collapse" aria-label="Collapse"/></div>');
+                var toggleButton2 = $('<div class="toggle" collapsed="false" tabindex=0><img src="/img/all_guides_minus.svg" alt="Collapse" aria-label="Collapse" /></div>');
                 toggleButton2.on('click', function(){
                     var collapsed = $(this).attr('collapsed');
                     if(collapsed === "true"){
@@ -120,6 +126,12 @@ function addExpandAndCollapseToggleButtons() {
                         leftBottom.css("height", headerHeight2);
                         $(this).empty().append($('<img src="/img/all_guides_plus.svg" alt="Expand" aria-label="Expand"/>'));
                         $(this).attr('collapsed', true);                    
+                    }
+                });
+                toggleButton2.on('keypress', function(event){
+                    event.stopPropagation();
+                    if(event.which === 13){
+                        toggleButton2.click();
                     }
                 });
                 header2.append(toggleButton2);

--- a/src/main/content/_assets/js/javadocs.js
+++ b/src/main/content/_assets/js/javadocs.js
@@ -86,7 +86,8 @@ function addExpandAndCollapseToggleButtons() {
             });
             toggleButton.on('keypress', function(event){
                 event.stopPropagation();
-                if(event.which === 13){
+                // Enter key
+                if(event.which === 13 || event.keyCode === 13){
                     toggleButton.click();
                 }
             });
@@ -130,7 +131,8 @@ function addExpandAndCollapseToggleButtons() {
                 });
                 toggleButton2.on('keypress', function(event){
                     event.stopPropagation();
-                    if(event.which === 13){
+                    // Enter key
+                    if(event.which === 13 || event.keyCode === 13){
                         toggleButton2.click();
                     }
                 });


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Add tab index to +/- in javadocs.
Enable the user to press enter to select them.
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [x] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [x] Dymanic Accessability Plugin (DAP)
