### PR TITLE
IE: fixed long URL link and long code block

### DIFF
--- a/src/main/content/_assets/css/guide.css
+++ b/src/main/content/_assets/css/guide.css
@@ -315,6 +315,10 @@
     /* to handle long continuous string with no blank in it such as URL and file path */
     #guide_content a, #guide_content code { 
         word-break: break-all;
-        display: inline-table;
+        display: inline-block;
+    }
+
+    #guide_content li a, #guide_content li code { 
+        display: inline-table; /* line up the list item bullet with the text properly */
     }
 }

--- a/src/main/content/_assets/css/guide.css
+++ b/src/main/content/_assets/css/guide.css
@@ -308,3 +308,13 @@
         margin-bottom: 30px;
     }
 }
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+    /* IE10+ CSS styles go here */
+
+    /* to handle long continuous string with no blank in it such as URL and file path */
+    #guide_content a, #guide_content code { 
+        word-break: break-all;
+        display: inline-table;
+    }
+}


### PR DESCRIPTION
#### Fix for issue #119 by adding IE10+ specific styling to force the breaking of long continuous words.
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [x] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)