### PR TITLE
Update blogs to use /blog/ in their URL path instead of /news/

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The [jQuery](https://jquery.com/) and [Bootstrap](http://getbootstrap.com/) fram
 ## Contributing to the blog
 Create a pull request with the content of the blog post placed in the `src/main/content/_posts/` folder using the following file naming scheme: `YYYY-MM-DD-post-title.extension`. HTML, markdown and asciidoc formats can be used. The file extension would be html, md or adoc respectively. In the blog post file the following front matter variables must be set:
 - layout: post
-- categories: news
+- categories: blog
 - title: `title of the blog post`
 - date: `date in YYYY-MM-DD HH:MM:SS +/-TTTT format`
 - author_picture: `secure url to author picture`

--- a/src/main/content/_posts/2017-09-19-open-sourcing-liberty.adoc
+++ b/src/main/content/_posts/2017-09-19-open-sourcing-liberty.adoc
@@ -2,7 +2,7 @@
 layout: post
 title:  "Open Liberty - the Open Source runtime for Java microservices"
 date:   2017-09-19 09:00:00 -0400
-categories: news
+categories: blog
 author_picture: https://avatars0.githubusercontent.com/u/1906689
 ---
 :description: Try Open Liberty, an open source,flexible and modular, Java microservices runtime. IncludesMicroProfile and is Java EE 7-compatible.

--- a/src/main/content/_posts/2017-09-29-javaone-sessions-open-liberty-team.adoc
+++ b/src/main/content/_posts/2017-09-29-javaone-sessions-open-liberty-team.adoc
@@ -2,7 +2,7 @@
 layout: post
 title:  "JavaOne sessions from the Open Liberty team"
 date:   2017-09-29 17:30:00 +0100
-categories: news
+categories: blog
 author_picture: https://avatars3.githubusercontent.com/u/3322532
 ---
 :description: Come to these JavaOne sessions, or the IBM booth, to hear current and former Liberty developers speak about Open Liberty, MicroProfile, and microservices.

--- a/src/main/content/_posts/2017-10-26-microprofile-12-open-liberty-17003.adoc
+++ b/src/main/content/_posts/2017-10-26-microprofile-12-open-liberty-17003.adoc
@@ -2,7 +2,7 @@
 layout: post
 title:  "MicroProfile 1.2 and build tools updates in our first Open Liberty release"
 date:   2017-10-26 19:05:00 +0100
-categories: news
+categories: blog
 author_picture: https://avatars3.githubusercontent.com/u/3322532
 ---
 :description: Download a full implementation of MicroProfile 1.2 in Open Liberty 17.0.0.3. Also, Liberty Gradle plugin updates.

--- a/src/main/content/_posts/2017-11-27-liberty-spring-boot.adoc
+++ b/src/main/content/_posts/2017-11-27-liberty-spring-boot.adoc
@@ -2,7 +2,7 @@
 layout: post
 title:  "Open Liberty Spring Boot Starter - embedding Open Liberty into Spring Boot applications"
 date:   2017-11-29 09:00:00 -0400
-categories: news
+categories: blog
 author_picture: https://avatars3.githubusercontent.com/u/656475
 ---
 :description: Use the Open Liberty web container embedded in Spring Boot applications by using the Open Liberty Spring Boot starter.

--- a/src/main/content/_posts/2017-12-21-jsf-implementation-open-liberty-17004.adoc
+++ b/src/main/content/_posts/2017-12-21-jsf-implementation-open-liberty-17004.adoc
@@ -2,7 +2,7 @@
 layout: post
 title:  "Bring your own JSF implementation to Open Liberty 17.0.0.4"
 date:   2017-12-21 12:05:00 +0100
-categories: news
+categories: blog
 author_picture: https://avatars3.githubusercontent.com/u/3322532
 ---
 :description: Download updates for JSF Container (bring your own JSF implementation!), Concurrency, and distributed tracing in Open Liberty 17.0.0.4.

--- a/src/main/content/_posts/2018-01-12-feature-detection-open-liberty-tools.adoc
+++ b/src/main/content/_posts/2018-01-12-feature-detection-open-liberty-tools.adoc
@@ -2,7 +2,7 @@
 layout: post
 title:  "How Open Liberty Tools detects features (and how to disable it)"
 date:   2018-01-12 12:05:00 +0100
-categories: news
+categories: blog
 blog_description: "When you deploy an application to a Liberty server using Open Liberty Tools, it attempts to detect what features your application needs and adds them to the server configuration automatically. Learn how Open Liberty Tools determines what features to add. And how to disable it when necessary."
 author_picture: https://avatars3.githubusercontent.com/u/9484320
 ---

--- a/src/main/content/_posts/2018-01-31-mpRestClient.adoc
+++ b/src/main/content/_posts/2018-01-31-mpRestClient.adoc
@@ -2,7 +2,7 @@
 layout: post
 title:  "MicroProfile Rest Client 1.0"
 date:   2018-01-31 12:05:00 +0100
-categories: news
+categories: blog
 blog_description: "Learn how to build type-safe REST clients using the new MicroProfile Rest Client APIs in Liberty."
 author_picture: https://avatars2.githubusercontent.com/u/21365299
 ---

--- a/src/main/content/_posts/2018-03-16-distributed-tracing-microservices-18001.adoc
+++ b/src/main/content/_posts/2018-03-16-distributed-tracing-microservices-18001.adoc
@@ -2,7 +2,7 @@
 layout: post
 title:  "Enable distributed tracing of microservices with MicroProfile 1.3 (and more) in Open Liberty 18.0.0.1"
 date:   2018-03-16 18:00:00 -0000
-categories: news
+categories: blog
 author_picture: https://avatars3.githubusercontent.com/u/3322532
 seo-title: Enable distributed tracing of microservices with MicroProfile 1.3 (and more) - Open Liberty
 seo-description: Get distributed tracking of your microservices, a standardised way (through OpenAPI) to describe your RESTful applications, and a type-safe approach to invoking RESTful services over HTTP in Open Liberty 18.0.0.1.

--- a/src/main/content/_posts/2018-03-22-distributed-in-memory-session-caching.adoc
+++ b/src/main/content/_posts/2018-03-22-distributed-in-memory-session-caching.adoc
@@ -2,7 +2,7 @@
 layout: post
 title:  "Add distributed in-memory session caching to your Java apps"
 date:   2018-03-22 16:45:00 -0000
-categories: news
+categories: blog
 blog_description: "Try out the new JCache-based distributed in-memory session caching in recent development builds of Open Liberty."
 author_picture: https://avatars2.githubusercontent.com/u/5427967
 seo-title: Add distributed in-memory session caching to your Java apps - Open Liberty

--- a/src/main/java/io/openliberty/website/TLSFilter.java
+++ b/src/main/java/io/openliberty/website/TLSFilter.java
@@ -31,7 +31,8 @@ public class TLSFilter implements Filter {
             put("/docs/ref/javaee/", "/docs/ref/javaee/7/");
             put("/docs/ref/microprofile/", "/docs/ref/microprofile/1.3/");
             put("/docs/ref/", "/docs/");        
-            put("/index.html/", "/index.html");    
+            put("/index.html/", "/index.html");  
+            put("/news/", "/blog/");  
             // put("old uri", "new uri");
         }};
 

