### PR TITLE
Static guide multipane

### DIFF
--- a/src/main/content/_assets/css/end-of-guide.css
+++ b/src/main/content/_assets/css/end-of-guide.css
@@ -51,6 +51,7 @@
 
 #feedback_ratings > img:hover{
     cursor: pointer;
+    opacity: 1 !important;
 }
 
 #end_of_guide_right_section {

--- a/src/main/content/_assets/css/guide-multipane.css
+++ b/src/main/content/_assets/css/guide-multipane.css
@@ -127,6 +127,11 @@ header {
     word-wrap: break-word;
 }
 
+/* Snippets of code for mobile view only, that comes from the right column file */
+.guide_column_code_snippet {
+    display: none;
+}
+
 .CodeRay .line-numbers {
     display: inline-block;
     visibility: hidden;

--- a/src/main/content/_assets/css/guide-multipane.css
+++ b/src/main/content/_assets/css/guide-multipane.css
@@ -87,11 +87,6 @@ header {
     color: #F4914D;
 }
 
-/* Hide code blocks by default unless in mobile view */
-#guide_content .listingblock:not(.no_copy):not(.inline_code) {
-    /* display: none; */
-}
-
 .code_reference {
     background:#f1f4fe;
     border: 1px solid #c8d6fb;
@@ -161,7 +156,7 @@ header {
 }
 
 /* Create pointed div using pseudo elements */
-#guide_content .code_command .content {
+#guide_content .code_command > .content {
     position: relative;    
     border-left: 8px solid #96bc32;
     border-top:1px solid #c8d6fb;
@@ -169,18 +164,18 @@ header {
     width: 90%;
 }
 
-#guide_content .code_command .content:after, #guide_content .code_command .content:before {
+#guide_content .code_command > .content:after, #guide_content .code_command > .content:before {
     content: "";
     position: absolute;
     left: 100%;
     width: 40px;
     height: 50%;
 }
-#guide_content .code_command .content:before {
+#guide_content .code_command > .content:before {
     top: 0px;
     background: linear-gradient(to top right, #F1F4FE 50%, transparent 51%), linear-gradient(230deg, transparent 29.5px, #c8d6fb 0);
 }
-#guide_content .code_command .content:after {
+#guide_content .code_command > .content:after {
     bottom: 0px;
     background: linear-gradient(to bottom right, #F1F4FE 50%, transparent 51%), linear-gradient(310deg, transparent 29.5px, #c8d6fb 0);
 }
@@ -480,12 +475,11 @@ header {
         padding-left: 15px;
         padding-right: 15px;
         box-shadow: none;
-    }  
-
-    /* Show the code snippets in mobile view that were on the right pane in desktop view */
-    #guide_content .listingblock:not(.no_copy):not(.inline_code) {
-        display: block;
     } 
+
+    .guide_column_code_snippet {
+        display: block;
+    }
 }
 
 @media (min-width: 1171px) {

--- a/src/main/content/_assets/css/guide-multipane.css
+++ b/src/main/content/_assets/css/guide-multipane.css
@@ -157,6 +157,7 @@ header {
 #guide_content .code_command pre,  #guide_content .code_command code {
     background-color: #F1F4FE;
     margin-bottom: 0;
+    overflow: hidden;
 }
 
 /* Create pointed div using pseudo elements */

--- a/src/main/content/_assets/css/guide-multipane.css
+++ b/src/main/content/_assets/css/guide-multipane.css
@@ -143,6 +143,7 @@ header {
     border: 1px solid #96bc32;
     border-left: 8px solid #96bc32;
     border-radius: 3px;    
+    overflow: hidden;
 }
 
 #guide_content .command code {

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -419,12 +419,7 @@ $(document).ready(function() {
                         //     scrollTop: y,
                         //     easing: 'linear'
                         // });
-                    // }                    
-
-                    // Set URL hash value to be the section id
-                    if(elem.id){
-                        location.hash = elem.id;
-                    }                       
+                    // }                       
 
                     // Hide other code blocks and show the correct code block.
                     var id = elem.id;

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -119,6 +119,7 @@ $(document).ready(function() {
             // Clone this code block so the full file can be shown in the right column and only a duplicate snippet will be shown in the single column view or mobile view.
             // The duplicated code block will be shown on the right column.
             var duplicate_code_block = code_block.clone();
+            code_block.addClass('guide_column_code_snippet'); // Add class to code snippet in the guide column to only show up in mobile view.
 
             var guide_section = code_block.parents('.sect1').first();
             var header = guide_section.find('h2')[0];

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -171,7 +171,7 @@ $(document).ready(function() {
             // Remove line numbers which were mainly used for highlighting the section.
             code_block.find('.line-numbers').remove();
             duplicate_code_block.find('.line-numbers').remove();
-        }    
+        }
     });
 
     // Map the guide sections that don't have any code sections to the previous section's code.

--- a/src/main/content/_includes/end-of-guide.html
+++ b/src/main/content/_includes/end-of-guide.html
@@ -52,9 +52,5 @@
                 </div>
             </div>
             {% endif %}
-
-            {% if page.categories %}
-            <p>Dive into the <b>{{ page.categories }} config</b>.</p>
-            {% endif %}
         </div>
     </div>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Minor styling and bug fixes, remove updating the URL hash when scrolling to prevent bug scrolling up and the guide keeps advancing back down to the next section, remove hardcoded categories sentence in the related links section as this will be specified in each guide's asciidoc, add a class to the duplicated code blocks so that they only show up in mobile view and not inline in the guide in desktop view, fix code command arrow selector because it was also affecting children elements.
![image](https://user-images.githubusercontent.com/6392944/41562540-8e853524-7312-11e8-9b34-12b16056d5de.png)

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
