### PR TITLE
Style changes to end of guide section

### DIFF
--- a/src/main/content/_assets/css/end-of-guide.css
+++ b/src/main/content/_assets/css/end-of-guide.css
@@ -10,7 +10,7 @@
  *******************************************************************************/
 
 #end_of_guide {
-    width: 100%;        
+    width: 100%;
     margin-bottom: 100px;
 }
 
@@ -18,8 +18,8 @@
     box-shadow: inset 0px 80px 0px 0px #F7F9E5, 0px 5px 11px -3px rgba(0,0,0,0.27);
     margin-top: 0;
     margin-bottom: 35px;
-    height: 80px;  
-    padding-top: 10px;
+    height: 80px;
+    padding-top: 31px;
     padding-left: 37px;
     font-family: BunueloLight;
     font-size: 35px;

--- a/src/main/content/_assets/css/guide-card.css
+++ b/src/main/content/_assets/css/guide-card.css
@@ -28,12 +28,12 @@
     padding-left: 14px;
     padding-right: 20px;
     display: block;
-    border-left: solid 9px #eeeff3;
+    border-left: solid 9px #9ea6bb;
     box-shadow:0 2px 4px 0 rgba(63,70,89,0.31);
     transition: box-shadow .2s, border .2s;
 }
 
-.guide_item:hover {
+.guide_item:hover, .small_guide_item:hover {
     box-shadow:0 2px 4px 0 rgba(63,70,89,0.59);
     border-left: solid 9px #e6eda8;
 }

--- a/src/main/content/_assets/js/common-multipane.js
+++ b/src/main/content/_assets/js/common-multipane.js
@@ -73,7 +73,7 @@ function resizeGuideSections() {
         });
     }
 }
