### PR TITLE
Move javadoc script into Travis's build process

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,5 +12,4 @@ rvm use 2.4.1 --default
 sudo apt-get -y install nodejs
 
 SCRIPT_DIR=$(dirname $0)
-source $SCRIPT_DIR/copy_javadoc_stylesheet.sh
 source $SCRIPT_DIR/build_jekyll_maven.sh

--- a/scripts/build_jekyll_maven.sh
+++ b/scripts/build_jekyll_maven.sh
@@ -14,6 +14,9 @@ gem install jekyll-assets -v 2.4.0
 echo "Ruby version:"
 echo `ruby -v`
 
+# Special handling for javadocs
+./scripts/copy_javadoc_stylesheet.sh
+
 # Guides that are ready to be published to openliberty.io
 echo "Cloning repositories with name starting with guide or iguide..."
 ruby ./scripts/build_clone_guides.rb


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

**Tested using my personal TravisCI environment and bluemix VM.**

TravisCI only builds using the `build_jekyll_maven.sh` script.   `build_jekyll_maven.sh` is called by `build.sh`.  We added a javadoc specific step in `build.sh` and needs to be done in Travis.  I moved the `copy_javadoc_stylesheet.sh` script call into `build_jekyll_maven.sh`.  Currently qa-guides.mybluemix.net is missing the CSS for javadoc.

![image](https://user-images.githubusercontent.com/31117513/41485097-c826be94-70a4-11e8-9fbf-df87bb8b5717.png)

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
