### PR TITLE
Fix scrolling up and down in the code column when there is a scroll bar

### DIFF
--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -133,15 +133,15 @@ $(document).ready(function() {
     // Handle scrolling in the code column.
     // Prevents the default scroll behavior which would scroll the whole browser.
     // The code column scrolling is independent of the guide column.
-    $('#code_column').on('wheel mousewheel DOMMouseScroll', function(event){
+    $('.code_column').on('wheel mousewheel DOMMouseScroll', function(event){
         $(this).stop(); // Stop animations taking place with this code section.
 
         var event0 = event.originalEvent;
         var dir = (event0.deltaY) < 0 ? 'up' : 'down';        
-        var hasVerticalScrollbar = false;     
+        var hasVerticalScrollbar = false;
 
         // Check if element is scrollable.
-        if(this.scrollTop > 0 || this.scrollHeight > document.documentElement.clientHeight){
+        if(this.scrollTop > 0 || this.offsetHeight > this.parentElement.offsetHeight){
             hasVerticalScrollbar = true;
         }
 
@@ -157,7 +157,7 @@ $(document).ready(function() {
             if(delta === 1 || delta === -1){
                 delta *= 150;
             }
-            this.scrollTop -= delta;
+            $("#code_column").get(0).scrollTop -= delta;
             handleGithubPopup(true);
             event.preventDefault();  
         }            

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -130,6 +130,16 @@ $(document).ready(function() {
     // Hide all code blocks except the first
     $('#code_column .code_column:not(:first)').hide();
 
+    // Prevent scrolling the page when scrolling inside of the code panel, but not one of the code blocks.
+    $('#code_column').on('wheel mousewheel DOMMouseScroll', function(event){
+        event.stopPropagation();
+        var target = $(event.target);
+        if(!(target.is('.code_column') || target.parents('.code_column').length > 0)){   
+            // Prevent scrolling the page when scrolling outside of lines of code but still inside of the code column.
+            event.preventDefault();
+        } 
+    });
+
     // Handle scrolling in the code column.
     // Prevents the default scroll behavior which would scroll the whole browser.
     // The code column scrolling is independent of the guide column.
@@ -139,6 +149,7 @@ $(document).ready(function() {
         var event0 = event.originalEvent;
         var dir = (event0.deltaY) < 0 ? 'up' : 'down';        
         var hasVerticalScrollbar = false;
+        var codeColumn = $("#code_column").get(0);
 
         // Check if element is scrollable.
         if(this.scrollTop > 0 || this.offsetHeight > this.parentElement.offsetHeight){
@@ -151,13 +162,13 @@ $(document).ready(function() {
             event.preventDefault();
         }
         // If the code column is at the top and the browser is scrolled down, the element has no scrollTop and does not respond to changing its scrollTop.
-        else if(!(dir == 'down' && this.scrollTop === 0)){
+        else if(!(dir == 'down' && codeColumn.scrollTop === 0)){
             var delta = event0.wheelDelta || -event0.detail || -event0.deltaY;
             // Firefox's scroll value is always 1 so multiply by 150 to scroll faster.
             if(delta === 1 || delta === -1){
                 delta *= 150;
             }
-            $("#code_column").get(0).scrollTop -= delta;
+            codeColumn.scrollTop -= delta;
             handleGithubPopup(true);
             event.preventDefault();  
         }            

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -144,6 +144,9 @@ $(document).ready(function() {
     // Prevents the default scroll behavior which would scroll the whole browser.
     // The code column scrolling is independent of the guide column.
     $('.code_column').on('wheel mousewheel DOMMouseScroll', function(event){
+        if(inSingleColumnView()){
+            return;
+        }
         $(this).stop(); // Stop animations taking place with this code section.
 
         var event0 = event.originalEvent;


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
When there's a scrollbar in the code pane, sometimes it wouldn't let you scroll because it was using the wrong element's heights/offsets to calculate if there is a scrollbar or not. This fixes that problem.

The code column has its own scroll listener because we do not want scrolling in the code column to scroll the entire page.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
