### PR TITLE
Remove the need to move the guide title into the attribution statemen…

### DIFF
--- a/src/main/content/_assets/js/common-multipane.js
+++ b/src/main/content/_assets/js/common-multipane.js
@@ -140,9 +140,9 @@ function createEndOfGuideContent(){
     $("#toc_container a[href='#great-work-you-re-done'], #toc_container a[href='#great-work-youre-done']").parent().remove(); // Remove from TOC.
 
     // Concatenate the guide title and guide attribution license and append it to the end of guide.
-    var guideAttribution = $("#guide-attribution").siblings().find('p').text();
-    if(guideAttribution){
-        $("#guide_attribution").text(guideAttribution);
+    var guideAttributionText = $("#guide-attribution").siblings().find('p').text();
+    if(guideAttributionText){
+        $("#guide_attribution").text(guideAttributionText);
         $("#guide-attribution").parent().remove();
         $("#toc_container a[href='#guide-attribution']").parent().remove(); // Remove from TOC.
     }

--- a/src/main/content/_assets/js/common-multipane.js
+++ b/src/main/content/_assets/js/common-multipane.js
@@ -142,9 +142,7 @@ function createEndOfGuideContent(){
     // Concatenate the guide title and guide attribution license and append it to the end of guide.
     var guideAttribution = $("#guide-attribution").siblings().find('p').text();
     if(guideAttribution){
-        var guideTitle = $("#guide_title").text();
-        var concatenatedAttribution = guideTitle + " is licensed under " + guideAttribution;
-        $("#guide_attribution").text(concatenatedAttribution);
+        $("#guide_attribution").text(guideAttribution);
         $("#guide-attribution").parent().remove();
         $("#toc_container a[href='#guide-attribution']").parent().remove(); // Remove from TOC.
     }


### PR DESCRIPTION
…t because asciidoc can natively support it

#### What was fixed?  (Issue # or description of fix)
Remove the need to copy over the guide's title into the attribution statement because we can natively support it using "{doctitle} is licensed under CC BY-ND 4.0 " in the attribution.adoc included inside the guide by specifying include::https://raw.githubusercontent.com/OpenLiberty/guides-common/multipane/attribution.adoc[subs="attributes"], allowing asciidoc to substitute the document title attribute into the attribution.

https://github.com/OpenLiberty/guides-common/blob/multipane/attribution.adoc has already been updated to use the native asciidoc title of the document.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
