### PR TITLE
Remove escape from the qa/dev site check

### DIFF
--- a/src/main/content/_includes/doc_header.html
+++ b/src/main/content/_includes/doc_header.html
@@ -34,9 +34,9 @@
                             </ul>
                     </li>                    
                 </ul>
-                {% if site.url contains 'qa-guides.mybluemix.net' | escape %}
+                {% if site.url contains 'qa-guides' %}
                     <div class="qa-descriptor">QA Site</div>               
-                {% elsif site.url contains 'openlibertydev.mybluemix.net' | escape %}
+                {% elsif site.url contains 'openlibertydev' %}
                     <div class="qa-descriptor">Dev Site</div>
                 {% endif %}
             </div>

--- a/src/main/content/_includes/header.html
+++ b/src/main/content/_includes/header.html
@@ -22,10 +22,10 @@
                 <li><a href="/contribute">Contribute</a></li>
                 <li><a href="/blog">Blog</a></li>
                 <li class="hidden-xs"><a id="navbar_github_link" href="https://github.com/OpenLiberty" target="new" aria-label="Open Liberty GitHub Repository"></a></li>                
-            </ul>            
-            {% if site.url contains 'qa-guides.mybluemix.net' | escape %}
+            </ul>   
+            {% if site.url contains 'qa-guides' %}
                 <div class="qa-descriptor">QA Site</div>               
-            {% elsif site.url contains 'openlibertydev.mybluemix.net' | escape %}
+            {% elsif site.url contains 'openlibertydev' %}
                 <div class="qa-descriptor">Dev Site</div>
             {% endif %}
         </div>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
