### PR TITLE
Add spacing between buttons and fix up alt text

### DIFF
--- a/src/main/content/_assets/css/post.css
+++ b/src/main/content/_assets/css/post.css
@@ -145,6 +145,10 @@
     background-image: url('/img/reddit_link_hover.svg');
 }
 
+.download-ol-button {
+    margin-bottom: 10px;
+}
+
 @media (max-width: 991px) {
 
     #article_container {

--- a/src/main/content/_drafts/2018-03-16-distributed-tracing-microservices-18001.adoc
+++ b/src/main/content/_drafts/2018-03-16-distributed-tracing-microservices-18001.adoc
@@ -23,10 +23,10 @@ As we don't have a full set of documentation implemented for Open Liberty yet, t
 You can now download Open Liberty and Open Liberty Tools 18.0.0.1.:
 
 [link=https://openliberty.io/downloads/]
-image::/img/blog_btn_download-ol.svg[align="center"][Download Open Liberty]
+image::/img/blog_btn_download-ol.svg[Download Open Liberty, align="center", role="download-ol-button"]
 
 [link=https://stackoverflow.com/tags/open-liberty]
-image::/img/blog_btn_stack.svg[align="center"][Ask a question on Stack Overflow]
+image::/img/blog_btn_stack.svg[Ask a question on Stack Overflow, align="center"]
 
 Alternatively, if you're using https://www.openliberty.io/guides/maven-intro.html[Maven], here are the coordinates:
 
@@ -235,7 +235,7 @@ For more info, see https://www.ibm.com/support/knowledgecenter/en/was_beta_liber
 
 
 [link=https://openliberty.io/downloads/]
-image::/img/blog_btn_download-ol.svg[align="center"][Download Open Liberty]
+image::/img/blog_btn_download-ol.svg[Download Open Liberty, align="center", role="download-ol-button"]
 
 [link=https://stackoverflow.com/tags/open-liberty]
-image::/img/blog_btn_stack.svg[align="center"][Ask a question on Stack Overflow]
+image::/img/blog_btn_stack.svg[Ask a question on Stack Overflow, align="center"]


### PR DESCRIPTION
- Add custom css to the Download Open Liberty button to add space between the buttons

#### What was fixed?  (Issue # or description of fix)
Fixes #224 
# Spacing fix
#### Before
![image](https://user-images.githubusercontent.com/31117513/37488758-9c688410-2863-11e8-8ec1-ccc6862ad29f.png)

#### After
![image](https://user-images.githubusercontent.com/31117513/37488771-a6c201d4-2863-11e8-958a-9a7a4f93d6a7.png)


# Alt text fix
#### Before
![image](https://user-images.githubusercontent.com/31117513/37488928-0ecd59c2-2864-11e8-9da2-ddce0a9b6fd4.png)

#### After
![image](https://user-images.githubusercontent.com/31117513/37488946-19cf5d20-2864-11e8-9256-bd5ba9adc15e.png)


#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
