### PR TITLE
Related guide cards

### DIFF
--- a/src/main/content/_assets/css/guide.css
+++ b/src/main/content/_assets/css/guide.css
@@ -30,6 +30,18 @@
     margin-bottom: 0px;
 }
 
+#guide_content #relateGuidesContent h3 {
+    font-size: 20px;
+    font-weight: 400;
+    margin-top: 0px;
+    margin-bottom: 14px;
+    padding-top: 0px;
+}
+#guide_content #relateGuidesContent p {
+    line-height: 1.4;
+    margin: 0;
+}
+
 #guide_content h4 {
     font-size: 16px;
     color: #6f7878;

--- a/src/main/content/_assets/css/iguide.css
+++ b/src/main/content/_assets/css/iguide.css
@@ -36,6 +36,18 @@
     margin-bottom: 8px;
 }
 
+#guide_content #relateGuidesContent h3 {
+    font-size: 20px;
+    font-weight: 400;
+    margin-top: 0px;
+    margin-bottom: 14px;
+    padding-top: 0px;
+}
+#guide_content #relateGuidesContent p {
+    line-height: 1.4;
+    margin: 0;
+}
+
 #guide_content h4 {
     font-size: 16px;
     color: #6f7878;


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Text spacing in guide cards for related guides inside a guide was messed up with spacing changes to the guides. This restores the originally intended spacing for the cards.

Testing in progress...

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
