### PR TITLE
Fixed logic to call udpateBuilds

### DIFF
--- a/src/main/java/io/openliberty/website/BuildsManager.java
+++ b/src/main/java/io/openliberty/website/BuildsManager.java
@@ -214,12 +214,14 @@ public class BuildsManager {
     // Compare the current time with the time the last build request is run. Allow the next
     // build request to go through if the last build request was run an hour ago or more.
     private boolean isBuildUpdateAllowed() {
-        boolean isBuildUpdateAllowed = false;
-        long currentTime = new Date().getTime();
-        long lastUpdateTime = lastSuccessfulUpdate.getTime();
-        // 1 hour = 3600000 ms
-        if (currentTime - lastUpdateTime >= 3600000) {
-            isBuildUpdateAllowed = true;
+        boolean isBuildUpdateAllowed = true;
+        if (lastSuccessfulUpdate != null) {
+            long currentTime = new Date().getTime();
+            long lastUpdateTime = lastSuccessfulUpdate.getTime();
+            // 1 hour = 3600000 ms
+            if (currentTime - lastUpdateTime < 3600000) {
+                isBuildUpdateAllowed = false;
+            }
         }
 
         return isBuildUpdateAllowed;

--- a/src/main/java/io/openliberty/website/BuildsManager.java
+++ b/src/main/java/io/openliberty/website/BuildsManager.java
@@ -45,14 +45,14 @@ public class BuildsManager {
     }
 
     public JsonObject getBuilds() {
-        if (lastSuccessfulUpdate == null) {
+        if (isBuildUpdateAllowed()) {
             updateBuilds();
         }
         return builds;
     }
 
     public JsonObject getLatestReleases() {
-        if (lastSuccessfulUpdate == null) {
+        if (isBuildUpdateAllowed()) {
             updateBuilds();
         }
         return latestReleases;
@@ -209,6 +209,20 @@ public class BuildsManager {
             return response.getHeaderString(Constants.CONTENT_LENGTH);
         }
         return null;
+    }
+
+    // Compare the current time with the time the last build request is run. Allow the next
+    // build request to go through if the last build request was run an hour ago or more.
+    private boolean isBuildUpdateAllowed() {
+        boolean isBuildUpdateAllowed = false;
+        long currentTime = new Date().getTime();
+        long lastUpdateTime = lastSuccessfulUpdate.getTime();
+        // 1 hour = 3600000 ms
+        if (currentTime - lastUpdateTime >= 3600000) {
+            isBuildUpdateAllowed = true;
+        }
+
+        return isBuildUpdateAllowed;
     }
 
 }


### PR DESCRIPTION
####  The original implementation allows the fetching of the builds once only. Change logic to allow builds to fetch if an hour has elapsed. An hour is chosen to take care of multiple builds done in a single day but disallow fetching builds continuously if the Download tab is clicked more often by a user. 
(Issue #196)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
