### PR TITLE
Various fixes to the static multipane guide

### DIFF
--- a/src/main/content/_assets/css/end-of-guide.css
+++ b/src/main/content/_assets/css/end-of-guide.css
@@ -34,6 +34,14 @@
     border-right: 1px solid #c8d3d3;
 }
 
+#guide_attribution {
+    font-family: Bunuelo;
+    font-weight: 500;
+    color:#5d6a8e;
+    letter-spacing:0;
+    line-height:24px;
+}
+
 #improve_guide_feedback, #need_help, #feedback_rating_question {
     font-family: BunueloBold;
     font-size:20px;

--- a/src/main/content/_assets/css/end-of-guide.css
+++ b/src/main/content/_assets/css/end-of-guide.css
@@ -29,7 +29,7 @@
 #end_of_guide_left_section {
     display: inline-block;
     float: left;
-    width: calc(100% - 730px);
+    width: calc(100% - 700px);
     padding: 0 37px;
     border-right: 1px solid #c8d3d3;
 }
@@ -64,7 +64,7 @@
 
 #end_of_guide_right_section {
     display: inline-block;
-    width: 730px;
+    width: 700px;
     padding: 0 50px;
 }
 
@@ -78,11 +78,11 @@
 
 @media (min-width: 1440px) {
     #end_of_guide_left_section {
-        width: calc(100% - 730px);
+        width: calc(100% - 700px);
     }
 
     #end_of_guide_right_section {
-        width: 730px;
+        width: 700px;
     }
 }
 

--- a/src/main/content/_assets/css/end-of-guide.css
+++ b/src/main/content/_assets/css/end-of-guide.css
@@ -29,7 +29,7 @@
 #end_of_guide_left_section {
     display: inline-block;
     float: left;
-    width: calc(100% - 700px);
+    width: calc(100% - 780px);
     padding: 0 37px;
     border-right: 1px solid #c8d3d3;
 }
@@ -64,7 +64,7 @@
 
 #end_of_guide_right_section {
     display: inline-block;
-    width: 700px;
+    width: 780px;
     padding: 0 50px;
 }
 
@@ -78,11 +78,11 @@
 
 @media (min-width: 1440px) {
     #end_of_guide_left_section {
-        width: calc(100% - 700px);
+        width: calc(100% - 780px);
     }
 
     #end_of_guide_right_section {
-        width: 700px;
+        width: 780px;
     }
 }
 

--- a/src/main/content/_assets/css/guide-card.css
+++ b/src/main/content/_assets/css/guide-card.css
@@ -44,7 +44,7 @@
 }
 
 .guide_title_container {
-    height: 40px;
+    height: 60px;
     overflow: hidden;
 }
 

--- a/src/main/content/_assets/css/guide-multipane.css
+++ b/src/main/content/_assets/css/guide-multipane.css
@@ -144,6 +144,11 @@ header {
     border-left: 8px solid #96bc32;
     border-radius: 3px;    
     overflow: hidden;
+    white-space: pre-wrap;       /* css-3 */
+    white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+    white-space: -pre-wrap;      /* Opera 4-6 */
+    white-space: -o-pre-wrap;    /* Opera 7 */
+    word-wrap: break-word;  
 }
 
 #guide_content .command code {
@@ -154,6 +159,11 @@ header {
     background-color: #F1F4FE;
     margin-bottom: 0;
     overflow: hidden;
+    white-space: pre-wrap;       /* css-3 */
+    white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+    white-space: -pre-wrap;      /* Opera 4-6 */
+    white-space: -o-pre-wrap;    /* Opera 7 */
+    word-wrap: break-word;      
 }
 
 /* Create pointed div using pseudo elements */

--- a/src/main/content/_assets/css/guide-multipane.css
+++ b/src/main/content/_assets/css/guide-multipane.css
@@ -20,7 +20,7 @@ header {
 .copyFileButton {
     display: inline-block;
     position: absolute;
-    right: 16px;
+    right: 26px;
     top: 14px;
     line-height: 5px;
 }
@@ -271,14 +271,14 @@ header {
 
 #guide_column {
     color: #24253a;
-    width: calc(100% - 730px);
+    width: calc(100% - 700px);
 }
 
 #code_column {
     padding: 0;
     background-color: #f1f4fe;
     position: fixed;
-    width: 730px;
+    width: 700px;
     left: calc(100% - 700px); /* Adjust for the width and padding */
     top: 100px;
     bottom: 0; /* Initially extend the code column the full height */
@@ -291,7 +291,7 @@ header {
 
 .code_column_title_container {
     height: 43px;
-    padding-left: 9.5px; 
+    padding-left: 23px; 
     border-bottom: solid 1px #d4d7e3;
     display: table;
     width: 100%;
@@ -417,8 +417,8 @@ header {
 }
 
 .code_column .CodeRay code, .code_column .CodeRay .highlightSection {
-    padding-left: 9.5px;
-    padding-right: 9.5px;
+    padding-left: 23px;
+    padding-right: 31px;
 }
 
 .codeTitle {
@@ -498,27 +498,27 @@ header {
 
     #down_arrow {
         display: block;
-        left: calc((100% - 730px - 45px)/2); /* Calculate positioning to be in the center of the guide column */
+        left: calc((100% - 700px - 45px)/2); /* Calculate positioning to be in the center of the guide column */
     }
 }
 
 @media (min-width: 1440px) {
     #guide_column {
-        width: calc(100% - 280px - 730px); /* Adjust for the size of the table of contents and the code column */
+        width: calc(100% - 280px - 700px); /* Adjust for the size of the table of contents and the code column */
         display: inline-block;
     }
 
     #guide_column.expanded {
-        width: calc(100% - 730px);
+        width: calc(100% - 700px);
     }
 
     #down_arrow {
         display: block;
-        left: calc(280px + (100% - 280px - 730px - 45px)/2); /* Calculate positioning to be in the center of the guide column */
+        left: calc(280px + (100% - 280px - 700px - 45px)/2); /* Calculate positioning to be in the center of the guide column */
     }
 
     #code_column {
-        left: calc(100% - 730px); /* Adjust for the width and padding */
+        left: calc(100% - 700px); /* Adjust for the width and padding */
         display: inline-block;
     }    
 }

