### PR TITLE
Remove red highlighting from YAML snippets

### DIFF
--- a/src/main/content/_assets/css/coderay-custom.css
+++ b/src/main/content/_assets/css/coderay-custom.css
@@ -67,7 +67,6 @@ table.CodeRay td { padding: 2px 4px; vertical-align: top; }
 .CodeRay .doctype { color:#34b }
 .CodeRay .done { text-decoration: line-through; color: gray }
 .CodeRay .entity { color:#800; font-weight:500 }
-.CodeRay .error { color:#F00; background-color:#FAA }
 .CodeRay .escape  { color:#666 }
 .CodeRay .exception { color:#554499; font-weight:500 }
 .CodeRay .float { color:#60E }


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Remove red highlighting in YAML code snippets.  For some reason, CodeRay marks those lines as `.error`.  We will just let the lines use the default color styling by deleting the `.error` styling completely.

# Before
![image](https://user-images.githubusercontent.com/31117513/37046345-c0a73020-212d-11e8-8859-e33fa003e4c5.png)

# After
![image](https://user-images.githubusercontent.com/31117513/37046761-b5e0e978-212e-11e8-989e-1cf08d0081dd.png)


#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [x] Dymanic Accessability Plugin (DAP)
