### PR TITLE
Update blue-green deploy for zero downtime.

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -13,6 +13,5 @@ applications:
 - name: openlibertydev
   domain: mybluemix.net
   host: openlibertydev
-- route: qa-guides.mybluemix.net
 env:
   JBP_CONFIG_LIBERTY: 'app_archive: {features: ["microProfile-1.0","webCache-1.0"]}'

--- a/scripts/cf-blue-green.sh
+++ b/scripts/cf-blue-green.sh
@@ -10,18 +10,42 @@ tar -xvf cf_cli_6.35.0.tar
 echo "============== LOGGING INTO CLOUD FOUNDRY =============="
 ./cf login -a=$BLUEMIX_API -s=$BLUEMIX_SPACE -o=$BLUEMIX_ORGANIZATION -u=$BLUEMIX_USER -p=$BLUEMIX_PASSWORD
 
-# grab app name from manifest.yml route
-BLUE=`cat manifest.yml|grep route:|awk '{print $3}'|sed -e 's,\..*,,'`
-GREEN="${BLUE}-B"
-TEMP="${BLUE}-old"
+# ==== VARIABLE SETUP ====
+MANIFEST="manifest.yml"
+# get route, app name (BLUE), and domain
+ROUTE=`cat $MANIFEST | grep route: | awk '{print $3}'`
+
+BLUE=`echo $ROUTE | sed -e 's,\..*,,'`
 echo "App name is $BLUE"
 
+GREEN="${BLUE}-B"
+TEMP="${BLUE}-old"
+
+DOMAIN=`echo $ROUTE | sed -e "s,$BLUE\.,,"`
+
+# ==== DEPLOYMENT ====
 # create the GREEN application
-./cf push $GREEN -p ./target/openliberty.war -b liberty-for-java -f manifest.yml
+./cf push $GREEN -p ./target/openliberty.war -b liberty-for-java
+
+# ensure it starts
+echo "Checking status of new instance https://${GREEN}.${DOMAIN}..."
+curl --fail -s -I "https://${GREEN}.${DOMAIN}" --connect-timeout 240 --max-time 300
+
+# add the GREEN application to each BLUE route to be load-balanced
+echo "Adding main route ($BLUE.$ROUTE) to new app ($GREEN)..."
+./cf map-route $GREEN $DOMAIN --hostname $BLUE
 
 # cleanup
 echo "Cleaning up after blue-green deployment..."
 ./cf stop $BLUE
+./cf unmap-route $GREEN $DOMAIN --hostname $GREEN # remove B route from new deploy
+
+# setup old BLUE deploy to be ready to be GREEN for next deployment
+./cf map-route $BLUE $DOMAIN --hostname $GREEN # add B route from old deploy
+./cf unmap-route $BLUE $DOMAIN --hostname $BLUE # remove main route from old deploy
+# this unmap may not be necessary, but keeps bluemix dashboard cleaner
+
+# swap app names
 ./cf rename $BLUE $TEMP
 ./cf rename $GREEN $BLUE
 ./cf rename $TEMP $GREEN

--- a/scripts/cf-blue-green.sh
+++ b/scripts/cf-blue-green.sh
@@ -11,10 +11,7 @@ echo "============== LOGGING INTO CLOUD FOUNDRY =============="
 ./cf login -a=$BLUEMIX_API -s=$BLUEMIX_SPACE -o=$BLUEMIX_ORGANIZATION -u=$BLUEMIX_USER -p=$BLUEMIX_PASSWORD
 
 # ==== VARIABLE SETUP ====
-MANIFEST="manifest.yml"
-# get route, app name (BLUE), and domain
-ROUTE=`cat $MANIFEST | grep route: | awk '{print $3}'`
-
+# ROUTE should be set in TravisCI repo
 BLUE=`echo $ROUTE | sed -e 's,\..*,,'`
 echo "App name is $BLUE"
 


### PR DESCRIPTION
Enhancement for #194 to bring the downtime of the test site to 0 seconds.

Previous blue-green implementation would still take down the site for a few seconds, or have a very slow first load of the page.

- Deploying site initially to a secondary route 
- Test secondary route up-status before rerouting the main site
- Bluemix cleanup to prepare environment for the next deploy
- Code cleanup and added comments
- Move route into TravisCI env