--- a/src/main/content/_assets/css/guide-multipane.css
+++ b/src/main/content/_assets/css/guide-multipane.css
@@ -271,15 +271,15 @@ header {
 
 #guide_column {
     color: #24253a;
-    width: calc(100% - 700px);
+    width: calc(100% - 780px);
 }
 
 #code_column {
     padding: 0;
     background-color: #f1f4fe;
     position: fixed;
-    width: 700px;
-    left: calc(100% - 700px); /* Adjust for the width and padding */
+    width: 780px;
+    left: calc(100% - 780px); /* Adjust for the width and padding */
     top: 100px;
     bottom: 0; /* Initially extend the code column the full height */
     overflow-y: scroll;
@@ -498,27 +498,27 @@ header {
 
     #down_arrow {
         display: block;
-        left: calc((100% - 700px - 45px)/2); /* Calculate positioning to be in the center of the guide column */
+        left: calc((100% - 780px - 45px)/2); /* Calculate positioning to be in the center of the guide column */
     }
 }
 
 @media (min-width: 1440px) {
     #guide_column {
-        width: calc(100% - 280px - 700px); /* Adjust for the size of the table of contents and the code column */
+        width: calc(100% - 280px - 780px); /* Adjust for the size of the table of contents and the code column */
         display: inline-block;
     }
 
     #guide_column.expanded {
-        width: calc(100% - 700px);
+        width: calc(100% - 780px);
     }
 
     #down_arrow {
         display: block;
-        left: calc(280px + (100% - 280px - 700px - 45px)/2); /* Calculate positioning to be in the center of the guide column */
+        left: calc(280px + (100% - 280px - 780px - 45px)/2); /* Calculate positioning to be in the center of the guide column */
     }
 
     #code_column {
-        left: calc(100% - 700px); /* Adjust for the width and padding */
+        left: calc(100% - 780px); /* Adjust for the width and padding */
         display: inline-block;
     }    
 }

--- a/src/main/content/_assets/js/common-multipane.js
+++ b/src/main/content/_assets/js/common-multipane.js
@@ -86,31 +86,28 @@ function handleFloatingCodeColumn() {
     }
 }
 
