### PR TITLE
Add link to the favicon for browsers that don't support putting it in…

### DIFF
--- a/src/main/content/_includes/head.html
+++ b/src/main/content/_includes/head.html
@@ -8,6 +8,7 @@
   <meta name="description" content="{% if page.seo-description %}{{ page.seo-description | escape }}{% else %}{{ page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}{% endif %}">
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+  <link rel="icon" type="image/x-icon" href="/favicon.ico">
   
   {% css openliberty %}
   {% css coderay-custom %}


### PR DESCRIPTION
… the root location

#### What was fixed?  (Issue # or description of fix)
Added link to the favicon in the head tag for browsers that don't have algorithms to find it in the server's root location.
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
