### PR TITLE
Update the content header for iguides multipane

### DIFF
--- a/src/main/content/_layouts/iguide-multipane.html
+++ b/src/main/content/_layouts/iguide-multipane.html
@@ -41,7 +41,12 @@ js: guide-multipane
                         <div id="duration_container">
                             <img src="/img/guide_duration_clock_icon_large.svg" alt="duration">
                             <span id="guide_duration">{{ page.duration }}</span>
+                            <div class="guide_interactive_container">
+                                <img class="interactive_bolt_icon" src="/img/guide_lightning_bolt.svg" alt="Interactive">
+                                <span class="guide_interactive">Interactive</span>
+                            </div>
                         </div>
+                        <p>{{ page.description }}</p>
                     </div>
 
                     <!-- Guide content section -->


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Update the guide header section for interactive multipane guides to include the interactive icon and the guide description.

#### Were the changes tested on
- [x ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x ] Chrome (Desktop)
- [ x] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
