### PR TITLE
Fix padding on static/interactive multipane guides in single column view

### DIFF
--- a/src/main/content/_assets/css/guide-multipane.css
+++ b/src/main/content/_assets/css/guide-multipane.css
@@ -515,6 +515,10 @@ header {
     
 @media (max-width: 1170px) {
 
+    #background_container > .row {
+        margin: 0;
+    }
+
     .qa-descriptor {
         display: none;
     }
@@ -567,7 +571,6 @@ header {
         width: 51px;
         height: 42px;
         background-color: #96bc32;
-        position: absolute;
         float: right;
         right: 39.5px;
         padding: 14px 16px 13px 20px;
@@ -587,21 +590,22 @@ header {
         width: auto;
         padding-top: 10px;
         padding-bottom: 60px;
-        padding-left: 15px;
-        padding-right: 15px;
         box-shadow: none;
     } 
-
-    #guide_column div.sect1, .code_column .CodeRay code {
-        padding-left: 0;
-        padding-right: 0;
-        margin-left: 0;
-        margin-right: 0;
-    }
 
     #guide_title, #duration_container, #mobile_github_section, #guide_content .sect1 h2, #guide_column .paragraph {
         padding-left: 24px;
         padding-right: 24px;
+    }
+
+    .listingblock {
+        margin-left: -45px;
+        margin-right: -45px;
+    }
+
+    .listingblock pre code {
+        padding-left: 0;
+        padding-right: 0;
     }
 
     .mobile_code_snippet {

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -104,7 +104,9 @@ $(document).ready(function() {
         var duplicate_code_block = code_block.clone();
         duplicate_code_block.removeClass('dimmed_code_column'); // Remove the blur from the original code block;
         duplicate_code_block.addClass('mobile_code_snippet'); // Add class to this code snippet in the guide column to only show up in mobile view.
+        duplicate_code_block.removeClass('code_columnn');
         duplicate_code_block.removeAttr('filename');
+        duplicate_code_block.find('.code_column_title_container').remove();
 
         // Wrap each leftover piece of text in a span to handle selecting a range of lines.
         duplicate_code_block.find('code').contents().each(function(){


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Before the padding wasn't perfect, and some of the elements were all the way on the left side of the screen. This will fix that by re-enabling the padding on the whole column and putting specific margins/padding on the elements that need to be full width.
#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [x] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
