### PR TITLE
Fix Javadoc package name to not uppercase

### DIFF
--- a/src/main/content/javadocs/liberty-javaee7-javadoc/stylesheet.css
+++ b/src/main/content/javadocs/liberty-javaee7-javadoc/stylesheet.css
@@ -167,7 +167,6 @@ Navigation bar styles
     margin-bottom: 5px;
     margin-top: 20px;
     font-family: BunueloBold;
-    text-transform: uppercase;
     font-size: 14px;
     color:#313653;
 }

--- a/src/main/content/javadocs/microprofile-1.2-javadoc/stylesheet.css
+++ b/src/main/content/javadocs/microprofile-1.2-javadoc/stylesheet.css
@@ -167,7 +167,6 @@ Navigation bar styles
     margin-bottom: 5px;
     margin-top: 20px;
     font-family: BunueloBold;
-    text-transform: uppercase;
     font-size: 14px;
     color:#313653;
 }

--- a/src/main/content/javadocs/microprofile-1.3-javadoc/stylesheet.css
+++ b/src/main/content/javadocs/microprofile-1.3-javadoc/stylesheet.css
@@ -167,7 +167,6 @@ Navigation bar styles
     margin-bottom: 5px;
     margin-top: 20px;
     font-family: BunueloBold;
-    text-transform: uppercase;
     font-size: 14px;
     color:#313653;
 }


### PR DESCRIPTION
#### When a package from javadoc is selected, the package name appeared at the bottom of the left navigation with all CAPS. The fix is to not transform the package name to uppercase. 
(Issue #219)
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)