### PR TITLE
Fix extra blue on the code_command arrows

### DIFF
--- a/src/main/content/_assets/css/guide-multipane.css
+++ b/src/main/content/_assets/css/guide-multipane.css
@@ -185,11 +185,11 @@ header {
 }
 #guide_content .code_command > .content:before {
     top: 0px;
-    background: linear-gradient(to top right, #F1F4FE 49%, #c8d6fb calc(49% + 1px), transparent calc(49% + 2px));
+    background: linear-gradient(to top right, #F1F4FE 48%, #c8d6fb calc(48% + 1px), transparent calc(48% + 2px));
 }
 #guide_content .code_command > .content:after {
     bottom: 0px;
-    background: linear-gradient(to bottom right, #F1F4FE 49%, #c8d6fb calc(49% + 1px), transparent calc(49% + 2px));
+    background: linear-gradient(to bottom right, #F1F4FE 48%, #c8d6fb calc(48% + 1px), transparent calc(48% + 2px));
 }
 /* End of pointed div */
 

--- a/src/main/content/_assets/css/guide-multipane.css
+++ b/src/main/content/_assets/css/guide-multipane.css
@@ -185,11 +185,11 @@ header {
 }
 #guide_content .code_command > .content:before {
     top: 0px;
-    background: linear-gradient(to top right, #F1F4FE 50%, transparent 51%), linear-gradient(230deg, transparent 100%, #c8d6fb 0);
+    background: linear-gradient(to top right, #F1F4FE 48%, #c8d6fb 50%, transparent 51%);
 }
 #guide_content .code_command > .content:after {
     bottom: 0px;
-    background: linear-gradient(to bottom right, #F1F4FE 50%, transparent 51%), linear-gradient(310deg, transparent 100%, #c8d6fb 0);
+    background: linear-gradient(to bottom right, #F1F4FE 48%, #c8d6fb 50%, transparent 51%);
 }
 /* End of pointed div */
 

--- a/src/main/content/_assets/css/guide-multipane.css
+++ b/src/main/content/_assets/css/guide-multipane.css
@@ -185,11 +185,11 @@ header {
 }
 #guide_content .code_command > .content:before {
     top: 0px;
-    background: linear-gradient(to top right, #F1F4FE 50%, transparent 51%), linear-gradient(230deg, transparent 29.5px, #c8d6fb 0);
+    background: linear-gradient(to top right, #F1F4FE 50%, transparent 51%), linear-gradient(230deg, transparent 100%, #c8d6fb 0);
 }
 #guide_content .code_command > .content:after {
     bottom: 0px;
-    background: linear-gradient(to bottom right, #F1F4FE 50%, transparent 51%), linear-gradient(310deg, transparent 29.5px, #c8d6fb 0);
+    background: linear-gradient(to bottom right, #F1F4FE 50%, transparent 51%), linear-gradient(310deg, transparent 100%, #c8d6fb 0);
 }
 /* End of pointed div */
 

--- a/src/main/content/_assets/css/guide-multipane.css
+++ b/src/main/content/_assets/css/guide-multipane.css
@@ -185,11 +185,11 @@ header {
 }
 #guide_content .code_command > .content:before {
     top: 0px;
-    background: linear-gradient(to top right, #F1F4FE 48%, #c8d6fb 50%, transparent 51%);
+    background: linear-gradient(to top right, #F1F4FE 49%, #c8d6fb calc(49% + 1px), transparent calc(49% + 2px));
 }
 #guide_content .code_command > .content:after {
     bottom: 0px;
-    background: linear-gradient(to bottom right, #F1F4FE 48%, #c8d6fb 50%, transparent 51%);
+    background: linear-gradient(to bottom right, #F1F4FE 49%, #c8d6fb calc(49% + 1px), transparent calc(49% + 2px));
 }
 /* End of pointed div */
 

--- a/src/main/content/_assets/css/table-of-contents.css
+++ b/src/main/content/_assets/css/table-of-contents.css
@@ -135,7 +135,7 @@
     word-wrap: break-word;
 }
 
-#toc_container > .sectlevel1 > li:hover {
+#toc_container > .sectlevel1 > li:not(.liSelected):hover {
     border-left: 8px solid #fdf2ea;
     font-weight: 500;
 }


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Fixed the end of the code_command arrows from getting cut off.
Old:
![image](https://user-images.githubusercontent.com/6392944/43158003-2582da06-8f44-11e8-8d25-e2b343769953.png)

New:
![image](https://user-images.githubusercontent.com/6392944/43157945-05c090fa-8f44-11e8-9f1d-d78c8f894ca8.png)

#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
