### PR TITLE
Remove old link because it's misleading (applies to the beta version).

### DIFF
--- a/src/main/content/_posts/2018-03-16-distributed-tracing-microservices-18001.adoc
+++ b/src/main/content/_posts/2018-03-16-distributed-tracing-microservices-18001.adoc
@@ -202,7 +202,7 @@ There’s a new endpoint control MBean so that you can now query and control the
 
 Prior to this feature, the only option for administrators wanting to stop inbound traffic to the server was to use the `server` pause and resume commands from the command line; for more info, see https://www.ibm.com/support/knowledgecenter/en/SSEQTP_liberty/com.ibm.websphere.wlp.doc/ae/twlp_PauseResume_cmd.html[the WebSphere Liberty Knowledge Center docs].
 
-The MBean has the Object name: `WebSphere:feature=kernel,name=ServerEndpointControl` and, like most mbeans, is self-describing. If you don't know what any of that means, take a look at Fred's blog post on https://developer.ibm.com/wasdev/blog/2017/12/21/mbean-controls-server-endpoints/[controlling server endpoint traffic with MBeans (Part 1)]. If you want to know more about what's new, take a look at Fred's new blog post on https://developer.ibm.com/wasdev/blog/2018/03/16/endpoints-liberty-mbeans-part2/[controlling traffic on server endpoints with Liberty MBeans (Part 2)].
+The MBean has the Object name: `WebSphere:feature=kernel,name=ServerEndpointControl` and, like most mbeans, is self-describing. To find out more, take a look at Fred's blog post on https://developer.ibm.com/wasdev/blog/2018/03/16/endpoints-liberty-mbeans-part2/[controlling traffic on server endpoints with Liberty MBeans].
 
 
 [#threadpool]


### PR DESCRIPTION
#### What was fixed?
Removed link that pointed to a blog post about the beta version of the mbean functionality.
