### PR TITLE
Build script fixes and enhancements

### DIFF
--- a/scripts/build_clone_guides.rb
+++ b/scripts/build_clone_guides.rb
@@ -22,6 +22,16 @@ client.auto_paginate = true
 repos = client.org_repos('OpenLiberty')
 
 # --------------------------------------------
+# Travis CI related steps
+# --------------------------------------------
+# For the interactive guides, only build the dev branch for the TravisCI environments
+iguide_branch = 'master'
+if ENV['TRAVIS']
+    iguide_branch = 'dev'
+end
+puts "Looking for draft interactive guides with branch: #{iguide_branch}..."
+
+# --------------------------------------------
 # Filter for Open Liberty guide repositories
 # --------------------------------------------
 guides = []
@@ -29,11 +39,11 @@ repos.each do |element|
     repo_name = element['name']
     if cloneDraftGuides == "draft-guide"
         ##################
-        # DRAFT GUIDES
+        # DRAFT GUIDES  
         # Clone guides that are still being drafted and are only for the staging website
         if repo_name.start_with?('draft-iguide')
             # Always clone the master branch for interactive guides
-            `git clone https://github.com/OpenLiberty/#{repo_name}.git --branch master --single-branch src/main/content/guides/#{repo_name}`
+            `git clone https://github.com/OpenLiberty/#{repo_name}.git --branch #{iguide_branch} --single-branch src/main/content/guides/#{repo_name}`
         elsif repo_name.start_with?('draft-guide')
             `git clone https://github.com/OpenLiberty/#{repo_name}.git src/main/content/guides/#{repo_name}`
         end

--- a/scripts/build_jekyll_maven.sh
+++ b/scripts/build_jekyll_maven.sh
@@ -24,11 +24,16 @@ if [ "$JEKYLL_ENV" != "production" ]; then
     echo "Adding robots.txt"
     cp robots.txt src/main/content/robots.txt
     
-    echo "Clone guides that are only for test site..."
+    echo "Clone draft guides for test environments..."
     ruby ./scripts/build_clone_guides.rb "draft-guide"
-    echo "Moving any js and css files from draft interactive guides..."
-    find src/main/content/guides/draft-iguide* -d -name js -exec cp -R '{}' src/main/content/_assets \;
-    find src/main/content/guides/draft-iguide* -d -name css -exec cp -R '{}' src/main/content/_assets \;
+
+    # Need to make sure there are draft-iguide* folders before using the find command
+    # If we don't, the find command will fail because the path does not exist
+    if [ $(find src/main/content/guides -type d -name "draft-iguide*" | wc -l ) != "0" ] ; then
+        echo "Moving any js and css files from draft interactive guides..."
+        find src/main/content/guides/draft-iguide* -d -name js -exec cp -R '{}' src/main/content/_assets \;
+        find src/main/content/guides/draft-iguide* -d -name css -exec cp -R '{}' src/main/content/_assets \;
+    fi
 
     # Include draft blog posts for non production environments
     JEKYLL_BUILD_FLAGS="--drafts"
@@ -36,6 +41,7 @@ fi
 
 # Move any js/css files from guides to the _assets folder for jekyll-assets minification.
 echo "Moving any js and css files published interactive guides..."
+# Assumption: There is _always_ iguide* folders
 find src/main/content/guides/iguide* -d -name js -exec cp -R '{}' src/main/content/_assets \;
 find src/main/content/guides/iguide* -d -name css -exec cp -R '{}' src/main/content/_assets \;
 
@@ -47,4 +53,5 @@ mkdir target/jekyll-webapp
 jekyll build $JEKYLL_BUILD_FLAGS --source src/main/content --destination target/jekyll-webapp
 
 # Maven packaging
+echo "Running maven (mvn)..."
 mvn -B package


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

Build process fix for find command
- We need to make sure there are draft iguides before invoking the find command.  If there are zero draft-iguide directories, the find command fails.

Cloning interactive guide dev or master branch
- For Travis environments, use the dev branch of the iguide* GitHub repositories.
- For non-Travis environments (ie Bluemix), use the master branch for the iguide* repos.