+/* Find the section that is most visible in the viewport and return the id */
 function getScrolledVisibleSectionID(event) {
-    var origEvent = event.originalEvent;
-    var dir = (origEvent.deltaY) < 0 ? 'up' : 'down';
     var id = null;
+    var maxVisibleSectionHeight = 0;
 
     // Multipane view
     if ($(window).width() > twoColumnBreakpoint) {
-        var sections = $('.sect1:not(#guide_meta):not(#related-guides) > h2');
+        var sections = $('.sect1:not(#guide_meta):not(#related-guides)');
         sections.each(function(index) {
-            var elem = sections.get(index);
-            var rect = elem.getBoundingClientRect();
-            var elemTop = rect.top - 100; // Offset by the sticky header's height
-            var elemBottom = rect.bottom;
-            // Check if the next section in the direction the user is scrolling shows up
-            var isVisible;
-            if (dir === 'down') {
-                // Element top is visible and bottom is not visible
-                isVisible = elemTop < window.innerHeight && elemBottom >= window.innerHeight;
-            } else if (dir === 'up') {
-                isVisible = elemBottom >= 0 && elemBottom < window.innerHeight;
+            var elem = $(sections.get(index));
+            var windowHeight   = $(window).height();
+            var elemHeight = elem.outerHeight();
+            var rect = elem[0].getBoundingClientRect();
+            var top = rect.top; 
+            var bottom = rect.bottom;
+            var visibleElemHeight = Math.max(0, top > 0 ? Math.min(elemHeight, windowHeight - top) : Math.min(bottom, windowHeight));
+            if(visibleElemHeight > maxVisibleSectionHeight){
+                maxVisibleSectionHeight = visibleElemHeight;
+                id = elem.children('h2')[0].id;
             }
-            if (isVisible) {
-                id = this.id;
-                return false;    // Break out of loop
-            }
+
+            console.log('Section most in view is: ' + id + ' with height of ' + maxVisibleSectionHeight);
         });
     }
     return id;
@@ -135,7 +132,7 @@ function createEndOfGuideContent(){
         $("#guide-attribution").parent().remove();
         $("#toc_container a[href='#guide-attribution']").parent().remove(); // Remove from TOC.
     }
-    
+
     var relatedLinks = $("#related-links").siblings().find('p').clone();
     rightSide.append(relatedLinks);
     $("#related-links").parent().remove(); // Remove section from the main guide column.

--- a/src/main/content/_assets/js/common-multipane.js
+++ b/src/main/content/_assets/js/common-multipane.js
@@ -101,7 +101,17 @@ function getScrolledVisibleSectionID(event) {
             var rect = elem[0].getBoundingClientRect();
             var top = rect.top; 
             var bottom = rect.bottom;
-            var visibleElemHeight = Math.max(0, top > 0 ? Math.min(elemHeight, windowHeight - top) : Math.min(bottom, windowHeight));
+            var visibleElemHeight = 0;           
+            if(top > 0){
+                 // Top of element is below the top of the viewport
+                 // Calculate the visible element height as the min of the whole element (if the whole element is in the viewport) and the top of the element to the bottom of the window (if only part of the element is visible and extends beyond the bottom of the viewport).
+                 visibleElemHeight = Math.min(elemHeight, windowHeight - top);
+            }
+            else {
+                // Top of element is at or above the top of the viewport
+                // Calculate the visible element height as the min between the bottom (if the element starts above the viewport and ends before the bottom of the viewport) or the windowHeight(the element extends beyond the top and bottom of viewport in both diretions).
+                visibleElemHeight = Math.min(bottom, windowHeight);
+            }
             if(visibleElemHeight > maxVisibleSectionHeight){
                 maxVisibleSectionHeight = visibleElemHeight;
                 id = elem.children('h2')[0].id;

--- a/src/main/content/_assets/js/common-multipane.js
+++ b/src/main/content/_assets/js/common-multipane.js
@@ -125,6 +125,17 @@ function createEndOfGuideContent(){
     leftSide.prepend(whatYouLearned);
     $("#great-work-you-re-done").parent().remove(); // Remove section from the main guide column.
     $("#toc_container a[href='#great-work-you-re-done'], #toc_container a[href='#great-work-youre-done']").parent().remove(); // Remove from TOC.
+
+    // Concatenate the guide title and guide attribution license and append it to the end of guide.
+    var guideAttribution = $("#guide-attribution").siblings().find('p').text();
+    if(guideAttribution){
+        var guideTitle = $("#guide_title").text();
+        var concatenatedAttribution = guideTitle + " is licensed under " + guideAttribution;
+        $("#guide_attribution").text(concatenatedAttribution);
+        $("#guide-attribution").parent().remove();
+        $("#toc_container a[href='#guide-attribution']").parent().remove(); // Remove from TOC.
+    }
+    
     var relatedLinks = $("#related-links").siblings().find('p').clone();
     rightSide.append(relatedLinks);
     $("#related-links").parent().remove(); // Remove section from the main guide column.

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -240,10 +240,7 @@ $(document).ready(function() {
             var id = getScrolledVisibleSectionID(event);
             if (id) {
                 // Remove previous TOC section highlighted and highlight correct step
-                updateTOCHighlighting(id);
-
-                // Set URL hash value to be the section id
-                location.hash = id;                       
+                updateTOCHighlighting(id);                      
 
                 // Hide other code blocks and show the correct code block.                  
                 try{

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -268,7 +268,6 @@ $(document).ready(function() {
             }   
         }            
     }
-    
     $(window).on('scroll', function(event) {
         handleGithubPopup(false);
         handleSectionSnapping(event);

--- a/src/main/content/_includes/end-of-guide.html
+++ b/src/main/content/_includes/end-of-guide.html
@@ -1,6 +1,7 @@
 <div id="end_of_guide">
         <h2>Nice work! You did it!</h2>
         <div id="end_of_guide_left_section">
+            <p id="guide_attribution"></p>
             <h3 id="improve_guide_feedback">What could make this guide better?</h3>
             <p><a href="https://github.com/OpenLiberty/guide-{{page.url | replace: '/guides/', ''}}/issues">Raise an issue</a> to share feedback</p>
             <p><a href="https://github.com/OpenLiberty/guide-{{page.url | replace: '/guides/', ''}}/pulls">Create a pull request</a> to contribute to this guide</p>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Update code_column chars per line to 90 and fix hidden overflow in commands. Also add the guide attribution logic. Update the scroll algorithm to show the section most in view instead of detecting what section is coming up.
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
