### PR TITLE
Fix Yaml syntax highlighting for start and end delimiters

### DIFF
--- a/src/main/content/_assets/css/coderay-custom.css
+++ b/src/main/content/_assets/css/coderay-custom.css
@@ -133,6 +133,8 @@ table.CodeRay td { padding: 2px 4px; vertical-align: top; }
 .CodeRay .delete { background: hsla(0,100%,50%,0.12) }
 .CodeRay .change { color: #bbf; background: #007 }
 .CodeRay .head { color: #f8f; background: #505 }
+.CodeRay code[data-lang="yaml"] .head { color: inherit; background: inherit }
+
 .CodeRay .head .filename { color: white; }
 
 .CodeRay .delete .eyecatcher { background-color: hsla(0,100%,50%,0.2); border: 1px solid hsla(0,100%,45%,0.5); margin: -1px; border-bottom: none; border-top-left-radius: 5px; border-top-right-radius: 5px; }
@@ -142,3 +144,4 @@ table.CodeRay td { padding: 2px 4px; vertical-align: top; }
 .CodeRay .delete .delete { color: #c00; background:transparent; font-weight:500 }
 .CodeRay .change .change { color: #88f }
 .CodeRay .head .head { color: #f4f }
+.CodeRay code[data-lang="yaml"] .head .head { color: inherit }


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Valid syntax in Yaml files were highlighted pink like an error.
Old:
![image](https://user-images.githubusercontent.com/6392944/42954563-abbe14c4-8b42-11e8-9c60-b6ad4af33822.png)

New:
![image](https://user-images.githubusercontent.com/6392944/42954502-88dc2d88-8b42-11e8-80a5-31eb92cbf59e.png)

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
