### PR TITLE
Initial move to interactive multi-column layout

### DIFF
--- a/src/main/content/_includes/doc_header.html
+++ b/src/main/content/_includes/doc_header.html
@@ -36,7 +36,7 @@
             <!-- Add breadcrumb for all pages except /docs -->
             {% if page.url != '/docs/' %}
             <div id="breadcrumb_row">
-                {% if page.layout == 'guide-multipane' or page.layout == 'interactive-guide-multipane' %}
+                {% if page.layout == 'guide-multipane' or page.layout == 'iguide-multipane' %}
                     <!-- Hamburger icon for showing the table of contents -->
                     <button id="breadcrumb_hamburger" class="toc-toggle collapsed" type="button" data-toggle="collapse" data-target="#toc_column"    aria-expanded="false" aria-controls="toc_column">
                         <span class="sr-only">Toggle navigation</span>

--- a/src/main/content/_includes/end-of-guide.html
+++ b/src/main/content/_includes/end-of-guide.html
@@ -39,7 +39,7 @@
                                 </div>
                                 <img class="duration_clock_icon" src="/img/guide_duration_clock_icon_small.svg" alt="Duration">
                                 <span class="guide_duration">{{related-guide-metadata.duration}}</span>
-                                {% if related-guide-metadata.layout == 'interactive-guide' %}
+                                {% if related-guide-metadata.layout == 'interactive-guide' or related-guide-metadata.layout == 'iguide-multipane' %}
                                 <img class="interactive_bolt_icon" src="/img/guide_lightning_bolt.svg" alt="Interactive">
                                 <span class="guide_interactive">Interactive</span>
                                 {% endif %}

--- a/src/main/content/_layouts/iguide-multipane.html
+++ b/src/main/content/_layouts/iguide-multipane.html
@@ -1,0 +1,62 @@
+---
+layout: doc
+css: 
+- doc-header
+- table-of-contents
+- end-of-guide
+- guide-card
+- guide-multipane
+js: guide-multipane
+---
+
+<div id="background_container" class="black_blue_gradient_background">
+        <div class="row">
+            <!-- Guide's table of contents section -->
+            <div id="toc_column" class="collapse inline">
+                <div id="toc_inner">
+                    <div id="close_container">
+                        <img src="{{ " /img/TOC_Close.svg " | relative }}" alt="Table of contents close button"/>
+                    </div>
+                    <h3 id="toc_title">Contents</h3>
+                    <div id="toc_container">
+                        <ul class="sectlevel1"></ul>
+                    </div>
+                    <div id="toc_separator"></div>
+                    {% if page.tags %}
+                        <h3 id="tag_title">Tags</h3>
+                        <div id="tags_container">
+                            {% for tag in page.tags %}
+                                <a href="/guides?search={{ tag }}&key=tag">{{ tag }}</a>
+                            {% endfor %}
+                        </div>
+                    {% endif %}
+                </div>
+            </div>
+            <!-- Entire guide section -->
+            <div id="guide_column" class="position_relative">
+                <div id="guide_content">
+                    <!-- Guide header section -->
+                    <div id="guide_meta" class="sect1">
+                        <h1 id="guide_title">{{ page.title }}</h1>
+                        <div id="duration_container">
+                            <img src="/img/guide_duration_clock_icon_large.svg" alt="duration">
+                            <span id="guide_duration">{{ page.duration }}</span>
+                        </div>
+                    </div>
+
+                    <!-- Guide content section -->
+                    {{ content }}
+
+                    <div id="down_arrow">
+                        <img src="/img/guide_down_arrow.svg" alt="scroll_down">
+                    </div>
+                </div>
+            </div>
+
+            <!-- Code section -->
+            <div id="code_column" class="position_relative">
+            </div>
+        </div>
+</div>
+
+{% include end-of-guide.html %}

--- a/src/main/content/_layouts/interactive-guide.html
+++ b/src/main/content/_layouts/interactive-guide.html
@@ -12,6 +12,7 @@ css:
             <div class="col-sm-3">
                 <h3 id="toc_title">Contents</h3>
                 <div id="toc_container">
+                    <ul class="sectlevel1"></ul>
                 </div>
                 {% if page.tags %}
                 <h3 id="tag_title">Tags</h3>

--- a/src/main/content/guides.html
+++ b/src/main/content/guides.html
@@ -13,7 +13,8 @@ permalink: /guides/
 {% assign static-guides = site.pages | where: 'layout', 'guide' %}
 {% assign multipane-static-guides = site.pages | where: 'layout', 'guide-multipane' %}
 {% assign interactive-guides = site.pages | where: 'layout', 'interactive-guide' %}
-{% assign guides = static-guides | concat: interactive-guides | concat: multipane-static-guides | sort: 'releasedate' | reverse %}
+{% assign multipane-iguides = site.pages | where: 'layout', 'iguide-multipane' %}
+{% assign guides = static-guides | concat: interactive-guides | concat: multipane-static-guides | concat: multipane-iguides | sort: 'releasedate' | reverse %}
 <!-- 
     Some of the found documents are for internal use only and are not intended to be 
     shown on the website.  Remove them from the total number of guides.
@@ -50,7 +51,7 @@ permalink: /guides/
                     </div>
                     <img class="duration_clock_icon" src="/img/guide_duration_clock_icon_small.svg" alt="Duration">
                     <span class="guide_duration">{{guide.duration}}</span>
-                    {% if guide.layout == 'interactive-guide' %}
+                    {% if guide.layout == 'interactive-guide' or guide.layout == 'iguide-multipane' %}
                     <div class="guide_interactive_container">
                             <img class="interactive_bolt_icon" src="/img/guide_lightning_bolt.svg" alt="Interactive">
                             <span class="guide_interactive">Interactive</span>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Fixes Issue #363.
Initial drop of code to enable the multi-column layout for the interactive guide.  See issue #363 for details.

#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [x] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