--- a/src/main/java/io/openliberty/website/TLSFilter.java
+++ b/src/main/java/io/openliberty/website/TLSFilter.java
@@ -32,9 +32,15 @@ public class TLSFilter implements Filter {
             put("/docs/ref/microprofile/", "/docs/ref/microprofile/1.3/");
             put("/docs/ref/", "/docs/");        
             put("/index.html/", "/index.html");  
-            put("/news/", "/blog/");  
             // put("old uri", "new uri");
-        }};
+    }};
+
+    // Generic deprecated redirect URLS that need to be redirected.
+    private final Map<String, String> GENERIC_REDIRECTS = new HashMap<String,String>(){
+        {
+            put("/news/","/blog/");
+        }
+    }
 
     public void destroy() {
     }
@@ -83,6 +89,18 @@ public class TLSFilter implements Filter {
               // We want to redirect the Servlet and stop further processing of
               // the incoming request.
               return;
+          }
+          // Generic redirects that handle multiple URIs
+          for(String key: GENERIC_REDIRECTS.keySet()){
+              if(uri.contains(key)){
+                  // Redirect using the old value replaced by the new value
+                  String newURI = uri.replaceAll(key, GENERIC_REDIRECTS.get(key));
+                  String newURL = req.getScheme() + "://" + req.getServerName() + newURI;
+                  response.sendRedirect(newURL);
+                  // We want to redirect the Servlet and stop further processing of
+                  // the incoming request.
+                  return;
+              }
           }
         }
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Change all blog posts URL from /news/* to /blog/*
Add generic redirect filter
Redirect all /news/* to /blog/*
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
