### PR TITLE
blue-green deployment for test site

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: ruby
+rvm:
+- 2.4.1
+
+before_script:
+- chmod +x ./scripts/build_jekyll_maven.sh # or do this locally and commit
+
+# Assume bundler is being used, therefore
+# the `install` step will run `bundle install` by default.
+script: ./scripts/build_jekyll_maven.sh
+
+# branch whitelist
+branches:
+  only:
+    - development
+
+sudo: false # route your build to the container-based infrastructure for a faster build
+
+before_deploy:
+- chmod +x ./scripts/cf-blue-green.sh
+
+deploy:
+  provider: script
+  script: ./scripts/cf-blue-green.sh
+  skip_cleanup: true
+  on:
+    branch: deployment

--- a/manifest.yml
+++ b/manifest.yml
@@ -13,5 +13,6 @@ applications:
 - name: openlibertydev
   domain: mybluemix.net
   host: openlibertydev
+- route: qa-guides.mybluemix.net
 env:
   JBP_CONFIG_LIBERTY: 'app_archive: {features: ["microProfile-1.0","webCache-1.0"]}'

--- a/scripts/cf-blue-green.sh
+++ b/scripts/cf-blue-green.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -e
+
+echo "============== INSTALLING CLOUD FOUNDRY CLI CLIENT =============="
+# https://github.com/cloudfoundry/cli/releases
+wget --max-redirect=1 --output-document=cf_cli_6.35.0.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.35.0&source=github-rel"
+gunzip cf_cli_6.35.0.tgz
+tar -xvf cf_cli_6.35.0.tar
+
+echo "============== LOGGING INTO CLOUD FOUNDRY =============="
+./cf login -a=$BLUEMIX_API -s=$BLUEMIX_SPACE -o=$BLUEMIX_ORGANIZATION -u=$BLUEMIX_USER -p=$BLUEMIX_PASSWORD
+
+# grab app name from manifest.yml route
+BLUE=`cat manifest.yml|grep route:|awk '{print $3}'|sed -e 's,\..*,,'`
+GREEN="${BLUE}-B"
+TEMP="${BLUE}-old"
+echo "App name is $BLUE"
+
+# create the GREEN application
+./cf push $GREEN -p ./target/openliberty.war -b liberty-for-java
+
+# cleanup
+echo "Cleaning up after blue-green deployment..."
+./cf stop $BLUE
+./cf rename $BLUE $TEMP
+./cf rename $GREEN $BLUE
+./cf rename $TEMP $GREEN

--- a/src/main/content/_config.yml
+++ b/src/main/content/_config.yml
@@ -37,3 +37,5 @@ plugins:
 exclude:
   - Gemfile
   - Gemfile.lock
+  - vendor # TravisCI bundles all gems in the vendor directory on its build servers, which Jekyll will mistakenly read and explode on.
+  


### PR DESCRIPTION
Fixes #194 

Script to be used by travis.
Added `route:` to test site in manifest.yml for consolidation of test domains.

`.travis.yml` will be updated in the repo that builds the test site via Travis CI.