### PR TITLE
Add description of qa/dev site to headers

### DIFF
--- a/src/main/content/_assets/css/openliberty.css
+++ b/src/main/content/_assets/css/openliberty.css
@@ -373,6 +373,11 @@ nav .container-fluid {
     box-shadow: none;
 }
 
+.navbar-default .navbar-nav > li > a.qa-descriptor {
+    color: blue;
+    background-color: orange;
+}
+
 .container-fluid > .navbar-header {
     padding-left: 30px;
 }

--- a/src/main/content/_includes/doc_header.html
+++ b/src/main/content/_includes/doc_header.html
@@ -17,7 +17,16 @@
                 </div>
             </div>
             <div id="navbar" class="navbar-collapse collapse">
-                <ul class="nav navbar-nav navbar-left text-right">                    
+                <ul class="nav navbar-nav navbar-left text-right">  
+                    {% if site.url contains 'qa-guides.mybluemix.net' %}
+                    <li>
+                        <a class="qa-descriptor" href="#">QA Site</a></li>  
+                    <li>                
+                    {% elsif site.url contains 'openlibertydev.mybluemix.net' %}
+                    <li>
+                        <a class="qa-descriptor" href="#">Dev Site</a></li>  
+                    <li>                
+                    {% endif %}
                     <li>
                         <a href="/guides">Guides</a>
                     </li>

--- a/src/main/content/_includes/header.html
+++ b/src/main/content/_includes/header.html
@@ -13,7 +13,14 @@
             {% endunless %}
         </div>
         <div id="navbar" class="navbar-collapse collapse">
+                
             <ul class="nav navbar-nav navbar-right text-right">
+                {% if site.url contains 'qa-guides.mybluemix.net' %}
+                    <li><a class="qa-descriptor" href="#">QA Site</a></li>               
+                {% endif %}
+                {% if site.url contains 'openlibertydev.mybluemix.net' %}
+                    <li><a class="qa-descriptor" href="#">Dev Site</a></li>                
+                {% endif %}
                 <li><a href="/about">About</a></li>
                 <li><a href="/docs">Docs</a></li>
                 <li><a href="/downloads">Downloads</a></li>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Normal header:
![image](https://user-images.githubusercontent.com/6392944/43977334-6ed3c496-9ca9-11e8-8dc8-9dcced76a9f7.png)

Doc header:
![image](https://user-images.githubusercontent.com/6392944/43977394-aed1c71e-9ca9-11e8-9db4-672644cb0630.png)


#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
