### PR TITLE
Various fixes to config doc including mobile view

### DIFF
--- a/scripts/build_jekyll_maven.sh
+++ b/scripts/build_jekyll_maven.sh
@@ -16,6 +16,7 @@ echo `ruby -v`
 
 # Special handling for javadocs
 ./scripts/copy_javadoc_stylesheet.sh
+./scripts/modify_config_adoc.sh
 
 # Guides that are ready to be published to openliberty.io
 echo "Cloning repositories with name starting with guide or iguide..."

--- a/scripts/modify_config_adoc.sh
+++ b/scripts/modify_config_adoc.sh
@@ -1,8 +1,8 @@
 addPageLayoutAttribute () {
     # insert page-layout attribute
     sed '1 i\
-    :page-layout: config
-    ' "$1" > newConfig.adoc
+:page-layout: config
+' "$1" > newConfig.adoc
     
     mv newConfig.adoc "$1"
 }

--- a/src/main/content/_assets/css/config.css
+++ b/src/main/content/_assets/css/config.css
@@ -310,10 +310,6 @@ div.toggle:hover {
         display: none;
     }
 
-    td {
-        word-break: break-word;
-    }
-
     #breadcrumb_row {
         background-color: #24243A;
     }

--- a/src/main/content/_assets/js/configs.js
+++ b/src/main/content/_assets/js/configs.js
@@ -429,7 +429,6 @@ function handleExpandCollapseTitle(titleId, isShow) {
                 $(this).removeClass("collapseMargin");
             }
             $(this).show();