-    
+
 function handleFloatingCodeColumn() {
     if($(window).width() > twoColumnBreakpoint) {
         // CURRENTLY IN DESKTOP VIEW
@@ -107,9 +107,9 @@ function getScrolledVisibleSectionID(event) {
             var windowHeight   = $(window).height();
             var elemHeight = elem.outerHeight();
             var rect = elem[0].getBoundingClientRect();
-            var top = rect.top; 
+            var top = rect.top;
             var bottom = rect.bottom;
-            var visibleElemHeight = 0;           
+            var visibleElemHeight = 0;
             if(top > 0){
                  // Top of element is below the top of the viewport
                  // Calculate the visible element height as the min of the whole element (if the whole element is in the viewport) and the top of the element to the bottom of the window (if only part of the element is visible and extends beyond the bottom of the viewport).
@@ -138,7 +138,6 @@ function createEndOfGuideContent(){
     leftSide.prepend(whatYouLearned);
     $("#great-work-you-re-done, #great-work-youre-done").parent().remove(); // Remove section from the main guide column.
     $("#toc_container a[href='#great-work-you-re-done'], #toc_container a[href='#great-work-youre-done']").parent().remove(); // Remove from TOC.
-
     // Concatenate the guide title and guide attribution license and append it to the end of guide.
     var guideAttributionText = $("#guide-attribution").siblings().find('p').text();
     if(guideAttributionText){
@@ -168,7 +167,7 @@ $(document).ready(function() {
         var atTop = $(window).scrollTop() === 0;
         atTop ? $("#down_arrow").fadeIn() : $("#down_arrow").fadeOut();
     }
-        
+
     function addGuideRatingsListener(){
         $("#feedback_ratings img").on('click', function(event){
             var rating = $(this).data('guide-rating');
@@ -178,11 +177,15 @@ $(document).ready(function() {
             if(typeof ga === "function"){
                 ga(1, "Guide Review", rating, 3);
             }
-            $("#feedback_ratings img").not($(this)).css('opacity', '.25');
+            $("#feedback_ratings img").not($(this)).css('opacity', '.30');
             $(this).css('opacity', '1');
         });
     }
 
+    $("#feedback_ratings img").hover (function(event) {
+      $("#feedback_ratings img").not($(this)).css('opacity', '.50');
+      $(this).css('opacity', '1');
+    });
 
     $(window).on('resize', function(){
         handleFloatingTableOfContent(); // Handle table of content view changes.
@@ -194,7 +197,7 @@ $(document).ready(function() {
 
     $(window).on('scroll', function(event) {
         handleDownArrow();
-        handleFloatingTableOfContent(); 
+        handleFloatingTableOfContent();
         handleFloatingTOCAccordion();
         handleFloatingCodeColumn();
     });

--- a/src/main/content/_includes/end-of-guide.html
+++ b/src/main/content/_includes/end-of-guide.html
@@ -3,12 +3,17 @@
         <div id="end_of_guide_left_section">
             <p id="guide_attribution"></p>
             <h3 id="improve_guide_feedback">What could make this guide better?</h3>
-            <p><a href="https://github.com/OpenLiberty/guide-{{page.url | replace: '/guides/', ''}}/issues">Raise an issue</a> to share feedback</p>
-            <p><a href="https://github.com/OpenLiberty/guide-{{page.url | replace: '/guides/', ''}}/pulls">Create a pull request</a> to contribute to this guide</p>
-    
+            {% if page.layout == 'guide-multipane' %}
+                <p><a target="_blank" rel="noopener noreferrer" href="https://github.com/OpenLiberty/guide-{{page.url | replace: '/guides/', ''}}/issues">Raise an issue</a> to share feedback</p>
+                <p><a target="_blank" rel="noopener noreferrer" href="https://github.com/OpenLiberty/guide-{{page.url | replace: '/guides/', ''}}/pulls">Create a pull request</a> to contribute to this guide</p>
+            {% elsif page.layout == 'iguide-multipane' %}
+                <p><a target="_blank" rel="noopener noreferrer" href="https://github.com/OpenLiberty/iguide-{{page.url | replace: '/guides/', ''}}/issues">Raise an issue</a> to share feedback</p>
+                <p><a target="_blank" rel="noopener noreferrer" href="https://github.com/OpenLiberty/iguide-{{page.url | replace: '/guides/', ''}}/pulls">Create a pull request</a> to contribute to this guide</p>
+            {% endif %}
+
             <h3 id="need_help">Need help?</h3>
-            <p><a href="https://stackoverflow.com/questions/tagged/open-liberty">Ask a question on Stack Overflow</a></p>
-    
+            <p><a target="_blank" rel="noopener noreferrer" href="https://stackoverflow.com/questions/tagged/open-liberty">Ask a question on Stack Overflow</a></p>
+
             <h3 id="feedback_rating_question">What did you think of this guide?</h3>
             <div id="feedback_ratings">
                 <img src="/img/1_Extreme_Dislike.png" alt="Extreme Dislike" data-guide-rating="1">
@@ -16,11 +21,15 @@
                 <img src="/img/3_Like.png" alt="Like" data-guide-rating="3">
                 <img src="/img/4_Extreme_Like.png" alt="Extreme Like" data-guide-rating="4">
             </div>
-            
+
         </div>
         <div id="end_of_guide_right_section">
-            <h3>Where to next?</h3>
+            <h3 id="where_to_next">Where to next?</h3>
 
+            {% if page.layout == 'iguide-multipane' %}
+                <p><a target="_blank" rel="noopener noreferrer" href="https://github.com/OpenLiberty/iguide-{{page.url | replace: '/guides/', ''}}/tree/master/finish">Download the sample application for this guide on github</a></p>
+                </br>
+            {% endif %}
             {% if page.categories %}
             <p>Keep exploring <b>{{ page.categories }}</b> with these guides.</p>
             {% endif %}
@@ -43,8 +52,10 @@
                                 <img class="duration_clock_icon" src="/img/guide_duration_clock_icon_small.svg" alt="Duration">
                                 <span class="guide_duration">{{related-guide-metadata.duration}}</span>
                                 {% if related-guide-metadata.layout == 'interactive-guide' or related-guide-metadata.layout == 'iguide-multipane' %}
-                                <img class="interactive_bolt_icon" src="/img/guide_lightning_bolt.svg" alt="Interactive">
-                                <span class="guide_interactive">Interactive</span>
+                                <div class="guide_interactive_container">
+                                  <img class="interactive_bolt_icon" src="/img/guide_lightning_bolt.svg" alt="Interactive">
+                                  <span class="guide_interactive">Interactive</span>
+                                </div>
                                 {% endif %}
                             </a>
                         </div>


### PR DESCRIPTION
#### I used these redlines: https://ibm.ent.box.com/file/292168237908
Changes made:
- _end-of-guide.css_: fix the padding for the end of guide section header
- _guide-card.css_: changed related-guide card styling
- _common-multipane.js_: added hover event listener for ratings
- _end-of-guide.html_: made sure orange links were correct and opened in new tab, added download sample app link, and fixed position of 'interactive' icon on cards
#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [x] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
