### PR TITLE
Archive old guides that have page-archived: true from the list of gui…

### DIFF
--- a/src/main/content/guides.html
+++ b/src/main/content/guides.html
@@ -26,7 +26,7 @@ permalink: /guides/
 
 <!-- Build one list of all the documents that have a particular layout -->
 {% assign static-guides = site.pages | where: 'layout', 'guide' %}
-{% assign interactive-guides = site.pages | where: 'layout', 'interactive-guide'%}
+{% assign interactive-guides = site.pages | where: 'layout', 'interactive-guide' %}
 {% assign guides = static-guides | concat: interactive-guides | sort: 'releasedate' | reverse %}
 <!-- 
     Some of the found documents are for internal use only and are not intended to be 
@@ -34,7 +34,7 @@ permalink: /guides/
 -->
 {% assign numGuides = guides.size %}
 {% for guide in guides %}
-    {% if guide.path contains "guides/guides-common" or guide.path contains "guides/iguides-common" %}
+    {% if guide.archived or guide.path contains "guides/guides-common" or guide.path contains "guides/iguides-common" %}
         {% assign numGuides = numGuides | minus: 1 %}
     {% endif %}
 {% endfor %}

--- a/src/main/content/guides.html
+++ b/src/main/content/guides.html
@@ -55,7 +55,7 @@ permalink: /guides/
     <div class="row">
         {% for guide in guides %}
         <!-- Do not render anything from the two common guide repositories containing shared code -->
-        {% unless guide.path contains "guides/guides-common" or guide.path contains "guides/iguides-common" %}
+        {% unless guide.archived or guide.path contains "guides/guides-common" or guide.path contains "guides/iguides-common" %}
             <div class="guide_column col-xs-12 col-sm-6 col-md-4">
                 <a href="{{ guide.url }}.html" class="guide_item" data-title="{{ guide.title | downcase }}" data-description="{{ guide.description | downcase }}" data-tags="{{ guide.tags | join: ' ' | downcase }}">
                     <div class="guide_title_and_description_container">


### PR DESCRIPTION
…des shown

Note: the guides will still be accessible from urls

#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
