### PR TITLE
Fix syntax error in the MicroProfile javadocs

### DIFF
--- a/src/main/content/javadocs/microprofile-1.2-javadoc/org/eclipse/microprofile/config/package-summary.html
+++ b/src/main/content/javadocs/microprofile-1.2-javadoc/org/eclipse/microprofile/config/package-summary.html
@@ -145,7 +145,7 @@ $('.navPadding').css('padding-top', $('.fixedNav').css("height"));
   The <a href="../../../../org/eclipse/microprofile/config/Config.html" title="interface in org.eclipse.microprofile.config"><code>Config</code></a> can be accessed via the <a href="../../../../org/eclipse/microprofile/config/ConfigProvider.html" title="class in org.eclipse.microprofile.config"><code>ConfigProvider</code></a>.
 
   <pre>
-  Config config = ConfigProvider#getConfig();
+  Config config = ConfigProvider.getConfig();
   String restUrl = config.getValue("myproject.some.endpoint.url", String.class);
   </pre>
 

--- a/src/main/content/javadocs/microprofile-1.3-javadoc/org/eclipse/microprofile/config/package-summary.html
+++ b/src/main/content/javadocs/microprofile-1.3-javadoc/org/eclipse/microprofile/config/package-summary.html
@@ -145,7 +145,7 @@ $('.navPadding').css('padding-top', $('.fixedNav').css("height"));
   The <a href="../../../../org/eclipse/microprofile/config/Config.html" title="interface in org.eclipse.microprofile.config"><code>Config</code></a> can be accessed via the <a href="../../../../org/eclipse/microprofile/config/ConfigProvider.html" title="class in org.eclipse.microprofile.config"><code>ConfigProvider</code></a>.
 
   <pre>
-  Config config = ConfigProvider#getConfig();
+  Config config = ConfigProvider.getConfig();
   String restUrl = config.getValue("myproject.some.endpoint.url", String.class);
   </pre>
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
