### PR TITLE
Remove template outline from guides page

### DIFF
--- a/src/main/content/guides.html
+++ b/src/main/content/guides.html
@@ -20,7 +20,7 @@ permalink: /guides/
 -->
 {% assign numGuides = guides.size %}
 {% for guide in guides %}
-    {% if guide.archived or guide.path contains "guides/guides-common" or guide.path contains "guides/iguides-common" %}
+    {% if guide.archived or guide.path contains "guides/guides-template" or guide.path contains "guides/guides-common" or guide.path contains "guides/iguides-common" %}
         {% assign numGuides = numGuides | minus: 1 %}
     {% endif %}
 {% endfor %}
@@ -41,7 +41,7 @@ permalink: /guides/
     <div class="row">
         {% for guide in guides %}
         <!-- Do not render anything from the two common guide repositories containing shared code -->
-        {% unless guide.archived or guide.path contains "guides/guides-common" or guide.path contains "guides/iguides-common" %}
+        {% unless guide.archived or guide.path contains "guides/guides-template" or guide.path contains "guides/guides-common" or guide.path contains "guides/iguides-common" %}
             <div class="guide_column col-xs-12 col-sm-6 col-md-3">
                 <a href="{{ guide.url }}.html" class="guide_item" data-title="{{ guide.title | downcase }}" data-description="{{ guide.description | downcase }}" data-tags="{{ guide.tags | join: ' ' | downcase }}">
                     <div class="guide_title_and_description_container">


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Before change:
![image](https://user-images.githubusercontent.com/6392944/40737491-8319e2fe-6406-11e8-866f-426dcd13e064.png)
After change:
![image](https://user-images.githubusercontent.com/6392944/40737507-91517620-6406-11e8-85cf-4aed4aec29ae.png)

#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [x] Dymanic Accessability Plugin (DAP)
