### PR TITLE
Guide page redesign - remove essentials

### DIFF
--- a/src/main/content/guides.html
+++ b/src/main/content/guides.html
@@ -64,7 +64,7 @@ permalink: /guides/
     <h2 id="guide_counter_title" class="guide_category_title"></h2>
     <div id="microprofile_header" class="guide_category_header">
         <h2 class="guide_category_title">MicroProfile and Open Liberty</h2>
-        <p id="microprofile_subtitle"><b>{{microprofile-numGuides}} essentials</b> to get you started</p>
+        <p id="microprofile_subtitle"><b>{{microprofile-numGuides}} guides</b></p>
     </div>
     <div class="row">
         {% for guide in microprofile-guides %}


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

Change the essentials title to just the total number of guides in the section.

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
