### PR TITLE
Snippet highlighting

### DIFF
--- a/src/main/content/_assets/css/guide-multipane.css
+++ b/src/main/content/_assets/css/guide-multipane.css
@@ -175,6 +175,7 @@ header {
 #guide_content .hotspot pre:hover {
     color: #24253A;
     background-color: #C7CCD9;
+    cursor: pointer;
 }
 
 #guide_content .code_command pre,  #guide_content .code_command code {
@@ -578,6 +579,10 @@ header {
 
     .guide_column_code_snippet {
         display: block;
+    }
+
+    #guide_content .hotspot pre {
+        display: none; /* Hide the hotspot snippets in mobile since there is no right pane */
     }
 
     #guide_content .code_command > .content {

--- a/src/main/content/_assets/css/guide-multipane.css
+++ b/src/main/content/_assets/css/guide-multipane.css
@@ -157,11 +157,11 @@ header {
     background-color: transparent;
 }
 
-.hotspot {
+.hotspot:not(.code_command) {
     display: inline-block;
 }
 
-#guide_content .hotspot pre {
+#guide_content .hotspot:not(.code_command) pre {
     font-family:Courier;
     font-size:14px;
     padding: 5px;
@@ -176,6 +176,14 @@ header {
     color: #24253A;
     background-color: #C7CCD9;
     cursor: pointer;
+}
+
+#guide_content .code_command.hotspot:hover > .content:before {
+    background: linear-gradient(to top right, #C7CCD9 48%, #c8d6fb calc(48% + 1px), transparent calc(48% + 2px));
+}
+
+#guide_content .code_command.hotspot:hover > .content:after{
+    background: linear-gradient(to bottom right, #C7CCD9 48%, #c8d6fb calc(48% + 1px), transparent calc(48% + 2px));
 }
 
 #guide_content .code_command pre,  #guide_content .code_command code {
@@ -581,7 +589,7 @@ header {
         display: block;
     }
 
-    #guide_content .hotspot pre {
+    #guide_content .hotspot:not(.code_command) pre {
         display: none; /* Hide the hotspot snippets in mobile since there is no right pane */
     }
 

--- a/src/main/content/_assets/css/guide-multipane.css
+++ b/src/main/content/_assets/css/guide-multipane.css
@@ -157,6 +157,26 @@ header {
     background-color: transparent;
 }
 
+.hotspot {
+    display: inline-block;
+}
+
+#guide_content .hotspot pre {
+    font-family:Courier;
+    font-size:14px;
+    padding: 5px;
+    background-color: #F1F4FE;
+    color:#5e6b8d;
+    letter-spacing:0;
+    line-height:24px;
+    text-align:left;
+}
+
+#guide_content .hotspot pre:hover {
+    color: #24253A;
+    background-color: #C7CCD9;
+}
+
 #guide_content .code_command pre,  #guide_content .code_command code {
     background-color: #F1F4FE;
     margin-bottom: 0;

--- a/src/main/content/_assets/css/guide-multipane.css
+++ b/src/main/content/_assets/css/guide-multipane.css
@@ -131,6 +131,7 @@ header {
 .CodeRay .line-numbers {
     display: inline-block;
     visibility: hidden;
+    display: none;
 }
 
 #guide_content pre {

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -20,7 +20,6 @@ $(document).ready(function() {
 
     var guide_sections = [];
     var code_sections = {}; // Map guide sections to code blocks to show on the right column.
-    var hotspot_snippets = {}; // Map of hotspots to code blocks in the code column on the right.
 
     // Move the code snippets to the code column on the right side.
     // Each code section is duplicated to show the full file in the right column and just the snippet of code relevant to the guide in the left column in single column / mobile view.
@@ -159,20 +158,31 @@ $(document).ready(function() {
         metadata.detach();
     });
 
-    // When hovering over a code snippet, highlight the corresponding lines of code in the code section.
+    // When hovering over a code 'hotspot', highlight the correct lines of code in the corresponding code section.
     $('.hotspot').on('hover mouseover', function(event){
-        var section = $(this).parents('.sect1').first();
+        
+        var snippet = $(this);
+        var section = snippet.parents('.sect1').first();
         var header = section.find('h2').get(0);
-        var code_block = code_sections[header.id];
-        highlight_code_range(code_block);
+        var code_section = code_sections[header.id];
+        if(code_section){
+            var code_block = code_section.code;
+            var fromLine = snippet.data('highlight_from_line');
+            var toLine = snippet.data('highlight_to_line');
+            if(code_block && fromLine && toLine){
+                highlight_code_range(code_block, fromLine, toLine);
+            }            
+        }        
     });
 
-    // Remove highlighting in the code section.
+    // When the mouse leaves a code 'hotspot', remove all highlighting in the corresponding code section.
     $('.hotspot').on('mouseleave', function(event){
         var section = $(this).parents('.sect1').first();
         var header = section.find('h2').get(0);
         var code_block = code_sections[header.id];
-        remove_highlighting(code_block);
+        if(code_block && code_block.code){
+            remove_highlighting(code_block.code);
+        }        
     });
    
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Add "hotspots" to the guide text where you can specify what lines of code should be highlighted when hovering over these "hotspots".
Specifying the hotspots will be done via the role="hotspot" and above the code block you specify the lines to highlight such as:

![image](https://user-images.githubusercontent.com/6392944/43531788-2b90056c-9576-11e8-9493-85cbbe8f9715.png)

The need to specify lines of code highlighted initially will be removed.

#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile) not applicable, only in desktop
- [ ] Android (Mobile) not applicable, only in desktop
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [x] Dymanic Accessability Plugin (DAP)