-
         } else {
             // don't hide the clicked toggle element title and description
             if ((dataId === titleId && $(this).is("table")) || (dataId !== titleId && (dataId.indexOf(titleId + "/") === 0))) {
@@ -468,16 +467,20 @@ function modifyFixedTableColumnWidth() {
     var colWidths = [];
     if (!isMobileView()) {
         colWidths[4] = ["25%", "15%", "15%", "45%"];
-    } else {
-        colWidths[4] = ["25%", "25%", "15%", "35%"];
+    // } else {
+    //     colWidths[4] = ["25%", "25%", "15%", "35%"];
     }
     $(colgroups).each(function () {
-        var cols = $(this).find("col");
-        var currentColWidths = colWidths[cols.length];
-        if (currentColWidths) {
-            $(cols).each(function (index) {
-                $(this).css("width", currentColWidths[index]);
-            })
+        if (isMobileView()) {
+            $(this).remove();
+        } else {
+            var cols = $(this).find("col");
+            var currentColWidths = colWidths[cols.length];
+            if (currentColWidths) {
+                $(cols).each(function (index) {
+                    $(this).css("width", currentColWidths[index]);
+                })
+            }
         }
     })
 }
@@ -882,9 +885,13 @@ function addHamburgerClick() {
             if ($("#toc_column").hasClass('in')) {
                 $("#config_content").show();
                 $("#breadcrumb_hamburger").show();
+                // For iphone, the footer doesn't show up in the right place. Not displaying the 
+                // footer for now.
+                $("footer").hide();
             } else {
                 $("#config_content").hide();
                 $("#breadcrumb_hamburger").hide();
+                $("footer").show();
                 // since the opening/closing of the toc container is managed by the hamburger,
                 // it always scrolls back to the top of the TOC. The codes here cannot override  
                 // the scrolling position as the default hamburger click event has not been fired
@@ -913,7 +920,7 @@ $(document).ready(function () {
     addHamburgerClick();
 
     $('iframe[name="contentFrame"]').load(function () {
-        //if ($(this)[0].contentDocument.title !== "Not Found") {
+        if ($(this)[0].contentDocument.title !== "Not Found") {
             initialContentBreadcrumbVisibility();
             modifyFixedTableColumnWidth();
             handleSubHeadingsInContent();
@@ -952,6 +959,6 @@ $(document).ready(function () {
             if ($(this).contents().attr("location").href.indexOf("#") !== -1) {
                 handleIFrameDocPosition($(this).contents().attr("location").href);
             }
-        //}
+        }
     });
 });

--- a/src/main/content/config/rwlp_config_activationSpec.adoc
+++ b/src/main/content/config/rwlp_config_activationSpec.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +activationSpec - Activation Specification+ (+activationSpec+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_activedLdapFilterProperties.adoc
+++ b/src/main/content/config/rwlp_config_activedLdapFilterProperties.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +activedLdapFilterProperties - Microsoft Active Directory LDAP Filters+ (+activedLdapFilterProperties+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_adminObject.adoc
+++ b/src/main/content/config/rwlp_config_adminObject.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +adminObject - Administered Object+ (+adminObject+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_administrator-role.adoc
+++ b/src/main/content/config/rwlp_config_administrator-role.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +administrator-role - Administrator Role+ (+administrator-role+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_application.adoc
+++ b/src/main/content/config/rwlp_config_application.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +application - Application+ (+application+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_applicationManager.adoc
+++ b/src/main/content/config/rwlp_config_applicationManager.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +applicationManager - Application Manager+ (+applicationManager+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_applicationMonitor.adoc
+++ b/src/main/content/config/rwlp_config_applicationMonitor.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +applicationMonitor - Application Monitoring+ (+applicationMonitor+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_authCache.adoc
+++ b/src/main/content/config/rwlp_config_authCache.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +authCache - Authentication Cache+ (+authCache+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_authData.adoc
+++ b/src/main/content/config/rwlp_config_authData.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +authData - Authentication Data+ (+authData+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_authentication.adoc
+++ b/src/main/content/config/rwlp_config_authentication.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +authentication - Authentication+ (+authentication+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_authorization-roles.adoc
+++ b/src/main/content/config/rwlp_config_authorization-roles.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +authorization-roles - Feature Authorization Role Mapping+ (+authorization-roles+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_basicRegistry.adoc
+++ b/src/main/content/config/rwlp_config_basicRegistry.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +basicRegistry - Basic User Registry+ (+basicRegistry+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_batchPersistence.adoc
+++ b/src/main/content/config/rwlp_config_batchPersistence.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +batchPersistence - Batch Persistence+ (+batchPersistence+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_bell.adoc
+++ b/src/main/content/config/rwlp_config_bell.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +bell - BELL+ (+bell+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_cdi12.adoc
+++ b/src/main/content/config/rwlp_config_cdi12.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +cdi12 - Contexts And Dependency Injection V1.2 Or Newer+ (+cdi12+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_channelfw.adoc
+++ b/src/main/content/config/rwlp_config_channelfw.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +channelfw - Channel Framework+ (+channelfw+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_classloading.adoc
+++ b/src/main/content/config/rwlp_config_classloading.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +classloading - Classloading+ (+classloading+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_cloudant.adoc
+++ b/src/main/content/config/rwlp_config_cloudant.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +cloudant - Cloudant Builder+ (+cloudant+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_cloudantDatabase.adoc
+++ b/src/main/content/config/rwlp_config_cloudantDatabase.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +cloudantDatabase - Cloudant Database+ (+cloudantDatabase+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_concurrencyPolicy.adoc
+++ b/src/main/content/config/rwlp_config_concurrencyPolicy.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +concurrencyPolicy - Concurrency Policy+ (+concurrencyPolicy+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_config.adoc
+++ b/src/main/content/config/rwlp_config_config.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +config - Configuration Management+ (+config+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_connectionFactory.adoc
+++ b/src/main/content/config/rwlp_config_connectionFactory.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +connectionFactory - Connection Factory+ (+connectionFactory+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_connectionManager.adoc
+++ b/src/main/content/config/rwlp_config_connectionManager.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +connectionManager - Connection Manager+ (+connectionManager+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_contextService.adoc
+++ b/src/main/content/config/rwlp_config_contextService.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +contextService - Thread Context Propagation+ (+contextService+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_cors.adoc
+++ b/src/main/content/config/rwlp_config_cors.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +cors - Cross-Origin Resource Sharing+ (+cors+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_couchdb.adoc
+++ b/src/main/content/config/rwlp_config_couchdb.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +couchdb - CouchDB+ (+couchdb+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_customLdapFilterProperties.adoc
+++ b/src/main/content/config/rwlp_config_customLdapFilterProperties.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +customLdapFilterProperties - Custom LDAP Filters+ (+customLdapFilterProperties+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_dataSource.adoc
+++ b/src/main/content/config/rwlp_config_dataSource.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +dataSource - Data Source+ (+dataSource+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_databaseStore.adoc
+++ b/src/main/content/config/rwlp_config_databaseStore.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +databaseStore - Database Store+ (+databaseStore+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_distributedMap.adoc
+++ b/src/main/content/config/rwlp_config_distributedMap.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +distributedMap - Distributed Map+ (+distributedMap+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_domino50LdapFilterProperties.adoc
+++ b/src/main/content/config/rwlp_config_domino50LdapFilterProperties.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +domino50LdapFilterProperties - IBM Lotus Domino LDAP Filters+ (+domino50LdapFilterProperties+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_edirectoryLdapFilterProperties.adoc
+++ b/src/main/content/config/rwlp_config_edirectoryLdapFilterProperties.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +edirectoryLdapFilterProperties - Novell eDirectory LDAP Filters+ (+edirectoryLdapFilterProperties+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_ejbApplication.adoc
+++ b/src/main/content/config/rwlp_config_ejbApplication.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +ejbApplication - EJB Application+ (+ejbApplication+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_ejbContainer.adoc
+++ b/src/main/content/config/rwlp_config_ejbContainer.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +ejbContainer - EJB Container+ (+ejbContainer+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_enterpriseApplication.adoc
+++ b/src/main/content/config/rwlp_config_enterpriseApplication.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +enterpriseApplication - Enterprise Application+ (+enterpriseApplication+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_executor.adoc
+++ b/src/main/content/config/rwlp_config_executor.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +executor - Executor Management+ (+executor+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_featureManager.adoc
+++ b/src/main/content/config/rwlp_config_featureManager.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +featureManager - Feature Manager+ (+featureManager+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_federatedRepository.adoc
+++ b/src/main/content/config/rwlp_config_federatedRepository.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +federatedRepository - User Registry Federation+ (+federatedRepository+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_fileset.adoc
+++ b/src/main/content/config/rwlp_config_fileset.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +fileset - Fileset+ (+fileset+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_httpAccessLogging.adoc
+++ b/src/main/content/config/rwlp_config_httpAccessLogging.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +httpAccessLogging - HTTP Access Logging+ (+httpAccessLogging+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_httpDispatcher.adoc
+++ b/src/main/content/config/rwlp_config_httpDispatcher.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +httpDispatcher - HTTP Dispatcher+ (+httpDispatcher+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_httpEncoding.adoc
+++ b/src/main/content/config/rwlp_config_httpEncoding.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +httpEncoding - HTTP Transport Encoding+ (+httpEncoding+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_httpEndpoint.adoc
+++ b/src/main/content/config/rwlp_config_httpEndpoint.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +httpEndpoint - HTTP Endpoint+ (+httpEndpoint+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_httpOptions.adoc
+++ b/src/main/content/config/rwlp_config_httpOptions.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +httpOptions - HTTP Options+ (+httpOptions+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_httpProxyRedirect.adoc
+++ b/src/main/content/config/rwlp_config_httpProxyRedirect.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +httpProxyRedirect - HTTP Proxy Redirect+ (+httpProxyRedirect+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_httpSession.adoc
+++ b/src/main/content/config/rwlp_config_httpSession.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +httpSession - HTTP Session+ (+httpSession+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_httpSessionCache.adoc
+++ b/src/main/content/config/rwlp_config_httpSessionCache.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +httpSessionCache - HTTP Session Cache+ (+httpSessionCache+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_httpSessionDatabase.adoc
+++ b/src/main/content/config/rwlp_config_httpSessionDatabase.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +httpSessionDatabase - HTTP Session Database+ (+httpSessionDatabase+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_idsLdapFilterProperties.adoc
+++ b/src/main/content/config/rwlp_config_idsLdapFilterProperties.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +idsLdapFilterProperties - IBM Tivoli Directory Server LDAP Filters+ (+idsLdapFilterProperties+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_iiopEndpoint.adoc
+++ b/src/main/content/config/rwlp_config_iiopEndpoint.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +iiopEndpoint - IIOP Endpoint+ (+iiopEndpoint+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_iiopServerPolicies.adoc
+++ b/src/main/content/config/rwlp_config_iiopServerPolicies.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +iiopServerPolicies - IIOP Server Policies+ (+iiopServerPolicies+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_include.adoc
+++ b/src/main/content/config/rwlp_config_include.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +include - Include+ (+include+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_iplanetLdapFilterProperties.adoc
+++ b/src/main/content/config/rwlp_config_iplanetLdapFilterProperties.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +iplanetLdapFilterProperties - Sun Java System Directory Server LDAP Filters+ (+iplanetLdapFilterProperties+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_jaasLoginContextEntry.adoc
+++ b/src/main/content/config/rwlp_config_jaasLoginContextEntry.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +jaasLoginContextEntry - JAAS Login Context Entry+ (+jaasLoginContextEntry+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_jaasLoginModule.adoc
+++ b/src/main/content/config/rwlp_config_jaasLoginModule.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +jaasLoginModule - JAAS Login Module+ (+jaasLoginModule+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_javaPermission.adoc
+++ b/src/main/content/config/rwlp_config_javaPermission.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +javaPermission - Java 2 Security+ (+javaPermission+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_jdbcDriver.adoc
+++ b/src/main/content/config/rwlp_config_jdbcDriver.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +jdbcDriver - JDBC Driver+ (+jdbcDriver+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_jmsActivationSpec.adoc
+++ b/src/main/content/config/rwlp_config_jmsActivationSpec.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +jmsActivationSpec - JMS Activation Specification+ (+jmsActivationSpec+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_jmsConnectionFactory.adoc
+++ b/src/main/content/config/rwlp_config_jmsConnectionFactory.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +jmsConnectionFactory - JMS Connection Factory+ (+jmsConnectionFactory+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_jmsDestination.adoc
+++ b/src/main/content/config/rwlp_config_jmsDestination.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +jmsDestination - JMS Destination+ (+jmsDestination+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_jmsQueue.adoc
+++ b/src/main/content/config/rwlp_config_jmsQueue.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +jmsQueue - JMS Queue+ (+jmsQueue+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_jmsQueueConnectionFactory.adoc
+++ b/src/main/content/config/rwlp_config_jmsQueueConnectionFactory.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +jmsQueueConnectionFactory - JMS Queue Connection Factory+ (+jmsQueueConnectionFactory+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_jmsTopic.adoc
+++ b/src/main/content/config/rwlp_config_jmsTopic.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +jmsTopic - JMS Topic+ (+jmsTopic+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_jmsTopicConnectionFactory.adoc
+++ b/src/main/content/config/rwlp_config_jmsTopicConnectionFactory.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +jmsTopicConnectionFactory - JMS Topic Connection Factory+ (+jmsTopicConnectionFactory+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_jndiEntry.adoc
+++ b/src/main/content/config/rwlp_config_jndiEntry.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +jndiEntry - JNDI Entry+ (+jndiEntry+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_jndiObjectFactory.adoc
+++ b/src/main/content/config/rwlp_config_jndiObjectFactory.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +jndiObjectFactory - JNDI Object Factory+ (+jndiObjectFactory+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_jndiReferenceEntry.adoc
+++ b/src/main/content/config/rwlp_config_jndiReferenceEntry.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +jndiReferenceEntry - JNDI Reference Entry+ (+jndiReferenceEntry+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_jndiURLEntry.adoc
+++ b/src/main/content/config/rwlp_config_jndiURLEntry.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +jndiURLEntry - JNDI URL Entry+ (+jndiURLEntry+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_jpa.adoc
+++ b/src/main/content/config/rwlp_config_jpa.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +jpa - JPA Container+ (+jpa+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_jspEngine.adoc
+++ b/src/main/content/config/rwlp_config_jspEngine.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +jspEngine - JSP Engine+ (+jspEngine+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_jwtBuilder.adoc
+++ b/src/main/content/config/rwlp_config_jwtBuilder.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +jwtBuilder - JWT Builder+ (+jwtBuilder+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_jwtConsumer.adoc
+++ b/src/main/content/config/rwlp_config_jwtConsumer.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +jwtConsumer - JWT Consumer+ (+jwtConsumer+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_jwtSso.adoc
+++ b/src/main/content/config/rwlp_config_jwtSso.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +jwtSso - JWT SSO+ (+jwtSso+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_keyStore.adoc
+++ b/src/main/content/config/rwlp_config_keyStore.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +keyStore - Keystore+ (+keyStore+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_ldapRegistry.adoc
+++ b/src/main/content/config/rwlp_config_ldapRegistry.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +ldapRegistry - LDAP User Registry+ (+ldapRegistry+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_library.adoc
+++ b/src/main/content/config/rwlp_config_library.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +library - Shared Library+ (+library+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_logging.adoc
+++ b/src/main/content/config/rwlp_config_logging.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +logging - Logging+ (+logging+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_ltpa.adoc
+++ b/src/main/content/config/rwlp_config_ltpa.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +ltpa - LTPA Token+ (+ltpa+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_mailSession.adoc
+++ b/src/main/content/config/rwlp_config_mailSession.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +mailSession - Mail Session Object+ (+mailSession+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_managedExecutorService.adoc
+++ b/src/main/content/config/rwlp_config_managedExecutorService.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +managedExecutorService - Managed Executor+ (+managedExecutorService+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_managedScheduledExecutorService.adoc
+++ b/src/main/content/config/rwlp_config_managedScheduledExecutorService.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +managedScheduledExecutorService - Managed Scheduled Executor+ (+managedScheduledExecutorService+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_managedThreadFactory.adoc
+++ b/src/main/content/config/rwlp_config_managedThreadFactory.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +managedThreadFactory - Managed Thread Factory+ (+managedThreadFactory+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_messagingEngine.adoc
+++ b/src/main/content/config/rwlp_config_messagingEngine.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +messagingEngine - Messaging Engine+ (+messagingEngine+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_mimeTypes.adoc
+++ b/src/main/content/config/rwlp_config_mimeTypes.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +mimeTypes - Default Mime Types+ (+mimeTypes+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_mongo.adoc
+++ b/src/main/content/config/rwlp_config_mongo.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +mongo - Mongo+ (+mongo+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_mongoDB.adoc
+++ b/src/main/content/config/rwlp_config_mongoDB.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +mongoDB - MongoDB DB+ (+mongoDB+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_monitor.adoc
+++ b/src/main/content/config/rwlp_config_monitor.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +monitor - Monitor+ (+monitor+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_mpJwt.adoc
+++ b/src/main/content/config/rwlp_config_mpJwt.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +mpJwt - MicroProfile JWT+ (+mpJwt+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_netscapeLdapFilterProperties.adoc
+++ b/src/main/content/config/rwlp_config_netscapeLdapFilterProperties.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +netscapeLdapFilterProperties - Netscape Directory Server LDAP Filters+ (+netscapeLdapFilterProperties+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_orb.adoc
+++ b/src/main/content/config/rwlp_config_orb.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +orb - Object Request Broker (ORB)+ (+orb+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_persistentExecutor.adoc
+++ b/src/main/content/config/rwlp_config_persistentExecutor.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +persistentExecutor - Persistent Scheduled Executor+ (+persistentExecutor+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_pluginConfiguration.adoc
+++ b/src/main/content/config/rwlp_config_pluginConfiguration.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +pluginConfiguration - Web Server Plugin+ (+pluginConfiguration+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_quickStartSecurity.adoc
+++ b/src/main/content/config/rwlp_config_quickStartSecurity.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +quickStartSecurity - Quick Start Security+ (+quickStartSecurity+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_remoteFileAccess.adoc
+++ b/src/main/content/config/rwlp_config_remoteFileAccess.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +remoteFileAccess - Remote File Access+ (+remoteFileAccess+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_resourceAdapter.adoc
+++ b/src/main/content/config/rwlp_config_resourceAdapter.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +resourceAdapter - Resource Adapter+ (+resourceAdapter+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_securewayLdapFilterProperties.adoc
+++ b/src/main/content/config/rwlp_config_securewayLdapFilterProperties.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +securewayLdapFilterProperties - IBM SecureWay Directory Server LDAP Filters+ (+securewayLdapFilterProperties+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_springBootApplication.adoc
+++ b/src/main/content/config/rwlp_config_springBootApplication.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +springBootApplication - Spring Boot Application+ (+springBootApplication+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_ssl.adoc
+++ b/src/main/content/config/rwlp_config_ssl.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +ssl - SSL Repertoire+ (+ssl+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_sslDefault.adoc
+++ b/src/main/content/config/rwlp_config_sslDefault.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +sslDefault - SSL Default Repertoire+ (+sslDefault+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_sslOptions.adoc
+++ b/src/main/content/config/rwlp_config_sslOptions.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +sslOptions - SSL Options+ (+sslOptions+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_tcpOptions.adoc
+++ b/src/main/content/config/rwlp_config_tcpOptions.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +tcpOptions - TCP Options+ (+tcpOptions+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_transaction.adoc
+++ b/src/main/content/config/rwlp_config_transaction.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +transaction - Transaction Manager+ (+transaction+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_trustAssociation.adoc
+++ b/src/main/content/config/rwlp_config_trustAssociation.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +trustAssociation - Trust Association Interceptor+ (+trustAssociation+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_variable.adoc
+++ b/src/main/content/config/rwlp_config_variable.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +variable - Variable Declaration+ (+variable+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_virtualHost.adoc
+++ b/src/main/content/config/rwlp_config_virtualHost.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +virtualHost - Virtual Host+ (+virtualHost+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_wasJmsEndpoint.adoc
+++ b/src/main/content/config/rwlp_config_wasJmsEndpoint.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +wasJmsEndpoint - WAS JMS Endpoint+ (+wasJmsEndpoint+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_wasJmsOutbound.adoc
+++ b/src/main/content/config/rwlp_config_wasJmsOutbound.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +wasJmsOutbound - WAS JMS Outbound+ (+wasJmsOutbound+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_webAppSecurity.adoc
+++ b/src/main/content/config/rwlp_config_webAppSecurity.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +webAppSecurity - Web Container Application Security+ (+webAppSecurity+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_webApplication.adoc
+++ b/src/main/content/config/rwlp_config_webApplication.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +webApplication - Web Application+ (+webApplication+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_webContainer.adoc
+++ b/src/main/content/config/rwlp_config_webContainer.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +webContainer - Web Container+ (+webContainer+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_webTarget.adoc
+++ b/src/main/content/config/rwlp_config_webTarget.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +webTarget - JAX-RS Client Properties+ (+webTarget+)
 :stylesheet: ../config.css
 :linkcss: 

--- a/src/main/content/config/rwlp_config_wsocOutbound.adoc
+++ b/src/main/content/config/rwlp_config_wsocOutbound.adoc
@@ -1,4 +1,3 @@
-:page-layout: config
 = +wsocOutbound - WAS WebSocket Outbound+ (+wsocOutbound+)
 :stylesheet: ../config.css
 :linkcss: 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
- Allow more responsive table in mobile view
- Hide footer when showing the config doc content in mobile view
- remove page-layout attribute and enable .sh to add the page-layout attribute without extra spacing in front of the attribute.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
