### PR TITLE
Refactoring one

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,30 @@
 			<artifactId>cdi-api</artifactId>
 			<version>1.2</version>
 		</dependency>
+		<!-- BEGIN: Needed to compile and run unit tests -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.5</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jersey.core</groupId>
+			<artifactId>jersey-client</artifactId>
+			<version>2.22.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>javax.json</groupId>
+			<artifactId>javax.json-api</artifactId>
+			<version>1.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish</groupId>
+			<artifactId>javax.json</artifactId>
+			<version>1.1</version>
+		</dependency>
+		<!-- END: Needed to compile and run unit tests -->
 	</dependencies>
 
 	<build>

--- a/src/main/java/io/openliberty/website/BuildsManager.java
+++ b/src/main/java/io/openliberty/website/BuildsManager.java
@@ -34,8 +34,7 @@ public class BuildsManager {
     @Inject private DHEClient dheParser;
 
     private LastUpdate lastUpdate = new LastUpdate();
-    private volatile BuildLists builds = new BuildLists();
-    private volatile LatestReleases latestReleases = new LatestReleases();
+    private volatile BuildData buildData = new BuildData(new LatestReleases(), new BuildLists());
 
     /** Defined default constructor */
     public BuildsManager() {}
@@ -49,21 +48,15 @@ public class BuildsManager {
         if (isBuildUpdateAllowed()) {
             updateBuilds();
         }
-        return new BuildData(latestReleases, builds);
+        return buildData;
     }
 
     public BuildLists getBuilds() {
-        if (isBuildUpdateAllowed()) {
-            updateBuilds();
-        }
-        return builds;
+        return getData().getBuilds();
     }
 
     public LatestReleases getLatestReleases() {
-        if (isBuildUpdateAllowed()) {
-            updateBuilds();
-        }
-        return latestReleases;
+        return getData().getLatestReleases();
     }
 
     public LastUpdate getStatus() {
@@ -91,9 +84,8 @@ public class BuildsManager {
                 all.setToolsReleases(updatedToolsReleases);
                 all.setToolsNightlyBuild(updatedToolsNightlyBuilds);
 
+                buildData = new BuildData(latest, all);
                 lastUpdate.markSuccessfulUpdate();
-                builds = all;
-                latestReleases = latest;
             }
         }
         return getStatus();

--- a/src/main/java/io/openliberty/website/BuildsManager.java
+++ b/src/main/java/io/openliberty/website/BuildsManager.java
@@ -26,6 +26,7 @@ import javax.json.JsonValue;
 import io.openliberty.website.data.LastUpdate;
 import io.openliberty.website.data.LatestReleases;
 import io.openliberty.website.data.BuildLists;
+import io.openliberty.website.data.BuildData;
 import io.openliberty.website.data.BuildInfo;
 
 @ApplicationScoped
@@ -42,6 +43,13 @@ public class BuildsManager {
     /** Allow for unittest injection */
     BuildsManager(DHEClient client) {
         dheParser = client;
+    }
+
+    public BuildData getData() {
+        if (isBuildUpdateAllowed()) {
+            updateBuilds();
+        }
+        return new BuildData(latestReleases, builds);
     }
 
     public BuildLists getBuilds() {

--- a/src/main/java/io/openliberty/website/DHEClient.java
+++ b/src/main/java/io/openliberty/website/DHEClient.java
@@ -1,0 +1,46 @@
+package io.openliberty.website;
+
+import java.io.StringReader;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.client.Invocation.Builder;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+public class DHEClient {
+	private Client client = null;
+
+	public DHEClient() {
+		client = ClientBuilder.newClient();
+	}
+
+	public JsonObject retrieveJSON(String url) {
+		WebTarget target = client.target(url);
+		Builder builder = target.request("application/json");
+		Response response = builder.get();
+		if (response.getStatus() == 200) {
+			if (MediaType.APPLICATION_JSON_TYPE.equals(response.getMediaType())) {
+				return response.readEntity(JsonObject.class);
+			} else if (MediaType.TEXT_PLAIN_TYPE.equals(response.getMediaType())) {
+				String responseBody = response.readEntity(String.class);
+				return Json.createReader(new StringReader(responseBody)).readObject();
+			}
+		}
+		return null;
+	}
+
+	public String retrieveSize(String url) {
+		WebTarget target = client.target(url);
+		Builder builder = target.request();
+		Response response = builder.head();
+		if (response.getStatus() == 200) {
+			return response.getHeaderString(Constants.CONTENT_LENGTH);
+		}
+		return null;
+	}
+
+}

--- a/src/main/java/io/openliberty/website/OpenLibertyEndpoint.java
+++ b/src/main/java/io/openliberty/website/OpenLibertyEndpoint.java
@@ -43,7 +43,7 @@ public class OpenLibertyEndpoint extends Application {
     public JsonObject builds() {
         JsonObjectBuilder data = Json.createObjectBuilder();
         data.add(Constants.LATEST_RELEASES, buildsManager.getLatestReleases());
-        data.add(Constants.BUILDS, buildsManager.getBuilds());
+        data.add(Constants.BUILDS, buildsManager.getBuilds().asJsonObject());
         return data.build();
     }
 

--- a/src/main/java/io/openliberty/website/OpenLibertyEndpoint.java
+++ b/src/main/java/io/openliberty/website/OpenLibertyEndpoint.java
@@ -12,9 +12,7 @@ package io.openliberty.website;
 
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
-import javax.json.Json;
 import javax.json.JsonObject;
-import javax.json.JsonObjectBuilder;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
@@ -41,10 +39,7 @@ public class OpenLibertyEndpoint extends Application {
     @Path("builds/data")
     @Produces({ "application/json" })
     public JsonObject builds() {
-        JsonObjectBuilder data = Json.createObjectBuilder();
-        data.add(Constants.LATEST_RELEASES, buildsManager.getLatestReleases().asJsonObject());
-        data.add(Constants.BUILDS, buildsManager.getBuilds().asJsonObject());
-        return data.build();
+        return buildsManager.getData().asJsonObject();
     }
 
     @GET

--- a/src/main/java/io/openliberty/website/OpenLibertyEndpoint.java
+++ b/src/main/java/io/openliberty/website/OpenLibertyEndpoint.java
@@ -42,7 +42,7 @@ public class OpenLibertyEndpoint extends Application {
     @Produces({ "application/json" })
     public JsonObject builds() {
         JsonObjectBuilder data = Json.createObjectBuilder();
-        data.add(Constants.LATEST_RELEASES, buildsManager.getLatestReleases());
+        data.add(Constants.LATEST_RELEASES, buildsManager.getLatestReleases().asJsonObject());
         data.add(Constants.BUILDS, buildsManager.getBuilds().asJsonObject());
         return data.build();
     }
@@ -51,7 +51,7 @@ public class OpenLibertyEndpoint extends Application {
     @Path("builds/latest")
     @Produces({ "application/json" })
     public JsonObject latestsReleases() {
-        return buildsManager.getLatestReleases();
+        return buildsManager.getLatestReleases().asJsonObject();
     }
 
     @PUT

--- a/src/main/java/io/openliberty/website/OpenLibertyEndpoint.java
+++ b/src/main/java/io/openliberty/website/OpenLibertyEndpoint.java
@@ -34,7 +34,7 @@ public class OpenLibertyEndpoint extends Application {
     @Path("builds")
     @Produces({ "application/json" })
     public JsonObject status() {
-        return buildsManager.getStatus();
+        return buildsManager.getStatus().asJsonObject();
     }
 
     @GET
@@ -58,7 +58,7 @@ public class OpenLibertyEndpoint extends Application {
     @Path("builds")
     @Produces({ "application/json" })
     public JsonObject update() {
-        return buildsManager.updateBuilds();
+        return buildsManager.updateBuilds().asJsonObject();
     }
 
     @GET

--- a/src/main/java/io/openliberty/website/data/BuildData.java
+++ b/src/main/java/io/openliberty/website/data/BuildData.java
@@ -1,0 +1,33 @@
+package io.openliberty.website.data;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+
+import io.openliberty.website.Constants;
+
+public class BuildData {
+	private LatestReleases latestReleases;
+	private BuildLists builds;
+
+	public BuildData(LatestReleases latestReleases, BuildLists builds) {
+		this.latestReleases = latestReleases;
+		this.builds = builds;
+	}
+
+	public JsonObject asJsonObject() {
+		JsonObjectBuilder data = Json.createObjectBuilder();
+		data.add(Constants.LATEST_RELEASES, latestReleases != null ? latestReleases.asJsonObject() : Json.createObjectBuilder().build());
+		data.add(Constants.BUILDS, builds != null ? builds.asJsonObject() : Json.createObjectBuilder().build());
+		return data.build();
+	}
+
+	public LatestReleases getLatestReleases() {
+		return latestReleases;
+	}
+
+	public BuildLists getBuilds() {
+		return builds;
+	}
+
+}

--- a/src/main/java/io/openliberty/website/data/BuildInfo.java
+++ b/src/main/java/io/openliberty/website/data/BuildInfo.java
@@ -52,47 +52,79 @@ public class BuildInfo {
 		return obj.build();
 	}
 
+	public String getVersion() {
+		return version;
+	}
+
 	public void addVersion(String version) {
 		this.version = version;
 	}
 
-	public void addDriverLocation(String driverLocation) {
-		this.driverLocation = driverLocation;
+	public String getDateTime() {
+		return dateTime;
 	}
 
 	public void addDateTime(String dateTime) {
 		this.dateTime = dateTime;
 	}
 
+	public String getDriverLocation() {
+		return driverLocation;
+	}
+
+	public void addDriverLocation(String driverLocation) {
+		this.driverLocation = driverLocation;
+	}
+
+	public String getSizeInBytes() {
+		return sizeInBytes;
+	}
+
 	public void addSizeInBytes(String sizeInBytes) {
 		this.sizeInBytes = sizeInBytes;
+	}
+
+	public String getTestPassed() {
+		return testPassed;
 	}
 
 	public void addTestPassed(String testPassed) {
 		this.testPassed = testPassed;
 	}
 
+	public String getTotalTests() {
+		return totalTests;
+	}
+
 	public void addTotalTests(String totalTests) {
 		this.totalTests = totalTests;
+	}
+
+	public String getBuildLog() {
+		return buildLog;
 	}
 
 	public void addBuildLog(String buildLog) {
 		this.buildLog = buildLog;
 	}
 
+	public String getTestLog() {
+		return testLog;
+	}
+
 	public void addTestLog(String testLog) {
 		this.testLog = testLog;
+	}
+
+	public List<String> getPackageLocations() {
+		return packageLocations;
 	}
 
 	public void addPackageLocation(String name, String location) {
 		if (packageLocations == null) {
 			packageLocations = new ArrayList<String>();
 		}
-		packageLocations.add(name+"="+location);
-	}
-
-	public String getDateTime() {
-		return dateTime;
+		packageLocations.add(name + "=" + location);
 	}
 
 }

--- a/src/main/java/io/openliberty/website/data/BuildInfo.java
+++ b/src/main/java/io/openliberty/website/data/BuildInfo.java
@@ -1,0 +1,98 @@
+package io.openliberty.website.data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+
+import io.openliberty.website.Constants;
+
+public class BuildInfo {
+	private String version;
+	private String dateTime;
+	private String driverLocation;
+	private String sizeInBytes;
+	private String testPassed;
+	private String totalTests;
+	private String buildLog;
+	private String testLog;
+	private List<String> packageLocations;
+
+	public JsonObject asJsonObject() {
+		JsonObjectBuilder obj = Json.createObjectBuilder();
+		if (version != null) {
+			obj.add(Constants.VERSION, version);
+		}
+		if (dateTime != null) {
+			obj.add(Constants.DATE, dateTime);
+		}
+		if (driverLocation != null) {
+			obj.add(Constants.DRIVER_LOCATION, driverLocation);
+		}
+		if (sizeInBytes != null) {
+			obj.add(Constants.SIZE_IN_BYTES, sizeInBytes);
+		}
+		if (totalTests != null) {
+			obj.add(Constants.TOTAL_TESTS, totalTests);
+		}
+		if (testPassed != null) {
+			obj.add(Constants.TESTS_PASSED, testPassed);
+		}
+		if (buildLog != null) {
+			obj.add(Constants.BUILD_LOG, buildLog);
+		}
+		if (testLog != null) {
+			obj.add(Constants.TESTS_LOG, testLog);
+		}
+		if (packageLocations != null) {
+			obj.add(Constants.PACKAGE_LOCATIONS, Json.createArrayBuilder(packageLocations).build());
+		}
+		return obj.build();
+	}
+
+	public void addVersion(String version) {
+		this.version = version;
+	}
+
+	public void addDriverLocation(String driverLocation) {
+		this.driverLocation = driverLocation;
+	}
+
+	public void addDateTime(String dateTime) {
+		this.dateTime = dateTime;
+	}
+
+	public void addSizeInBytes(String sizeInBytes) {
+		this.sizeInBytes = sizeInBytes;
+	}
+
+	public void addTestPassed(String testPassed) {
+		this.testPassed = testPassed;
+	}
+
+	public void addTotalTests(String totalTests) {
+		this.totalTests = totalTests;
+	}
+
+	public void addBuildLog(String buildLog) {
+		this.buildLog = buildLog;
+	}
+
+	public void addTestLog(String testLog) {
+		this.testLog = testLog;
+	}
+
+	public void addPackageLocation(String name, String location) {
+		if (packageLocations == null) {
+			packageLocations = new ArrayList<String>();
+		}
+		packageLocations.add(name+"="+location);
+	}
+
+	public String getDateTime() {
+		return dateTime;
+	}
+
+}

--- a/src/main/java/io/openliberty/website/data/BuildLists.java
+++ b/src/main/java/io/openliberty/website/data/BuildLists.java
@@ -1,0 +1,93 @@
+package io.openliberty.website.data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+
+import io.openliberty.website.Constants;
+
+public class BuildLists {
+	List<BuildInfo> runtimeReleases = new ArrayList<BuildInfo>();
+	List<BuildInfo> runtimeNightlyBuilds = new ArrayList<BuildInfo>();
+	List<BuildInfo> toolsReleases = new ArrayList<BuildInfo>();
+	List<BuildInfo> toolsNightlyBuilds = new ArrayList<BuildInfo>();
+
+	public List<BuildInfo> getRuntimeReleases() {
+		return runtimeReleases;
+	}
+
+	public void addRuntimeRelease(BuildInfo info) {
+		runtimeReleases.add(info);
+	}
+
+	public void setRuntimeReleases(List<BuildInfo> list) {
+		this.runtimeReleases = list;
+	}
+
+	public List<BuildInfo> getRuntimeNightlyBuilds() {
+		return runtimeNightlyBuilds;
+	}
+
+	public void addRuntimeNightlyBuild(BuildInfo info) {
+		runtimeNightlyBuilds.add(info);
+	}
+
+	public void setRuntimeNightlyBuilds(List<BuildInfo> list) {
+		this.runtimeNightlyBuilds = list;
+	}
+
+	public List<BuildInfo> getToolsReleases() {
+		return toolsReleases;
+	}
+
+	public void addToolsRelease(BuildInfo info) {
+		toolsReleases.add(info);
+	}
+
+	public void setToolsReleases(List<BuildInfo> list) {
+		this.toolsReleases = list;
+	}
+
+	public List<BuildInfo> getToolsNightlyBuilds() {
+		return toolsNightlyBuilds;
+	}
+
+	public void addToolsNightlyBuild(BuildInfo info) {
+		toolsNightlyBuilds.add(info);
+	}
+
+	public void setToolsNightlyBuild(List<BuildInfo> list) {
+		this.toolsNightlyBuilds = list;
+	}
+
+	private JsonArray asJsonArray(List<BuildInfo> buildList) {
+		JsonArrayBuilder array = Json.createArrayBuilder();
+		for (BuildInfo info : buildList) {
+			array.add(info.asJsonObject());
+		}
+		return array.build();
+	}
+
+	public JsonObject asJsonObject() {
+		JsonObjectBuilder json = Json.createObjectBuilder();
+		if (!runtimeReleases.isEmpty()) {
+			json.add(Constants.RUNTIME_RELEASES, asJsonArray(runtimeReleases));
+		}
+		if (!runtimeNightlyBuilds.isEmpty()) {
+			json.add(Constants.RUNTIME_NIGHTLY_BUILDS, asJsonArray(runtimeNightlyBuilds));
+		}
+		if (!toolsReleases.isEmpty()) {
+			json.add(Constants.TOOLS_RELEASES, asJsonArray(toolsReleases));
+		}
+		if (!toolsNightlyBuilds.isEmpty()) {
+			json.add(Constants.TOOLS_NIGHTLY_BUILDS, asJsonArray(toolsNightlyBuilds));
+		}
+		return json.build();
+	}
+
+}

--- a/src/main/java/io/openliberty/website/data/DateUtil.java
+++ b/src/main/java/io/openliberty/website/data/DateUtil.java
@@ -1,0 +1,26 @@
+package io.openliberty.website.data;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+public class DateUtil {
+
+	/**
+	 * Returns a String for the given Date object in UTC time.
+	 * Formatted as: "Thu Jan 01 00:00:00 UTC 1970"
+	 *
+	 * @param date
+	 * @return A date formatted like "Thu Jan 01 00:00:00 UTC 1970"
+	 */
+	public static String asUTCString(Date date) {
+		if (date == null) {
+			return null;
+		}
+		final SimpleDateFormat sdf = new SimpleDateFormat("EEE MMM dd HH:mm:ss z yyyy", Locale.US);
+		sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+		return sdf.format(date);
+	}
+
+}

--- a/src/main/java/io/openliberty/website/data/LastUpdate.java
+++ b/src/main/java/io/openliberty/website/data/LastUpdate.java
@@ -1,0 +1,41 @@
+package io.openliberty.website.data;
+
+import java.util.Date;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+
+import io.openliberty.website.Constants;
+
+public class LastUpdate {
+	private Date lastAttempt;
+	private Date lastSuccess;
+
+	public String getLastUpdateAttempt() {
+		return lastAttempt == null ? Constants.NEVER_ATTEMPTED : DateUtil.asUTCString(lastAttempt);
+	}
+
+	public void setLastUpdateAttempt(Date date) {
+		lastAttempt = date;
+	}
+
+	public String getLastSuccessfulUpdate() {
+		return lastSuccess == null ? Constants.NEVER_UPDATED : DateUtil.asUTCString(lastSuccess);
+	}
+
+	public void markSuccessfulUpdate() {
+		lastSuccess = lastAttempt;
+	}
+
+	public Date lastSuccessfulUpdate() {
+		return lastSuccess;
+	}
+
+	public JsonObject asJsonObject() {
+		JsonObjectBuilder builder = Json.createObjectBuilder();
+		builder.add(Constants.LAST_UPDATE_ATTEMPT, getLastUpdateAttempt());
+		builder.add(Constants.LAST_SUCCESSFULL_UPDATE, getLastSuccessfulUpdate());
+		return builder.build();
+	}
+}

--- a/src/main/java/io/openliberty/website/data/LatestReleases.java
+++ b/src/main/java/io/openliberty/website/data/LatestReleases.java
@@ -1,0 +1,32 @@
+package io.openliberty.website.data;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+
+import io.openliberty.website.Constants;
+
+public class LatestReleases {
+	private BuildInfo runtime;
+	private BuildInfo tools;
+
+	public LatestReleases() {
+	}
+
+	public LatestReleases(BuildInfo runtime, BuildInfo tools) {
+		this.runtime = runtime;
+		this.tools = tools;
+	}
+
+	public JsonObject asJsonObject() {
+		JsonObjectBuilder json = Json.createObjectBuilder();
+		if (runtime != null) {
+			json.add(Constants.RUNTIME, runtime.asJsonObject());
+		}
+		if (tools != null) {
+			json.add(Constants.TOOLS, tools.asJsonObject());
+		}
+		return json.build();
+	}
+
+}

--- a/src/test/java/io/openliberty/website/BuildsManagerTest.java
+++ b/src/test/java/io/openliberty/website/BuildsManagerTest.java
@@ -60,7 +60,7 @@ public class BuildsManagerTest {
         assertTrue(builds.getToolsReleases().isEmpty());
         assertTrue(builds.getToolsNightlyBuilds().isEmpty());
 
-        assertEquals("{}", bm.getLatestReleases().toString());
+        assertEquals("{}", bm.getLatestReleases().asJsonObject().toString());
     }
 
 	@Test
@@ -79,7 +79,7 @@ public class BuildsManagerTest {
         assertTrue(builds.getToolsReleases().isEmpty());
         assertTrue(builds.getToolsNightlyBuilds().isEmpty());
 
-		assertEquals("{}", bm.getLatestReleases().toString());
+		assertEquals("{}", bm.getLatestReleases().asJsonObject().toString());
 	}
 
     private JsonObject getExpectedBuilds() {
@@ -116,7 +116,7 @@ public class BuildsManagerTest {
         assertFalse(Constants.NEVER_UPDATED.equals(status.getLastSuccessfulUpdate()));
 
         JsonObject expectedReleases = getExpectedReleases();
-        assertEquals(expectedReleases, bm.getLatestReleases());
+        assertEquals(expectedReleases, bm.getLatestReleases().asJsonObject());
 
         JsonObject expectedBuilds = getExpectedBuilds();
         assertEquals(expectedBuilds, bm.getBuilds().asJsonObject());

--- a/src/test/java/io/openliberty/website/BuildsManagerTest.java
+++ b/src/test/java/io/openliberty/website/BuildsManagerTest.java
@@ -7,38 +7,22 @@ import static org.junit.Assert.assertTrue;
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
-import javax.json.JsonString;
-import javax.json.JsonValue;
-import javax.json.JsonValue.ValueType;
 
 import org.junit.Test;
 
+import io.openliberty.website.data.LastUpdate;
 import io.openliberty.website.mock.MockDHEClient;
 import io.openliberty.website.mock.NullDHEClient;
 
 public class BuildsManagerTest {
 
-    private void assertJsonStringEqual(String expectedValue, JsonValue actualJsonValue) {
-        assertEquals("JsonValue is not a JsonString type", 0,
-                actualJsonValue.getValueType().compareTo(ValueType.STRING));
-        assertEquals("JsonString is not of the expected value", expectedValue,
-                ((JsonString) actualJsonValue).getString());
-    }
-
-    private void assertJsonStringNotEqual(String expectedToNotEqual, JsonValue actualJsonValue) {
-        assertEquals("JsonValue is not a JsonString type", 0,
-                actualJsonValue.getValueType().compareTo(ValueType.STRING));
-        assertFalse("JsonString should not equal the expected value",
-                expectedToNotEqual.equals(((JsonString) actualJsonValue).getString()));
-    }
-
     @Test
     public void default_initialized_BuildManager() {
         BuildsManager bm = new BuildsManager();
 
-        JsonObject status = bm.getStatus();
-        assertJsonStringEqual(Constants.NEVER_ATTEMPTED, status.get(Constants.LAST_UPDATE_ATTEMPT));
-        assertJsonStringEqual(Constants.NEVER_UPDATED, status.get(Constants.LAST_SUCCESSFULL_UPDATE));
+        LastUpdate status = bm.getStatus();
+        assertEquals(Constants.NEVER_ATTEMPTED, status.getLastUpdateAttempt());
+        assertEquals(Constants.NEVER_UPDATED, status.getLastSuccessfulUpdate());
     }
 
     @Test
@@ -58,12 +42,12 @@ public class BuildsManagerTest {
     @Test
     public void validate_state_of_BuildManager_after_failed_update() {
         BuildsManager bm = new BuildsManager(new NullDHEClient());
-        JsonObject status = bm.updateBuilds();
+        LastUpdate status = bm.updateBuilds();
 
         assertEquals(status, bm.getStatus());
 
-        assertJsonStringNotEqual(Constants.NEVER_ATTEMPTED, status.get(Constants.LAST_UPDATE_ATTEMPT));
-        assertJsonStringEqual(Constants.NEVER_UPDATED, status.get(Constants.LAST_SUCCESSFULL_UPDATE));
+        assertFalse(Constants.NEVER_ATTEMPTED.equals(status.getLastUpdateAttempt()));
+        assertEquals(Constants.NEVER_UPDATED, status.getLastSuccessfulUpdate());
 
         assertEquals("{}", bm.getBuilds().toString());
         assertEquals("{}", bm.getLatestReleases().toString());
@@ -93,12 +77,12 @@ public class BuildsManagerTest {
     @Test
     public void validate_state_of_BuildManager_after_successful_update() {
         BuildsManager bm = new BuildsManager(new MockDHEClient());
-        JsonObject status = bm.updateBuilds();
+        LastUpdate status = bm.updateBuilds();
 
         assertEquals(status, bm.getStatus());
 
-        assertJsonStringNotEqual(Constants.NEVER_ATTEMPTED, status.get(Constants.LAST_UPDATE_ATTEMPT));
-        assertJsonStringNotEqual(Constants.NEVER_UPDATED, status.get(Constants.LAST_SUCCESSFULL_UPDATE));
+        assertFalse(Constants.NEVER_ATTEMPTED.equals(status.getLastUpdateAttempt()));
+        assertFalse(Constants.NEVER_UPDATED.equals(status.getLastSuccessfulUpdate()));
 
         JsonObject expectedReleases = getExpectedReleases();
         assertEquals(expectedReleases, bm.getLatestReleases());

--- a/src/test/java/io/openliberty/website/BuildsManagerTest.java
+++ b/src/test/java/io/openliberty/website/BuildsManagerTest.java
@@ -1,22 +1,120 @@
 package io.openliberty.website;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import javax.json.Json;
 import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import javax.json.JsonString;
+import javax.json.JsonValue;
 import javax.json.JsonValue.ValueType;
 
 import org.junit.Test;
 
+import io.openliberty.website.mock.MockDHEClient;
+import io.openliberty.website.mock.NullDHEClient;
+
 public class BuildsManagerTest {
 
-	@Test
-	public void testBuildsManager() {
-		BuildsManager bm = new BuildsManager();
-		JsonObject json = bm.getStatus();
-		assertTrue(0 == json.get(Constants.LAST_UPDATE_ATTEMPT).getValueType().compareTo(ValueType.STRING));
-		assertEquals("\""+Constants.NEVER_ATTEMPTED+"\"", json.get(Constants.LAST_UPDATE_ATTEMPT).toString());
-		assertEquals("\""+Constants.NEVER_UPDATED+"\"", json.get(Constants.LAST_SUCCESSFULL_UPDATE).toString());
-	}
+    private void assertJsonStringEqual(String expectedValue, JsonValue actualJsonValue) {
+        assertEquals("JsonValue is not a JsonString type", 0,
+                actualJsonValue.getValueType().compareTo(ValueType.STRING));
+        assertEquals("JsonString is not of the expected value", expectedValue,
+                ((JsonString) actualJsonValue).getString());
+    }
+
+    private void assertJsonStringNotEqual(String expectedToNotEqual, JsonValue actualJsonValue) {
+        assertEquals("JsonValue is not a JsonString type", 0,
+                actualJsonValue.getValueType().compareTo(ValueType.STRING));
+        assertFalse("JsonString should not equal the expected value",
+                expectedToNotEqual.equals(((JsonString) actualJsonValue).getString()));
+    }
+
+    @Test
+    public void default_initialized_BuildManager() {
+        BuildsManager bm = new BuildsManager();
+
+        JsonObject status = bm.getStatus();
+        assertJsonStringEqual(Constants.NEVER_ATTEMPTED, status.get(Constants.LAST_UPDATE_ATTEMPT));
+        assertJsonStringEqual(Constants.NEVER_UPDATED, status.get(Constants.LAST_SUCCESSFULL_UPDATE));
+    }
+
+    @Test
+    public void isAllowedToRun() {
+        BuildsManager bm = new BuildsManager(new MockDHEClient());
+
+        assertTrue("The first call to isBuildUpdateAllowed should always return true", bm.isBuildUpdateAllowed());
+        assertTrue("The second call to isBuildUpdateAllowed should return true if no update has been attempted",
+                bm.isBuildUpdateAllowed());
+
+        bm.updateBuilds();
+
+        assertFalse("Calls to isBuildUpdateAllowed should return false if a successful update recently occurred",
+                bm.isBuildUpdateAllowed());
+    }
+
+    @Test
+    public void validate_state_of_BuildManager_after_failed_update() {
+        BuildsManager bm = new BuildsManager(new NullDHEClient());
+        JsonObject status = bm.updateBuilds();
+
+        assertEquals(status, bm.getStatus());
+
+        assertJsonStringNotEqual(Constants.NEVER_ATTEMPTED, status.get(Constants.LAST_UPDATE_ATTEMPT));
+        assertJsonStringEqual(Constants.NEVER_UPDATED, status.get(Constants.LAST_SUCCESSFULL_UPDATE));
+
+        assertEquals("{}", bm.getBuilds().toString());
+        assertEquals("{}", bm.getLatestReleases().toString());
+    }
+
+    private JsonObject getExpectedBuilds() {
+        JsonObjectBuilder expected = Json.createObjectBuilder();
+        expected.add("runtime_releases", Json.createArrayBuilder().add(createTestRelease("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release", "runtime-release-v1")).build());
+        expected.add("runtime_nightly_builds", Json.createArrayBuilder().add(createTestRelease("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/nightly", "runtime-nightly-v1")).build());
+        expected.add("tools_releases", Json.createArrayBuilder().add(createTestRelease("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/tools/release", "tools-release-v1")).build());
+        expected.add("tools_nightly_builds", Json.createArrayBuilder().add(createTestRelease("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/tools/nightly", "tools-nightly-v1")).build());
+        return expected.build();
+    }
+
+    private JsonObject createTestRelease(String urlPath, String date_time) {
+        JsonObjectBuilder releaseInfo = Json.createObjectBuilder();
+        releaseInfo.add(Constants.VERSION, "v1");
+        releaseInfo.add(Constants.BUILD_LOG, urlPath+"/"+date_time+"/build-log-path");
+        releaseInfo.add(Constants.TESTS_LOG, urlPath+"/"+date_time+"/test-log-path");
+        releaseInfo.add(Constants.DRIVER_LOCATION, urlPath+"/"+date_time+"/driver-location");
+        releaseInfo.add(Constants.PACKAGE_LOCATIONS, Json.createArrayBuilder().add(Json.createValue("package="+urlPath+"/"+date_time+"/my-package-v1")).build());
+        releaseInfo.add("date_time", Json.createValue(date_time));
+        releaseInfo.add("size_in_bytes", Json.createValue("1234"));
+        return releaseInfo.build();
+    }
+
+    @Test
+    public void validate_state_of_BuildManager_after_successful_update() {
+        BuildsManager bm = new BuildsManager(new MockDHEClient());
+        JsonObject status = bm.updateBuilds();
+
+        assertEquals(status, bm.getStatus());
+
+        assertJsonStringNotEqual(Constants.NEVER_ATTEMPTED, status.get(Constants.LAST_UPDATE_ATTEMPT));
+        assertJsonStringNotEqual(Constants.NEVER_UPDATED, status.get(Constants.LAST_SUCCESSFULL_UPDATE));
+
+        JsonObject expectedReleases = getExpectedReleases();
+        assertEquals(expectedReleases, bm.getLatestReleases());
+        
+        JsonObject expectedBuilds = getExpectedBuilds();
+        assertEquals(expectedBuilds, bm.getBuilds());
+        
+    }
+
+    private JsonObject getExpectedReleases() {
+        JsonObjectBuilder expected = Json.createObjectBuilder();
+        expected.add("runtime", createTestRelease("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release", "runtime-release-v1"));
+        expected.add("tools", createTestRelease("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/tools/release", "tools-release-v1"));
+        return expected.build();
+    }
 
 }
+
+

--- a/src/test/java/io/openliberty/website/BuildsManagerTest.java
+++ b/src/test/java/io/openliberty/website/BuildsManagerTest.java
@@ -11,6 +11,7 @@ import javax.json.JsonObjectBuilder;
 import org.junit.Test;
 
 import io.openliberty.website.data.LastUpdate;
+import io.openliberty.website.mock.EmptyVersionsDHEClient;
 import io.openliberty.website.mock.MockDHEClient;
 import io.openliberty.website.mock.NullDHEClient;
 
@@ -52,6 +53,20 @@ public class BuildsManagerTest {
         assertEquals("{}", bm.getBuilds().toString());
         assertEquals("{}", bm.getLatestReleases().toString());
     }
+
+	@Test
+	public void validate_state_of_BuildManager_with_no_releases() {
+		BuildsManager bm = new BuildsManager(new EmptyVersionsDHEClient());
+		LastUpdate status = bm.updateBuilds();
+
+		assertEquals(status, bm.getStatus());
+
+		assertFalse(Constants.NEVER_ATTEMPTED.equals(status.getLastUpdateAttempt()));
+		assertEquals(Constants.NEVER_UPDATED, status.getLastSuccessfulUpdate());
+
+		assertEquals("{}", bm.getBuilds().toString());
+		assertEquals("{}", bm.getLatestReleases().toString());
+	}
 
     private JsonObject getExpectedBuilds() {
         JsonObjectBuilder expected = Json.createObjectBuilder();

--- a/src/test/java/io/openliberty/website/BuildsManagerTest.java
+++ b/src/test/java/io/openliberty/website/BuildsManagerTest.java
@@ -1,0 +1,22 @@
+package io.openliberty.website;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import javax.json.JsonObject;
+import javax.json.JsonValue.ValueType;
+
+import org.junit.Test;
+
+public class BuildsManagerTest {
+
+	@Test
+	public void testBuildsManager() {
+		BuildsManager bm = new BuildsManager();
+		JsonObject json = bm.getStatus();
+		assertTrue(0 == json.get(Constants.LAST_UPDATE_ATTEMPT).getValueType().compareTo(ValueType.STRING));
+		assertEquals("\""+Constants.NEVER_ATTEMPTED+"\"", json.get(Constants.LAST_UPDATE_ATTEMPT).toString());
+		assertEquals("\""+Constants.NEVER_UPDATED+"\"", json.get(Constants.LAST_SUCCESSFULL_UPDATE).toString());
+	}
+
+}

--- a/src/test/java/io/openliberty/website/BuildsManagerTest.java
+++ b/src/test/java/io/openliberty/website/BuildsManagerTest.java
@@ -13,6 +13,7 @@ import javax.json.JsonObjectBuilder;
 import org.junit.Test;
 
 import io.openliberty.website.data.BuildLists;
+import io.openliberty.website.data.BuildData;
 import io.openliberty.website.data.BuildInfo;
 import io.openliberty.website.data.LastUpdate;
 import io.openliberty.website.mock.EmptyVersionsDHEClient;
@@ -146,6 +147,13 @@ public class BuildsManagerTest {
         expected.add("runtime", createTestRelease("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release", "runtime-release-v1"));
         expected.add("tools", createTestRelease("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/tools/release", "tools-release-v1"));
         return expected.build();
+    }
+
+    @Test
+    public void getData_after_failed_update() {
+        BuildsManager bm = new BuildsManager(new NullDHEClient());
+        BuildData data = bm.getData();
+        assertEquals("{\"latest_releases\":{},\"builds\":{}}", data.asJsonObject().toString());
     }
 
 }

--- a/src/test/java/io/openliberty/website/DHEClientTest.java
+++ b/src/test/java/io/openliberty/website/DHEClientTest.java
@@ -1,0 +1,12 @@
+package io.openliberty.website;
+
+import org.junit.Test;
+
+public class DHEClientTest {
+
+	@Test
+	public void constructor() {
+		new DHEClient();
+	}
+
+}

--- a/src/test/java/io/openliberty/website/data/BuildDataTest.java
+++ b/src/test/java/io/openliberty/website/data/BuildDataTest.java
@@ -1,0 +1,32 @@
+package io.openliberty.website.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class BuildDataTest {
+
+	@Test
+	public void null_data() {
+		BuildData data = new BuildData(null, null);
+
+		assertEquals("{\"latest_releases\":{},\"builds\":{}}", data.asJsonObject().toString());
+
+		assertNull(data.getLatestReleases());
+		assertNull(data.getBuilds());
+	}
+
+	@Test
+	public void empty_data() {
+		LatestReleases latest = new LatestReleases();
+		BuildLists builds = new BuildLists();
+		BuildData data = new BuildData(latest, builds);
+
+		assertEquals("{\"latest_releases\":{},\"builds\":{}}", data.asJsonObject().toString());
+
+		assertEquals(latest, data.getLatestReleases());
+		assertEquals(builds, data.getBuilds());
+	}
+
+}

--- a/src/test/java/io/openliberty/website/data/BuildInfoTest.java
+++ b/src/test/java/io/openliberty/website/data/BuildInfoTest.java
@@ -7,35 +7,66 @@ import org.junit.Test;
 public class BuildInfoTest {
 
 	@Test
-	public void emptyReleaseInfo() {
+	public void default_build_info() {
 		BuildInfo info = new BuildInfo();
+
 		assertEquals("{}", info.asJsonObject().toString());
+
+		assertNull(info.getDriverLocation());
+		assertNull(info.getVersion());
 		assertNull(info.getDateTime());
+		assertNull(info.getSizeInBytes());
+		assertNull(info.getTotalTests());
+		assertNull(info.getTestPassed());
+		assertNull(info.getBuildLog());
+		assertNull(info.getTestLog());
+		assertNull(info.getPackageLocations());
 	}
 
 	@Test
-	public void driverInfo() {
+	public void driver_info_only() {
 		BuildInfo info = new BuildInfo();
 		info.addDriverLocation("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/openliberty-18.0.0.2.zip");
+
 		assertEquals("{\"driver_location\":\"https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/openliberty-18.0.0.2.zip\"}", info.asJsonObject().toString());
+
+		assertEquals("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/openliberty-18.0.0.2.zip", info.getDriverLocation());
+		assertNull(info.getVersion());
 		assertNull(info.getDateTime());
+		assertNull(info.getSizeInBytes());
+		assertNull(info.getTotalTests());
+		assertNull(info.getTestPassed());
+		assertNull(info.getBuildLog());
+		assertNull(info.getTestLog());
+		assertNull(info.getPackageLocations());
 	}
 
 	@Test
-	public void allInfo() {
+	public void all_build_info() {
 		BuildInfo info = new BuildInfo();
 		info.addDriverLocation("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/openliberty-18.0.0.2.zip");
 		info.addVersion("18.0.0.2");
 		info.addDateTime("2018-06-20_1913");
 		info.addSizeInBytes("6050953");
-		info.addTotalTests("8500");
+		info.addTotalTests("8501");
 		info.addTestPassed("8500");
 		info.addBuildLog("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/gradle.log");
 		info.addTestLog("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/open-liberty.unitTest.results.zip");
 		info.addPackageLocation("javaee8.zip", "https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/openliberty-javaee8-18.0.0.2.zip");
 		info.addPackageLocation("webProfile8.zip", "https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/openliberty-webProfile8-18.0.0.2.zip");
-		assertEquals("{\"version\":\"18.0.0.2\",\"date_time\":\"2018-06-20_1913\",\"driver_location\":\"https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/openliberty-18.0.0.2.zip\",\"size_in_bytes\":\"6050953\",\"total_tests\":\"8500\",\"test_passed\":\"8500\",\"build_log\":\"https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/gradle.log\",\"tests_log\":\"https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/open-liberty.unitTest.results.zip\",\"package_locations\":[\"javaee8.zip=https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/openliberty-javaee8-18.0.0.2.zip\",\"webProfile8.zip=https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/openliberty-webProfile8-18.0.0.2.zip\"]}", info.asJsonObject().toString());
 
+		assertEquals("{\"version\":\"18.0.0.2\",\"date_time\":\"2018-06-20_1913\",\"driver_location\":\"https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/openliberty-18.0.0.2.zip\",\"size_in_bytes\":\"6050953\",\"total_tests\":\"8501\",\"test_passed\":\"8500\",\"build_log\":\"https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/gradle.log\",\"tests_log\":\"https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/open-liberty.unitTest.results.zip\",\"package_locations\":[\"javaee8.zip=https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/openliberty-javaee8-18.0.0.2.zip\",\"webProfile8.zip=https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/openliberty-webProfile8-18.0.0.2.zip\"]}", info.asJsonObject().toString());
+
+		assertEquals("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/openliberty-18.0.0.2.zip", info.getDriverLocation());
+		assertEquals("18.0.0.2", info.getVersion());
 		assertEquals("2018-06-20_1913", info.getDateTime());
+		assertEquals("6050953", info.getSizeInBytes());
+		assertEquals("8501", info.getTotalTests());
+		assertEquals("8500", info.getTestPassed());
+		assertEquals("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/gradle.log", info.getBuildLog());
+		assertEquals("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/open-liberty.unitTest.results.zip", info.getTestLog());
+		assertEquals(2, info.getPackageLocations().size());
+		assertEquals("javaee8.zip=https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/openliberty-javaee8-18.0.0.2.zip", info.getPackageLocations().get(0));
+		assertEquals("webProfile8.zip=https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/openliberty-webProfile8-18.0.0.2.zip", info.getPackageLocations().get(1));
 	}
 }

--- a/src/test/java/io/openliberty/website/data/BuildInfoTest.java
+++ b/src/test/java/io/openliberty/website/data/BuildInfoTest.java
@@ -1,0 +1,41 @@
+package io.openliberty.website.data;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class BuildInfoTest {
+
+	@Test
+	public void emptyReleaseInfo() {
+		BuildInfo info = new BuildInfo();
+		assertEquals("{}", info.asJsonObject().toString());
+		assertNull(info.getDateTime());
+	}
+
+	@Test
+	public void driverInfo() {
+		BuildInfo info = new BuildInfo();
+		info.addDriverLocation("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/openliberty-18.0.0.2.zip");
+		assertEquals("{\"driver_location\":\"https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/openliberty-18.0.0.2.zip\"}", info.asJsonObject().toString());
+		assertNull(info.getDateTime());
+	}
+
+	@Test
+	public void allInfo() {
+		BuildInfo info = new BuildInfo();
+		info.addDriverLocation("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/openliberty-18.0.0.2.zip");
+		info.addVersion("18.0.0.2");
+		info.addDateTime("2018-06-20_1913");
+		info.addSizeInBytes("6050953");
+		info.addTotalTests("8500");
+		info.addTestPassed("8500");
+		info.addBuildLog("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/gradle.log");
+		info.addTestLog("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/open-liberty.unitTest.results.zip");
+		info.addPackageLocation("javaee8.zip", "https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/openliberty-javaee8-18.0.0.2.zip");
+		info.addPackageLocation("webProfile8.zip", "https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/openliberty-webProfile8-18.0.0.2.zip");
+		assertEquals("{\"version\":\"18.0.0.2\",\"date_time\":\"2018-06-20_1913\",\"driver_location\":\"https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/openliberty-18.0.0.2.zip\",\"size_in_bytes\":\"6050953\",\"total_tests\":\"8500\",\"test_passed\":\"8500\",\"build_log\":\"https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/gradle.log\",\"tests_log\":\"https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/open-liberty.unitTest.results.zip\",\"package_locations\":[\"javaee8.zip=https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/openliberty-javaee8-18.0.0.2.zip\",\"webProfile8.zip=https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/openliberty-webProfile8-18.0.0.2.zip\"]}", info.asJsonObject().toString());
+
+		assertEquals("2018-06-20_1913", info.getDateTime());
+	}
+}

--- a/src/test/java/io/openliberty/website/data/BuildListsTest.java
+++ b/src/test/java/io/openliberty/website/data/BuildListsTest.java
@@ -1,0 +1,76 @@
+package io.openliberty.website.data;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+public class BuildListsTest {
+
+	@Test
+	public void initial_construction() {
+		BuildLists all = new BuildLists();
+		assertEquals(0, all.getRuntimeReleases().size());
+		assertEquals(0, all.getRuntimeNightlyBuilds().size());
+		assertEquals(0, all.getToolsReleases().size());
+		assertEquals(0, all.getToolsNightlyBuilds().size());
+
+		assertEquals("{}", all.asJsonObject().toString());
+
+		// It mmight be nice if this was the agreed-to return value
+		// assertEquals(
+		// "{\"runtime_releases\":[],\"runtime_nightly_builds\":[],\"tools_releases\":[],\"tools_nightly_builds\":[]}",
+		// all.asJsonObject().toString());
+	}
+
+	@Test
+	public void set_builds_info() {
+		BuildLists all = new BuildLists();
+
+		BuildInfo info = new BuildInfo();
+		List<BuildInfo> list = new ArrayList<BuildInfo>();
+		list.add(info);
+
+		all.setRuntimeReleases(list);
+		all.setRuntimeNightlyBuilds(list);
+		all.setToolsReleases(list);
+		all.setToolsNightlyBuild(list);
+
+		assertEquals(1, all.getRuntimeReleases().size());
+		assertEquals(info, all.getRuntimeReleases().get(0));
+
+		assertEquals(1, all.getRuntimeNightlyBuilds().size());
+		assertEquals(info, all.getRuntimeNightlyBuilds().get(0));
+
+		assertEquals(1, all.getToolsReleases().size());
+		assertEquals(info, all.getToolsReleases().get(0));
+
+		assertEquals(1, all.getToolsNightlyBuilds().size());
+		assertEquals(info, all.getToolsNightlyBuilds().get(0));
+	}
+
+	@Test
+	public void populate_builds_info() {
+		BuildLists all = new BuildLists();
+		BuildInfo info = new BuildInfo();
+
+		all.addRuntimeRelease(info);
+		assertEquals(1, all.getRuntimeReleases().size());
+		assertEquals(info, all.getRuntimeReleases().get(0));
+
+		all.addRuntimeNightlyBuild(info);
+		assertEquals(1, all.getRuntimeNightlyBuilds().size());
+		assertEquals(info, all.getRuntimeNightlyBuilds().get(0));
+
+		all.addToolsRelease(info);
+		assertEquals(1, all.getToolsReleases().size());
+		assertEquals(info, all.getToolsReleases().get(0));
+
+		all.addToolsNightlyBuild(info);
+		assertEquals(1, all.getToolsNightlyBuilds().size());
+		assertEquals(info, all.getToolsNightlyBuilds().get(0));
+	}
+
+}

--- a/src/test/java/io/openliberty/website/data/DateUtilTest.java
+++ b/src/test/java/io/openliberty/website/data/DateUtilTest.java
@@ -1,0 +1,20 @@
+package io.openliberty.website.data;
+
+import static org.junit.Assert.*;
+
+import java.util.Date;
+
+import org.junit.Test;
+
+public class DateUtilTest {
+
+	@Test
+	public void asUTC_null() {
+		assertNull(DateUtil.asUTCString(null));
+	}
+
+	@Test
+	public void asUTC_date_object() {
+		assertEquals("Thu Jan 01 00:00:00 UTC 1970", DateUtil.asUTCString(new Date(0)));
+	}
+}

--- a/src/test/java/io/openliberty/website/data/LastUpdateTest.java
+++ b/src/test/java/io/openliberty/website/data/LastUpdateTest.java
@@ -1,0 +1,51 @@
+package io.openliberty.website.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Date;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+
+import org.junit.Test;
+
+import io.openliberty.website.Constants;
+
+public class LastUpdateTest {
+
+	@Test
+	public void ctor() {
+		LastUpdate lastUpdate = new LastUpdate();
+		assertEquals(Constants.NEVER_ATTEMPTED, lastUpdate.getLastUpdateAttempt());
+		assertEquals(Constants.NEVER_UPDATED, lastUpdate.getLastSuccessfulUpdate());
+		assertNull(lastUpdate.lastSuccessfulUpdate());
+	}
+
+	@Test
+	public void set_last_attempt() {
+		LastUpdate lastUpdate = new LastUpdate();
+		lastUpdate.setLastUpdateAttempt(new Date(1000));
+		assertEquals("Thu Jan 01 00:00:01 UTC 1970", lastUpdate.getLastUpdateAttempt());
+	}
+
+	@Test
+	public void set_last_success() {
+		LastUpdate lastUpdate = new LastUpdate();
+		lastUpdate.setLastUpdateAttempt(new Date(2000));
+		lastUpdate.markSuccessfulUpdate();
+		assertEquals("Thu Jan 01 00:00:02 UTC 1970", lastUpdate.getLastSuccessfulUpdate());
+		assertEquals(new Date(2000), lastUpdate.lastSuccessfulUpdate());
+	}
+
+	@Test
+	public void asJson_never_attempted() {
+		LastUpdate lastUpdate = new LastUpdate();
+
+		JsonObject expected = Json.createObjectBuilder().add(Constants.LAST_UPDATE_ATTEMPT, Constants.NEVER_ATTEMPTED)
+				.add(Constants.LAST_SUCCESSFULL_UPDATE, Constants.NEVER_UPDATED).build();
+		assertEquals(expected, lastUpdate.asJsonObject());
+
+	}
+
+}

--- a/src/test/java/io/openliberty/website/data/LatestReleasesTest.java
+++ b/src/test/java/io/openliberty/website/data/LatestReleasesTest.java
@@ -1,0 +1,24 @@
+package io.openliberty.website.data;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class LatestReleasesTest {
+
+	@Test
+	public void no_releases() {
+		LatestReleases latest = new LatestReleases();
+		assertEquals("{}", latest.asJsonObject().toString());
+	}
+
+	@Test
+	public void full_release_info() {
+		BuildInfo runtime = new BuildInfo();
+		BuildInfo tools = new BuildInfo();
+		LatestReleases latest = new LatestReleases(runtime, tools);
+
+		assertEquals("{\"runtime\":{},\"tools\":{}}", latest.asJsonObject().toString());
+	}
+
+}

--- a/src/test/java/io/openliberty/website/mock/EmptyVersionsDHEClient.java
+++ b/src/test/java/io/openliberty/website/mock/EmptyVersionsDHEClient.java
@@ -1,0 +1,41 @@
+package io.openliberty.website.mock;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+
+import io.openliberty.website.Constants;
+import io.openliberty.website.DHEClient;
+
+public class EmptyVersionsDHEClient extends DHEClient {
+
+	@Override
+	public JsonObject retrieveJSON(String url) {
+		if (url.equals("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/info.json")) {
+			JsonObjectBuilder runtimeReleaseVersions = Json.createObjectBuilder();
+			runtimeReleaseVersions.add(Constants.VERSIONS, Json.createArrayBuilder().build());
+			return runtimeReleaseVersions.build();
+		}
+		if (url.equals("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/nightly/info.json")) {
+			JsonObjectBuilder runtimeReleaseVersions = Json.createObjectBuilder();
+			runtimeReleaseVersions.add(Constants.VERSIONS, Json.createArrayBuilder().build());
+			return runtimeReleaseVersions.build();
+		}
+		if (url.equals("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/tools/release/info.json")) {
+			JsonObjectBuilder runtimeReleaseVersions = Json.createObjectBuilder();
+			runtimeReleaseVersions.add(Constants.VERSIONS, Json.createArrayBuilder().build());
+			return runtimeReleaseVersions.build();
+		}
+		if (url.equals("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/tools/nightly/info.json")) {
+			JsonObjectBuilder runtimeReleaseVersions = Json.createObjectBuilder();
+			runtimeReleaseVersions.add(Constants.VERSIONS, Json.createArrayBuilder().build());
+			return runtimeReleaseVersions.build();
+		}
+		return null;
+	}
+
+	@Override
+	public String retrieveSize(String url) {
+		return "1234";
+	}
+}

--- a/src/test/java/io/openliberty/website/mock/MockDHEClient.java
+++ b/src/test/java/io/openliberty/website/mock/MockDHEClient.java
@@ -64,6 +64,8 @@ public class MockDHEClient extends DHEClient {
 			releaseInfo.add(Constants.BUILD_LOG, "build-log-path");
 			releaseInfo.add(Constants.TESTS_LOG, "test-log-path");
 			releaseInfo.add(Constants.DRIVER_LOCATION, "driver-location");
+			releaseInfo.add(Constants.TESTS_PASSED, "8500");
+			releaseInfo.add(Constants.TOTAL_TESTS, "8501");
 			releaseInfo.add(Constants.PACKAGE_LOCATIONS,
 					Json.createArrayBuilder().add(Json.createValue("my-package-v1")).build());
 			return releaseInfo.build();

--- a/src/test/java/io/openliberty/website/mock/MockDHEClient.java
+++ b/src/test/java/io/openliberty/website/mock/MockDHEClient.java
@@ -1,0 +1,79 @@
+package io.openliberty.website.mock;
+
+import javax.json.Json;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+
+import io.openliberty.website.Constants;
+import io.openliberty.website.DHEClient;
+
+public class MockDHEClient extends DHEClient {
+
+	// The following are examples of the kinds of JSON payloads returned in the real
+	// world from info.json hosted on DHE
+
+	// https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/info.json
+	// {"versions":["2017-09-27_1951","2017-12-06_1606","2018-03-09_2209","2018-06-19_0502"]}
+
+	// https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2018-06-19_0502/info.json
+	/*
+	 * { "test_passed": "8500", "total_tests": "8500", "tests_log":
+	 * "open-liberty.unitTest.results.zip", "build_log": "gradle.log",
+	 * "driver_location": "openliberty-18.0.0.2.zip", "package_locations":
+	 * ["openliberty-javaee8-18.0.0.2.zip","openliberty-webProfile8-18.0.0.2.zip"],
+	 * "version": "18.0.0.2" }
+	 */
+
+	// https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/tools/nightly/2018-07-19_0033/info.json
+	// {"build_log":"build.log","driver_location":"openlibertytools-18.0.0.3.v2018-07-19_0033.zip","test_passed":114,"total_tests":114,"tests_log":"test_results.html"}
+
+	@Override
+	public JsonObject retrieveJSON(String url) {
+		System.out.println(url);
+		if (url.equals("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/info.json")) {
+			JsonObjectBuilder runtimeReleaseVersions = Json.createObjectBuilder();
+			JsonArrayBuilder runtimeVersions = Json.createArrayBuilder();
+			runtimeVersions.add(Json.createValue("runtime-release-v1"));
+			runtimeReleaseVersions.add(Constants.VERSIONS, runtimeVersions.build());
+			return runtimeReleaseVersions.build();
+		}
+		if (url.equals("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/nightly/info.json")) {
+			JsonObjectBuilder runtimeReleaseVersions = Json.createObjectBuilder();
+			JsonArrayBuilder runtimeVersions = Json.createArrayBuilder();
+			runtimeVersions.add(Json.createValue("runtime-nightly-v1"));
+			runtimeReleaseVersions.add(Constants.VERSIONS, runtimeVersions.build());
+			return runtimeReleaseVersions.build();
+		}
+		if (url.equals("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/tools/release/info.json")) {
+			JsonObjectBuilder runtimeReleaseVersions = Json.createObjectBuilder();
+			JsonArrayBuilder runtimeVersions = Json.createArrayBuilder();
+			runtimeVersions.add(Json.createValue("tools-release-v1"));
+			runtimeReleaseVersions.add(Constants.VERSIONS, runtimeVersions.build());
+			return runtimeReleaseVersions.build();
+		}
+		if (url.equals("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/tools/nightly/info.json")) {
+			JsonObjectBuilder runtimeReleaseVersions = Json.createObjectBuilder();
+			JsonArrayBuilder runtimeVersions = Json.createArrayBuilder();
+			runtimeVersions.add(Json.createValue("tools-nightly-v1"));
+			runtimeReleaseVersions.add(Constants.VERSIONS, runtimeVersions.build());
+			return runtimeReleaseVersions.build();
+		}
+		if (url.contains("v1")) {
+			JsonObjectBuilder releaseInfo = Json.createObjectBuilder();
+			releaseInfo.add(Constants.VERSION, "v1");
+			releaseInfo.add(Constants.BUILD_LOG, "build-log-path");
+			releaseInfo.add(Constants.TESTS_LOG, "test-log-path");
+			releaseInfo.add(Constants.DRIVER_LOCATION, "driver-location");
+			releaseInfo.add(Constants.PACKAGE_LOCATIONS,
+					Json.createArrayBuilder().add(Json.createValue("my-package-v1")).build());
+			return releaseInfo.build();
+		}
+		return null;
+	}
+
+	@Override
+	public String retrieveSize(String url) {
+		return "1234";
+	}
+}

--- a/src/test/java/io/openliberty/website/mock/MockDHEClient.java
+++ b/src/test/java/io/openliberty/website/mock/MockDHEClient.java
@@ -30,7 +30,6 @@ public class MockDHEClient extends DHEClient {
 
 	@Override
 	public JsonObject retrieveJSON(String url) {
-		System.out.println(url);
 		if (url.equals("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/info.json")) {
 			JsonObjectBuilder runtimeReleaseVersions = Json.createObjectBuilder();
 			JsonArrayBuilder runtimeVersions = Json.createArrayBuilder();

--- a/src/test/java/io/openliberty/website/mock/NullDHEClient.java
+++ b/src/test/java/io/openliberty/website/mock/NullDHEClient.java
@@ -1,0 +1,18 @@
+package io.openliberty.website.mock;
+
+import javax.json.JsonObject;
+
+import io.openliberty.website.DHEClient;
+
+public class NullDHEClient extends DHEClient {
+
+	@Override
+	public JsonObject retrieveJSON(String url) {
+		return null;
+	}
+
+	@Override
+	public String retrieveSize(String url) {
+		return null;
+	}
+}


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

No issue fixed per-se, but this proposes a refactoring of BuildsManager which uses POJOs to represent the various return values, ultimately with the aim of refactoring the logic to populate that data from DHE into an async, multi-threaded implementation to reduce the 30 second+ blocking occasionally observed on the downloads page.

*This is still a work in progress. Creating the PR now for a preliminary review. I suggest reviewing per commit since the scope of the changes is large but each commit is logically incremental*

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
