### PR TITLE
Change the guides page to use the first 'visible' card as the search width

### DIFF
--- a/src/main/content/_assets/js/guides.js
+++ b/src/main/content/_assets/js/guides.js
@@ -102,7 +102,7 @@ $(document).ready(function() {
     /* Resize the search bar to match the width of a guide card */
     function resize_search_bar(){
         // Get guide card width
-        var card = $('.guide_item').get(0);
+        var card = $('.guide_item:visible').get(0);
         var card_width = $(card).width();
         // Set the search to the same width as the guide card
         $('#guide_search_input').width(card_width);
@@ -111,6 +111,5 @@ $(document).ready(function() {
     $(window).on('resize', function(){
         resize_search_bar();
     });
-    resize_search_bar();   
-    
+    resize_search_bar(); 
 });


### PR DESCRIPTION



#### What was fixed?  (Issue # or description of fix)
Fixes a bug where filtering guides by a tag using query parameters would result in a broken search bar
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
