### PR TITLE
Remove more duplicated CSS from iguide.css

### DIFF
--- a/src/main/content/_assets/css/iguide.css
+++ b/src/main/content/_assets/css/iguide.css
@@ -11,73 +11,13 @@
 
 /* GUIDE CONTENT */
 
-#guide_content h2 {
-    font-size: 20px;
-    color: #24253a;
-    margin-top: 24px;
-    margin-bottom: 8px;
-}
-
 #guide_content h3 {
-    font-size: 16px;
-    color: #24253a;
-    font-weight: 500;
-    padding-top: 10px;
-    margin-top: 20px;
     margin-bottom: 8px;
 }
 
 #guide_content h4 {
-    font-size: 16px;
-    color: #6f7878;
-    font-weight: 500;
-    padding-top: 10px;
-    margin-top: 20px;
     margin-bottom: 8px;
 }
-
-#guide_content p {
-    margin-top: 20px;
-    margin-bottom: 20px;
-    line-height: 26px;
-}
-
-#guide_content a {
-    font-weight: 400;
-    color: #E3700D;
-    /*color: #1b1c34; new color for editor filename */
-    transition: color .2s;
-}
-
-#guide_content a:hover {
-    color: #F4914D;
-    /* color: #5E6B8D; new color for editor filename on hover */
-}
-
-#guide_content code,
-#guide_content pre  {
-    /* Bootstrap override */
-    background-color: #F3F4F7;
-    color: #5e6b8d;
-}
-
-#guide_content code {
-    /* Bootstrap override */
-    word-wrap: break-word;
-}
-
-#guide_content pre {
-    border-radius: 0;
-    border: none;
-    padding: 30px;
-}
-
-#guide_content table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
-#guide_content table thead, #guide_content table tfoot{background:#f7f8f7;font-weight:bold}
-#guide_content table thead tr th,#guide_content table thead tr td,#guide_content table tfoot tr th,#guide_content table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
-#guide_content table tr th,#guide_content table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-#guide_content table tr.even,#guide_content table tr.alt,#guide_content table tr:nth-of-type(even){background:#f8f8f7}
-#guide_content table thead tr th,#guide_content table tfoot tr th,#guide_content table tbody tr td,#guide_content table tr td,#guide_content table tfoot tr td{display:table-cell;line-height:1.6}
 
 /* GUIDE PAGE LAYOUT */
 
@@ -106,79 +46,4 @@
 
 #toc_container a:hover {
     color: #f7fbd2;
-}
-
-#tag_title {
-    margin-bottom: 22px;
-}
-
-#tags_container a {
-    color: #c8d6fb;
-    margin-right: 15px;
-    line-height: 30px;
-}
-
-#tags_container a:hover {
-    color: #eaf0ff;
-}
-
-#copied_to_clipboard_confirmation {
-    position: absolute;
-    font-size: 11px;
-    color: #5e6b8d;
-}
-
-#copy_to_clipboard {
-    position: absolute;
-    display: block;
-    background-color: #eeeff3;
-    background-image: url('/img/guide_copy_button.svg');
-    background-repeat: no-repeat;
-    background-position: center center;
-    height: 63px;
-    width: 58px;
-}
-
-#copy_to_clipboard:hover {
-    border: solid 1px #b2bbd1;
-}
-
-#copy_to_clipboard:active {
-    border: solid 1px #5e6b8d;
-}
-
-@media (max-width: 1199px) {
-    .guide_item {
-        width: 100%;
-    }
-}
-
-@media (max-width: 991px) {
-    
-    #guide_column {
-        padding-top: 30px;
-        padding-bottom: 70px;
-        padding-left: 30px;
-        padding-right: 30px;
-    }
-}
-    
-@media (max-width: 767px) {
-
-    #background_container {
-        padding-top: 40px;
-        margin-bottom: 0;
-    }
-        
-    #guide_column {
-        padding-top: 10px;
-        padding-bottom: 60px;
-        padding-left: 15px;
-        padding-right: 15px;
-        box-shadow: none;
-    }
-    
-    #tags_container {
-        margin-bottom: 30px;
-    }
 }

--- a/src/main/content/_assets/css/table-of-contents.css
+++ b/src/main/content/_assets/css/table-of-contents.css
@@ -176,12 +176,15 @@
 
 #tags_container {
     margin-left: 27px;
+    padding-right: 19px;
 }
 
 #tags_container a {
     color: #4f660a;
     margin-right: 15px;
     line-height: 30px;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
 }
 
 #tags_container a:hover {


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Remove more unneeded CSS from iguide.css.   These items were defined in both iguide.css and guide-multipane.css or table-of-contents.css.   Since we are going to a common multipane guide design for both static and interactive guides, there is no need to have the css duplicated in both files.  

Also added a padding-right to the #tags_container to prevent overflow of some of the Circuit Breaker guide tags.  This padding is what the TOC entries above had.

#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [x] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
