### PR TITLE
Change the github popup to stay until the user scrolls past the what …

### DIFF
--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -241,7 +241,10 @@ $(document).ready(function() {
                 }
                 atTop = $("#code_column").scrollTop() === 0;
             } else {
-                atTop = $(window).scrollTop() === 0;
+                // Check if the "What You'll Learn" section is scrolled past yet.
+                var whatYoullLearnTop = $("#what-youll-learn, #what-you-ll-learn")[0].getBoundingClientRect().top;
+                var navHeight = $('.navbar').height();
+                atTop = (whatYoullLearnTop - navHeight) > 0;
             }
             if(atTop){
                 githubPopup.fadeIn();


### PR DESCRIPTION
…youll learn section

#### What was fixed?  (Issue # or description of fix)
See commit message
#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
