### PR TITLE
Fix overflow of guide description on some browser widths; Fix guide c…

### DIFF
--- a/src/main/content/_assets/css/guide-card.css
+++ b/src/main/content/_assets/css/guide-card.css
@@ -13,7 +13,7 @@
     margin-bottom: 40px;
     height: 215px;
     padding-top: 22px;
-    padding-left: 20px;
+    padding-left: 14px;
     padding-right: 20px;
     display: block;
     border-left: solid 9px #eeeff3;
@@ -27,14 +27,14 @@
 }
 
 .guide_title_and_description_container {
-    height: 150px;
+    height: 155px;
     overflow: hidden;
 }
 
 .guide_title {
     color: #24253a;
     margin-top: 0;
-    margin-bottom: 14px;
+    margin-bottom: 9px;
     overflow: hidden;
     font-size: 16px;
     line-height: 20px;
@@ -52,10 +52,6 @@
     border-radius: 100px;
     float: right;
     padding: 0px 5px;
-}
-
-.duration_clock_icon {
-    margin-left: 5px;
 }
 
 .guide_duration {


### PR DESCRIPTION
…ard clock and interactive alignment and overflow on some widths

#### What was fixed?  (Issue # or description of fix)
Fix alignment of text/icons on the guide cards.

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
