### PR TITLE
Use separate manifest for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ branches:
 sudo: false # route your build to the container-based infrastructure for a faster build
 
 before_deploy:
-- chmod +x ./scripts/cf-blue-green.sh
+- chmod +x ./.travis/cf-blue-green.sh
 
 deploy:
   provider: script
-  script: ./scripts/cf-blue-green.sh
+  script: ./.travis/cf-blue-green.sh
   skip_cleanup: true
   on:
     branch: development

--- a/.travis/cf-blue-green.sh
+++ b/.travis/cf-blue-green.sh
@@ -22,7 +22,7 @@ DOMAIN=`echo $ROUTE | sed -e "s,$BLUE\.,,"`
 
 # ==== DEPLOYMENT ====
 # create the GREEN application
-./cf push $GREEN -p ./target/openliberty.war -b liberty-for-java
+./cf push $GREEN -f ./.travis/travis_manifest.yml
 
 # ensure it starts
 echo "Checking status of new instance https://${GREEN}.${DOMAIN}..."

--- a/.travis/travis_manifest.yml
+++ b/.travis/travis_manifest.yml
@@ -1,0 +1,8 @@
+memory: 256M
+instances: 1
+disk_quota: 512M
+path: ../target/openliberty.war
+buildpack: liberty-for-java
+
+env:
+  JBP_CONFIG_LIBERTY: 'app_archive: {features: ["microProfile-1.0","webCache-1.0"]}'


### PR DESCRIPTION
Addition to #251, which did not work when `manifest.yml` contained more than 1 application. To fix this, created a new `travis_manifest.yml` for deployment.

- Use separate manifest.yml file for TravisCI. 
