### PR TITLE
Escape site urls when checking for qa/dev site

### DIFF
--- a/src/main/content/_includes/doc_header.html
+++ b/src/main/content/_includes/doc_header.html
@@ -34,9 +34,9 @@
                             </ul>
                     </li>                    
                 </ul>
-                {% if site.url contains 'qa-guides.mybluemix.net' %}
+                {% if site.url contains 'qa-guides.mybluemix.net' | escape %}
                     <div class="qa-descriptor">QA Site</div>               
-                {% elsif site.url contains 'openlibertydev.mybluemix.net' %}
+                {% elsif site.url contains 'openlibertydev.mybluemix.net' | escape %}
                     <div class="qa-descriptor">Dev Site</div>
                 {% endif %}
             </div>

--- a/src/main/content/_includes/header.html
+++ b/src/main/content/_includes/header.html
@@ -23,9 +23,9 @@
                 <li><a href="/blog">Blog</a></li>
                 <li class="hidden-xs"><a id="navbar_github_link" href="https://github.com/OpenLiberty" target="new" aria-label="Open Liberty GitHub Repository"></a></li>                
             </ul>            
-            {% if site.url contains 'qa-guides.mybluemix.net' %}
+            {% if site.url contains 'qa-guides.mybluemix.net' | escape %}
                 <div class="qa-descriptor">QA Site</div>               
-            {% elsif site.url contains 'openlibertydev.mybluemix.net' %}
+            {% elsif site.url contains 'openlibertydev.mybluemix.net' | escape %}
                 <div class="qa-descriptor">Dev Site</div>
             {% endif %}
         </div>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
We need to escape the urls because they contain dashes and periods.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
