### PR TITLE
Add description of qa/dev site to headers

### DIFF
--- a/src/main/content/_assets/css/doc-header.css
+++ b/src/main/content/_assets/css/doc-header.css
@@ -21,6 +21,10 @@
     padding-top: 0;
 }
 
+.qa-descriptor {
+    top: 10px;
+}
+
 .container-fluid > .navbar-header {
     padding-top: 10px;
 }

--- a/src/main/content/_assets/css/openliberty.css
+++ b/src/main/content/_assets/css/openliberty.css
@@ -373,9 +373,13 @@ nav .container-fluid {
     box-shadow: none;
 }
 
-.navbar-default .navbar-nav > li > a.qa-descriptor {
+.qa-descriptor {
+    position: absolute;
+    top: 30px;
+    right: 30px;
     color: blue;
     background-color: orange;
+    padding: 10px 15px;    
 }
 
 .container-fluid > .navbar-header {

--- a/src/main/content/_assets/css/openliberty.css
+++ b/src/main/content/_assets/css/openliberty.css
@@ -373,6 +373,11 @@ nav .container-fluid {
     box-shadow: none;
 }
 
+.navbar-default .navbar-nav > li > a.qa-descriptor {
+    color: blue;
+    background-color: orange;
+}
+
 .container-fluid > .navbar-header {
     padding-left: 30px;
 }

--- a/src/main/content/_includes/doc_header.html
+++ b/src/main/content/_includes/doc_header.html
@@ -17,7 +17,16 @@
                 </div>
             </div>
             <div id="navbar" class="navbar-collapse collapse">
-                <ul class="nav navbar-nav navbar-left text-right">                    
+                <ul class="nav navbar-nav navbar-left text-right">  
+                    {% if site.url contains 'qa-guides.mybluemix.net' %}
+                    <li>
+                        <a class="qa-descriptor" href="#">QA Site</a></li>  
+                    <li>                
+                    {% elsif site.url contains 'openlibertydev.mybluemix.net' %}
+                    <li>
+                        <a class="qa-descriptor" href="#">Dev Site</a></li>  
+                    <li>                
+                    {% endif %}
                     <li>
                         <a href="/guides">Guides</a>
                     </li>
@@ -49,7 +58,7 @@
                     </button>                        
                 {% endif %}  
 
-                <ol class="breadcrumb fluid-container">     
+                <ol class="breadcrumb fluid-container">   
                     <li>
                         <a href="/docs">Docs</a>
                     </li>

--- a/src/main/content/_includes/doc_header.html
+++ b/src/main/content/_includes/doc_header.html
@@ -34,7 +34,7 @@
                             </ul>
                     </li>                    
                 </ul>
-                {% if site.url contains 'qa-guides.mybluemix.net' or site.url contains 'localhost' %}
+                {% if site.url contains 'qa-guides.mybluemix.net' %}
                     <div class="qa-descriptor">QA Site</div>               
                 {% elsif site.url contains 'openlibertydev.mybluemix.net' %}
                     <div class="qa-descriptor">Dev Site</div>

--- a/src/main/content/_includes/doc_header.html
+++ b/src/main/content/_includes/doc_header.html
@@ -17,16 +17,7 @@
                 </div>
             </div>
             <div id="navbar" class="navbar-collapse collapse">
-                <ul class="nav navbar-nav navbar-left text-right">  
-                    {% if site.url contains 'qa-guides.mybluemix.net' %}
-                    <li>
-                        <a class="qa-descriptor" href="#">QA Site</a></li>  
-                    <li>                
-                    {% elsif site.url contains 'openlibertydev.mybluemix.net' %}
-                    <li>
-                        <a class="qa-descriptor" href="#">Dev Site</a></li>  
-                    <li>                
-                    {% endif %}
+                <ul class="nav navbar-nav navbar-left text-right"> 
                     <li>
                         <a href="/guides">Guides</a>
                     </li>
@@ -41,8 +32,13 @@
                                 <li><a href="/docs/ref/config/">Server Config</a></li>
                                 <li><a href="/docs/ref/feature/">Server Features</a></li>
                             </ul>
-                    </li>
+                    </li>                    
                 </ul>
+                {% if site.url contains 'qa-guides.mybluemix.net' or site.url contains 'localhost' %}
+                    <div class="qa-descriptor">QA Site</div>               
+                {% elsif site.url contains 'openlibertydev.mybluemix.net' %}
+                    <div class="qa-descriptor">Dev Site</div>
+                {% endif %}
             </div>
             <!-- Add breadcrumb for all pages except /docs -->
             {% if page.url != '/docs/' %}

--- a/src/main/content/_includes/header.html
+++ b/src/main/content/_includes/header.html
@@ -15,20 +15,19 @@
         <div id="navbar" class="navbar-collapse collapse">
                 
             <ul class="nav navbar-nav navbar-right text-right">
-                {% if site.url contains 'qa-guides.mybluemix.net' %}
-                    <li><a class="qa-descriptor" href="#">QA Site</a></li>               
-                {% endif %}
-                {% if site.url contains 'openlibertydev.mybluemix.net' %}
-                    <li><a class="qa-descriptor" href="#">Dev Site</a></li>                
-                {% endif %}
                 <li><a href="/about">About</a></li>
                 <li><a href="/docs">Docs</a></li>
                 <li><a href="/downloads">Downloads</a></li>
                 <li><a href="/community">Community</a></li>
                 <li><a href="/contribute">Contribute</a></li>
                 <li><a href="/blog">Blog</a></li>
-                <li class="hidden-xs"><a id="navbar_github_link" href="https://github.com/OpenLiberty" target="new" aria-label="Open Liberty GitHub Repository"></a></li>
-            </ul>
+                <li class="hidden-xs"><a id="navbar_github_link" href="https://github.com/OpenLiberty" target="new" aria-label="Open Liberty GitHub Repository"></a></li>                
+            </ul>            
+            {% if site.url contains 'qa-guides.mybluemix.net' or site.url contains 'localhost' %}
+                <div class="qa-descriptor">QA Site</div>               
+            {% elsif site.url contains 'openlibertydev.mybluemix.net' %}
+                <div class="qa-descriptor">Dev Site</div>
+            {% endif %}
         </div>
     </div>
   </nav>

--- a/src/main/content/_includes/header.html
+++ b/src/main/content/_includes/header.html
@@ -23,7 +23,7 @@
                 <li><a href="/blog">Blog</a></li>
                 <li class="hidden-xs"><a id="navbar_github_link" href="https://github.com/OpenLiberty" target="new" aria-label="Open Liberty GitHub Repository"></a></li>                
             </ul>            
-            {% if site.url contains 'qa-guides.mybluemix.net' or site.url contains 'localhost' %}
+            {% if site.url contains 'qa-guides.mybluemix.net' %}
                 <div class="qa-descriptor">QA Site</div>               
             {% elsif site.url contains 'openlibertydev.mybluemix.net' %}
                 <div class="qa-descriptor">Dev Site</div>

--- a/src/main/content/_includes/header.html
+++ b/src/main/content/_includes/header.html
@@ -13,7 +13,14 @@
             {% endunless %}
         </div>
         <div id="navbar" class="navbar-collapse collapse">
+                
             <ul class="nav navbar-nav navbar-right text-right">
+                {% if site.url contains 'qa-guides.mybluemix.net' %}
+                    <li><a class="qa-descriptor" href="#">QA Site</a></li>               
+                {% endif %}
+                {% if site.url contains 'openlibertydev.mybluemix.net' %}
+                    <li><a class="qa-descriptor" href="#">Dev Site</a></li>                
+                {% endif %}
                 <li><a href="/about">About</a></li>
                 <li><a href="/docs">Docs</a></li>
                 <li><a href="/downloads">Downloads</a></li>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
doc header:
![image](https://user-images.githubusercontent.com/6392944/43979555-bd3f7c0e-9cb0-11e8-9a30-abd8636c450f.png)

normal header:
![image](https://user-images.githubusercontent.com/6392944/43979567-c665a574-9cb0-11e8-9822-3657bdb1bfd6.png)

#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
