### PR TITLE
Update the latest version to be 18.0.0.2

### DIFF
--- a/src/main/content/_posts/2018-07-02-creating-dual-layer-docker-images-for-spring-boot-apps.adoc
+++ b/src/main/content/_posts/2018-07-02-creating-dual-layer-docker-images-for-spring-boot-apps.adoc
@@ -11,7 +11,7 @@ blog_description: "Embrace Docker for your Spring Boot applications! Building du
 = Creating Dual Layer Docker images for Spring Boot apps
 Michael Thompson <https://github.com/barecode>
 
-In the first part of this blog post series link:/blog/2018/06/29/optimizing-spring-boot-for-docker.html[Optimizing Spring Boot apps for Docker] we looked at the single layer approach to building Docker images for Spring Boot applications and the implications it has for CI/CD pipelines.
+In the first part of this blog post series link:/blog/2018/06/29/optimizing-spring-boot-apps-for-docker.html[Optimizing Spring Boot apps for Docker] we looked at the single layer approach to building Docker images for Spring Boot applications and the implications it has for CI/CD pipelines.
 I proposed that a dual layer approach has concrete benefits over the single layer approach and that these benefits are in the form of efficiencies in iterative development environments.
 
 Here we introduce an approach to creating dual layer Docker images for existing Spring Boot applications using a new tool in Open Liberty called `springBootUtility`.

--- a/src/main/content/latestVersion.js
+++ b/src/main/content/latestVersion.js
@@ -10,7 +10,7 @@
  *******************************************************************************/
 
 var latestReleasedVersion = {
-    version: '18.0.0.1',
+    version: '18.0.0.2',
     productName : 'Open Liberty Runtime',
     availableFrom : 'https://openliberty.io/downloads?welcome'
 };


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

Update the latest version to be 18.0.0.2.  This version number is used by splash page on a running open liberty server.

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
