### PR TITLE
Redirect /guides/microprofile-intro.html to /guides/cdi-intro.html

### DIFF
--- a/src/main/java/io/openliberty/website/TLSFilter.java
+++ b/src/main/java/io/openliberty/website/TLSFilter.java
@@ -32,6 +32,7 @@ public class TLSFilter implements Filter {
             put("/docs/ref/microprofile/", "/docs/ref/microprofile/1.3/");
             put("/docs/ref/", "/docs/");        
             put("/index.html/", "/index.html");  
+            put("/guides/microprofile-intro.html", "/guides/cdi-intro.html");
             // put("old uri", "new uri");
     }};
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Redirect /guides/microprofile-intro.html to /guides/cdi-intro.html
Some background: @evelinec already archived the microprofile-intro guide using the :page-archived tag at the top of that guide, and we want to redirect that old url to the cdi-intro guide.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
