### PR TITLE
Add enter key support

### DIFF
--- a/src/main/content/_assets/js/guides.js
+++ b/src/main/content/_assets/js/guides.js
@@ -75,6 +75,13 @@ $(document).ready(function() {
         processSearch(input_value);        
     });
 
+    $('#guide_search_input').keypress(function(event) {
+        if(event.which == 13) { // 13 is the enter key
+            var searchInput = $('#guide_search_input').val();
+            updateSearchUrl(searchInput);
+        }
+    });
+
     var query_string = location.search;
     // Process the url parameters for searching
     if(query_string.length > 0) {
@@ -108,8 +115,34 @@ $(document).ready(function() {
         $('#guide_search_input').width(card_width);
     };
 
+    function updateSearchUrl(value) {
+        if(! value) {
+            // Remove query string because search text is empty
+            location.href = [location.protocol, '//', location.host, location.pathname].join('');
+        } else {
+            // Handle various search functions
+            _processSearchText(value);
+        }
+    }
+
+    function _processSearchText(value) {
+        // We support searching with prefex
+        // 1.  tag: <tag text>
+        // 2.  Free form text
+        if(value.startsWith("tag:")) {
+            var searchTextWithoutTag = value.substring(value.indexOf(':') + 1);
+            searchTextWithoutTag = searchTextWithoutTag.trim();
+            location.search = "search=" + encodeURIComponent(searchTextWithoutTag) + "&key=tag";
+
+        } else {
+            value = value.trim();
+            location.search = "search=" + encodeURIComponent(value);
+        }
+    }
+
     $(window).on('resize', function(){
         resize_search_bar();
     });
-    resize_search_bar(); 
+    resize_search_bar();
+
 });


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

PR for #361 

There is no way to bookmark the search results when filtering the list of guides.  As a minimum, we can update the URL with the `search=<text>` and `tag=key` when a user hits the enter button.

#### Preview of the new behavior using the Enter key
![osearch](https://user-images.githubusercontent.com/31117513/41665631-0498bd60-746e-11e8-9f47-9b5b6672be94.gif)


#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
