### PR TITLE
Return hash code to guide-multipane since iguides need their own hash code

### DIFF
--- a/src/main/content/_assets/js/common-multipane.js
+++ b/src/main/content/_assets/js/common-multipane.js
@@ -149,6 +149,11 @@ function createEndOfGuideContent(){
     $("#toc_container a[href='#related-links']").parent().remove(); // Remove from TOC.
 }
 
+// Adjust the window for the sticky header when requesting a specific section.
+function shiftWindow() {
+    scrollBy(0, -100);
+}
+
 
 $(document).ready(function() {
     function handleDownArrow() {
@@ -174,23 +179,6 @@ $(document).ready(function() {
         });
     }
 
-    // Adjust the window for the sticky header when requesting a specific section.
-    function shiftWindow() {
-        scrollBy(0, -100);
-    }
-
-    if (location.hash){
-        shiftWindow();
-        handleFloatingTableOfContent();
-        var id = location.hash.substring(1);
-        updateTOCHighlighting(id);
-    }
-
-    window.addEventListener("hashchange", function(){
-        shiftWindow();
-        var id = location.hash.substring(1);
-        updateTOCHighlighting(id);
-    });
 
     $(window).on('resize', function(){
         handleFloatingTableOfContent(); // Handle table of content view changes.

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -270,6 +270,19 @@ $(document).ready(function() {
         handleSectionSnapping(event);
     });
 
+    if (location.hash){
+        shiftWindow();
+        handleFloatingTableOfContent();
+        var id = location.hash.substring(1);
+        updateTOCHighlighting(id);
+    }
+
+    window.addEventListener("hashchange", function(){
+        shiftWindow();
+        var id = location.hash.substring(1);
+        updateTOCHighlighting(id);
+    });
+
     $(window).on('load', function(){
         if(window.location.hash === ""){
             handleGithubPopup();            


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Simply moving the code related to hash code changes from common-multipane.js back to guide-multipane.js.  Do this because
1.  The TOC is not yet built for iteractive guides when this code executes because the guide steps have not been read in at this point.  Therefore, this code is like a no-op for interative guides and should be moved to guide-multipane.js instead.
2. Interactive guides need their own hash change code because of the way the sections within a step are displayed and managed.

Had to leave the shiftWindow() method in common-multipane.js to make it accessible by the interactive guide code.

#### Were the changes tested on
- [x ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x ] Chrome (Desktop)
- [x ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
