### PR TITLE
Add codes to iterate through all the TOC titles to remove the code block

### DIFF
--- a/src/main/content/_assets/js/guide.js
+++ b/src/main/content/_assets/js/guide.js
@@ -98,6 +98,24 @@ function handleTOCScolling() {
     }
 }
 
+// Remove code block from TOC titles
+function sanitizeTitleInTOC() {
+    var tocLevel1 = $('#toc_container ul.sectlevel1 li');
+    $.each(tocLevel1, function (i, tocElements) {
+        var aHrefElements = $(tocElements).find("a");
+        $.each(aHrefElements, function (i, tocElement) {
+            var title = $(tocElement).html();
+            // look for code block and remove it 
+            var stringToMatch = "([\\s\\S]*)<\\s*code\\s*>([\\s\\S]*)<\\s*\\/code\\s*>([\\s\\S]*)";
+            var regExprToMatch = new RegExp(stringToMatch, "g");
+            var matches = regExprToMatch.exec(title);
+            if (matches) {
+                $(tocElement).html(matches[1] + matches[2] + matches[3]);
+            }
+        });
+    });
+}
+
 $(document).ready(function() {
 
     var offset;
@@ -165,6 +183,9 @@ $(document).ready(function() {
         $('#toc_container ul.sectlevel1').append('<li><a href="#related-guides">Related guides</a></li>');
     }
 
+    // Iterate through the titles in TOC to remove code block
+    sanitizeTitleInTOC();
+    
     // TABLE OF CONTENT
     //
     // Keep the table of content (TOC) in view while scrolling (Desktop only)

--- a/src/main/content/_assets/js/guide.js
+++ b/src/main/content/_assets/js/guide.js
@@ -103,14 +103,14 @@ function sanitizeTitleInTOC() {
     var tocLevel1 = $('#toc_container ul.sectlevel1 li');
     $.each(tocLevel1, function (i, tocElements) {
         var aHrefElements = $(tocElements).find("a");
-        $.each(aHrefElements, function (i, tocElement) {
-            var title = $(tocElement).html();
+        $.each(aHrefElements, function (i, aHrefElement) {
+            var title = $(aHrefElement).html();
             // look for code block and remove it 
             var stringToMatch = "([\\s\\S]*)<\\s*code\\s*>([\\s\\S]*)<\\s*\\/code\\s*>([\\s\\S]*)";
             var regExprToMatch = new RegExp(stringToMatch, "g");
             var matches = regExprToMatch.exec(title);
             if (matches) {
-                $(tocElement).html(matches[1] + matches[2] + matches[3]);
+                $(aHrefElement).html(matches[1] + matches[2] + matches[3]);
             }
         });
     });


### PR DESCRIPTION
#### issue #188 to remove code block styling in the TOC of guides
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
