### PR TITLE
Upgrade lowest version of Sprockets allowed to 3.7.2

### DIFF
--- a/src/main/content/Gemfile.lock
+++ b/src/main/content/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     thread_safe (0.3.6)

--- a/src/main/content/Gemfile.lock
+++ b/src/main/content/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
       jekyll (~> 3.1, >= 3.0)
       pathutil (>= 0.8)
       rack (~> 1.6)
-      sprockets (~> 3.3, < 3.8)
+      sprockets (~> 3.7.2, < 3.8)
     jekyll-feed (0.9.2)
       jekyll (~> 3.3)
     jekyll-redirect-from (0.13.0)


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
