### PR TITLE
Increase curl timeout to 10 min from 5

### DIFF
--- a/.travis/cf-blue-green.sh
+++ b/.travis/cf-blue-green.sh
@@ -26,7 +26,7 @@ DOMAIN=`echo $ROUTE | sed -e "s,$BLUE\.,,"`
 
 # ensure it starts
 echo "Checking status of new instance https://${GREEN}.${DOMAIN}..."
-curl --fail -s -I "https://${GREEN}.${DOMAIN}" --connect-timeout 240 --max-time 300
+curl --fail -s -I "https://${GREEN}.${DOMAIN}" --connect-timeout 240 --max-time 600
 
 # add the GREEN application to each BLUE route to be load-balanced
 echo "Adding main route ($BLUE.$ROUTE) to new app ($GREEN)..."


### PR DESCRIPTION
Travis builds keep timing out on the curl command. Increasing the timeout.