### PR TITLE
Increase the Strict Transport Security max-age to 1 year

### DIFF
--- a/src/main/java/io/openliberty/website/TLSFilter.java
+++ b/src/main/java/io/openliberty/website/TLSFilter.java
@@ -56,7 +56,7 @@ public class TLSFilter implements Filter {
           response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY); // HTTP 301
           response.setHeader("Location", ((HttpServletRequest)req).getRequestURL().replace(0, 4, "https").toString());
         } else if ("https".equals(req.getScheme())) {
-          response.setHeader("Strict-Transport-Security", "max-age=2592000");
+          response.setHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains"); // Tell browsers that this site should only be accessed using HTTPS, instead of using HTTP. IncludeSubDomains and 1 year set per OWASP.
 
           String uri = ((HttpServletRequest)req).getRequestURI();
           if(uri.startsWith("/img/")) {

--- a/src/main/java/io/openliberty/website/TLSFilter.java
+++ b/src/main/java/io/openliberty/website/TLSFilter.java
@@ -56,7 +56,7 @@ public class TLSFilter implements Filter {
           response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY); // HTTP 301
           response.setHeader("Location", ((HttpServletRequest)req).getRequestURL().replace(0, 4, "https").toString());
         } else if ("https".equals(req.getScheme())) {
-          response.setHeader("Strict-Transport-Security", "max-age=3600");
+          response.setHeader("Strict-Transport-Security", "max-age=2592000");
 
           String uri = ((HttpServletRequest)req).getRequestURI();
           if(uri.startsWith("/img/")) {


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Fixes #199 

The HTTP Strict-Transport-Security response header (often abbreviated as HSTS)  lets a web site tell browsers that it should only be accessed using HTTPS, instead of using HTTP.

Per OWASP, it is recommended to also add `includeSubDomains` when using 1 year `max-age`
https://www.owasp.org/index.php/HTTP_Strict_Transport_Security_Cheat_Sheet
![image](https://user-images.githubusercontent.com/31117513/37308912-590d5dd8-260d-11e8-8c4e-f9d87b1035cc.png)

Many examples use a 1 year `max-age`.  I suspect they got 1 year from the RFC spec.
https://tools.ietf.org/html/rfc6797#section-6.2

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
