### PR TITLE
Disable Google Tag Manager for GDPR

### DIFF
--- a/src/main/content/_config.yml
+++ b/src/main/content/_config.yml
@@ -18,7 +18,7 @@ asciidoctor:
     - coderay-css=class
     - allow-uri-read
 
-google_tag_manager: GTM-TKP3KJ7
+#google_tag_manager: GTM-TKP3KJ7
 #google_analytics: UA-104349928-1
 
 markdown: kramdown  


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Disable Google Tag Manager for GDPR deadline. If we find out that we can have the tags, we can revert the pull request to re-enable it.
Disabling this id in _config.yml will prevent the scripts from being loaded since we have checks if the id exists before using Google Tag Manager.