### PR TITLE
Change the google tag manager key back to the actual key

### DIFF
--- a/src/main/content/_config.yml
+++ b/src/main/content/_config.yml
@@ -16,7 +16,7 @@ asciidoctor:
     - coderay-css=class
     - allow-uri-read
 
-google_tag_manager: GTM-PKC6C7B
+google_tag_manager: GTM-TKP3KJ7
 #google_analytics: UA-104349928-1
 
 markdown: kramdown

--- a/src/main/content/_includes/analytics.html
+++ b/src/main/content/_includes/analytics.html
@@ -1,3 +1,3 @@
-{% if site.google_tag_manager %}
+{% if jekyll.environment == 'production' and site.google_tag_manager %}
     {% include google_tag_manager_body.html %}
 {% endif %}

--- a/src/main/content/_includes/head.html
+++ b/src/main/content/_includes/head.html
@@ -20,7 +20,7 @@
     {% css {{css_name}} %}
   {% endfor %}
 
-  {% if site.google_tag_manager %}
+  {% if jekyll.environment == 'production' and site.google_tag_manager %}
     {% include google_tag_manager_head.html %}
   {% endif %}
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
