### PR TITLE
Fix Multipane Guide IE bugs

### DIFF
--- a/src/main/content/_assets/css/doc-header.css
+++ b/src/main/content/_assets/css/doc-header.css
@@ -48,14 +48,14 @@
     letter-spacing:0;
     text-align:center;
     border: none;
-    background: inherit;
+    background: #313653;
 }
 
 /* Override the dropdown button colors */
 #navbar .btn-default.active, #navbar .btn-default:active, #navbar .open > .dropdown-toggle.btn-default{
     color: white;
     border: none;
-    background-color: inherit;
+    background-color: #313653;
     box-shadow: none;
     -webkit-box-shadow: none;
 }
@@ -66,7 +66,7 @@
 }
 
 .reference_dropdown:hover, .reference_dropdown:focus, .reference_dropdown:active {
-    background-color: inherit;
+    background-color: #313653;
     border: none;
     color: white;
 }

--- a/src/main/content/_assets/css/guide-multipane.css
+++ b/src/main/content/_assets/css/guide-multipane.css
@@ -13,8 +13,14 @@
 header {
     position: sticky;
     position: -webkit-sticky;
-    top: 0;
+    top: 0;    
     z-index: 1;
+}
+
+/* Internet Explorer only */
+.IEStickyHeader {
+    position: fixed;
+    width: 100%;
 }
 
 .copyFileButton {

--- a/src/main/content/_assets/js/common-multipane.js
+++ b/src/main/content/_assets/js/common-multipane.js
@@ -20,6 +20,23 @@ function inMobile(){
     return (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent));
 }
 
+// Handle sticky header in IE, because IE doesn't support position: sticky
+function handleStickyHeader() {
+    var userAgent = window.navigator.userAgent;
+    if(userAgent.indexOf('MSIE') > 0 || userAgent.indexOf('Trident/') > 0){
+        var header = $('header');
+        var currentTopPosition = $(window).scrollTop();
+        var headerHeight = header.height();
+        if(currentTopPosition < headerHeight){
+            // Remove fixed header
+            header.removeClass('IEStickyHeader');
+        } else{ 
+            // Make header fixed to top
+            header.addClass('IEStickyHeader');
+        }
+    }    
+}
+
 function heightOfVisibleBackground() {
     var result;
     if(isBackgroundBottomVisible()) {
@@ -194,6 +211,7 @@ $(document).ready(function() {
 
     $(window).on('scroll', function(event) {
         handleDownArrow();
+        handleStickyHeader();
         handleFloatingTableOfContent(); 
         handleFloatingTOCAccordion();
         handleFloatingCodeColumn();


### PR DESCRIPTION
Add support for a sticky header on IE while scrolling down the page since IE does not support the css position: sticky
Fix the reference dropdown menu color
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [x] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
