### PR TITLE
Fix resizing browser bug with mobile accordion

### DIFF
--- a/src/main/content/_assets/js/common-multipane.js
+++ b/src/main/content/_assets/js/common-multipane.js
@@ -188,6 +188,7 @@ $(document).ready(function() {
 
     $(window).on('resize', function(){
         handleFloatingTableOfContent(); // Handle table of content view changes.
+        handleFloatingTOCAccordion();
         handleDownArrow();
         resizeGuideSections();
         handleFloatingCodeColumn();
@@ -196,6 +197,7 @@ $(document).ready(function() {
     $(window).on('scroll', function(event) {
         handleDownArrow();
         handleFloatingTableOfContent(); 
+        handleFloatingTOCAccordion();
         handleFloatingCodeColumn();
     });
 

--- a/src/main/content/_assets/js/toc-multipane.js
+++ b/src/main/content/_assets/js/toc-multipane.js
@@ -62,6 +62,31 @@ function handleTOCScrolling() {
     }
 }
 
+function handleFloatingTOCAccordion() {
+    var accordion = $('#mobile_toc_accordion_container');
+    var enableFloatingAccordion = function(){
+        accordion.addClass('floating_accordion');
+        $('.navbar').css('display', 'none');
+    };
+    var disableFloatingTOCAccordion = function(){
+        accordion.removeClass('floating_accordion'); 
+        $('.navbar').css('display', 'block');
+    };
+    if(inSingleColumnView()){
+        var isMobile = inMobile();
+        var transitionPoint = isMobile ? 428 : 400;        
+        var isPositionFixed = (accordion.css('position') === 'fixed');
+        if ($(this).scrollTop() > transitionPoint && !isPositionFixed) { 
+            enableFloatingAccordion();
+        } else if ($(this).scrollTop() < transitionPoint && isPositionFixed) {
+            disableFloatingTOCAccordion();
+        }
+    }
+    else{
+        disableFloatingTOCAccordion();
+    }
+}
+
 
 $(document).ready(function() {
     
@@ -109,26 +134,5 @@ $(document).ready(function() {
         if(inSingleColumnView()){
             $("#mobile_close_container").trigger('click');
         }
-    });
-
-    function handleFloatingTOCAccordion() {
-        if(inSingleColumnView()){
-            var isMobile = inMobile();
-            var transitionPoint = isMobile ? 428 : 400;
-            var accordion = $('#mobile_toc_accordion_container');
-            var isPositionFixed = (accordion.css('position') === 'fixed');
-            if ($(this).scrollTop() > transitionPoint && !isPositionFixed) { 
-                accordion.addClass('floating_accordion');
-                $('.navbar').css('display', 'none');
-            } else if ($(this).scrollTop() < transitionPoint && isPositionFixed) {
-                accordion.removeClass('floating_accordion'); 
-                $('.navbar').css('display', 'block');
-            }
-        }
-    }
-
-    $(window).scroll(function(){
-        handleFloatingTOCAccordion();
-    });
-
+    });    
 });


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Fixed the doc_header from dissapearing when resizing the browser while the mobile table of contents was stickied to the top of the page.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
