### PR TITLE
Remove unneeded header and related guide section css from iguide.css

### DIFF
--- a/src/main/content/_assets/css/iguide.css
+++ b/src/main/content/_assets/css/iguide.css
@@ -11,20 +11,11 @@
 
 /* GUIDE CONTENT */
 
-#guide_content h1 {
-    font-size: 28px;
-    color: #24253a;
-}
-
 #guide_content h2 {
     font-size: 20px;
     color: #24253a;
     margin-top: 24px;
     margin-bottom: 8px;
-}
-
-#guide_content #related_guides_header h2 {
-    margin-bottom: 32px;
 }
 
 #guide_content h3 {
@@ -34,18 +25,6 @@
     padding-top: 10px;
     margin-top: 20px;
     margin-bottom: 8px;
-}
-
-#guide_content #relateGuidesContent h3 {
-    font-size: 20px;
-    font-weight: 400;
-    margin-top: 0px;
-    margin-bottom: 14px;
-    padding-top: 0px;
-}
-#guide_content #relateGuidesContent p {
-    line-height: 1.4;
-    margin: 0;
 }
 
 #guide_content h4 {
@@ -102,26 +81,6 @@
 
 /* GUIDE PAGE LAYOUT */
 
-#background_container {
-    padding-top: 50px;
-    min-height: 600px;
-    background-size: 100% calc(100% - 200px);
-    background-repeat: no-repeat;
-    margin-bottom: 100px;
-}
-
-#guide_column {
-    background-color: white;
-    color: #24253a;
-    padding-top: 45px;
-    padding-bottom: 90px;
-    padding-left: 50px;
-    padding-right: 50px;
-    -webkit-box-shadow: 0px 5px 11px -3px rgba(0,0,0,0.27);
-    -moz-box-shadow: 0px 5px 11px -3px rgba(0,0,0,0.27);
-    box-shadow: 0px 5px 11px -3px rgba(0,0,0,0.27);
-}
-
 #toc_title {
     margin-top: 0;
     margin-bottom: 22px;
@@ -161,18 +120,6 @@
 
 #tags_container a:hover {
     color: #eaf0ff;
-}
-
-#guide_title {
-    margin-bottom: 32px;
-}
-
-#duration_container {
-    margin-bottom: 44px;
-}
-
-#guide_duration {
-    margin-left: 15px;
 }
 
 #copied_to_clipboard_confirmation {


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Removed CSS from iguide.css that we no longer need for the guide header and the related guides pages since we will be using the CSS defined for the multipane layout that is common for both the static and interactive guides.

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
