### PR TITLE
Add redirect from /docs/intro/ to /docs/

### DIFF
--- a/src/main/java/io/openliberty/website/TLSFilter.java
+++ b/src/main/java/io/openliberty/website/TLSFilter.java
@@ -28,10 +28,11 @@ public class TLSFilter implements Filter {
     // A list of deprecated URLs that need to be redirected using the HTTP 302.
     private final Map<String, String> TEMP_REDIRECTS = 
         new HashMap<String, String>() {{
+            put("/index.html/", "/index.html");
             put("/docs/ref/javaee/", "/docs/ref/javaee/8/");
             put("/docs/ref/microprofile/", "/docs/ref/microprofile/1.3/");
-            put("/docs/ref/", "/docs/");        
-            put("/index.html/", "/index.html");  
+            put("/docs/ref/", "/docs/"); 
+            put("/docs/intro/", "/docs/");
             put("/guides/microprofile-intro.html", "/guides/cdi-intro.html");
             // put("old uri", "new uri");
     }};


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
