### PR TITLE
prevent caching of the download api builds data

### DIFF
--- a/src/main/java/io/openliberty/website/TLSFilter.java
+++ b/src/main/java/io/openliberty/website/TLSFilter.java
@@ -65,7 +65,10 @@ public class TLSFilter implements Filter {
 
           String uri = ((HttpServletRequest)req).getRequestURI();
           if(uri.startsWith("/img/")) {
-        	  response.setHeader("Cache-Control", "max-age=604800");
+              response.setHeader("Cache-Control", "max-age=604800");
+          } else if (uri.startsWith("/api/builds/") || uri.startsWith("/api/github/")) {
+              response.setHeader("Cache-Control", "no-store");
+              response.setHeader("Pragma", "no-cache");
           } else {
         	  response.setHeader("Cache-Control", "no-cache");
           }


### PR DESCRIPTION
#### Prevent caching of the /api/builds/xxx data by adding cache-control: no-store and pragma: no-cache
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
