### PR TITLE
Do not use default red code text for blog posts

### DIFF
--- a/src/main/content/_assets/css/post.css
+++ b/src/main/content/_assets/css/post.css
@@ -24,6 +24,13 @@
     padding: 0;
 }
 
+#post_column code,
+#post_column pre  {
+    /* Bootstrap override */
+    background-color: #F3F4F7;
+    color: #5e6b8d;
+}
+
 #article_container {
     background-color: white;
     color: #24253a;


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Fixes #82 

#### Before
![image](https://user-images.githubusercontent.com/31117513/37306955-6145720c-2607-11e8-9a85-39a3cc719c7f.png)

#### After
![image](https://user-images.githubusercontent.com/31117513/37306973-7085c7da-2607-11e8-8e52-7c0efec3444c.png)

#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [x] Dymanic Accessability Plugin (DAP)
     - Did not cause any color new contract violations
