### PR TITLE
Update openliberty.io - new redirect and code refactoring

### DIFF
--- a/src/main/content/_assets/css/intro.css
+++ b/src/main/content/_assets/css/intro.css
@@ -4,7 +4,7 @@ section.banner {
     border-bottom: 3px solid #d4d7e3;
 }
 
-#guide_title {
+#intro_title {
     font-family: BunueloLight;
     font-size: 35px;
     color: #1b1c34;
@@ -14,13 +14,13 @@ section.banner {
     margin-bottom: 41px;
 }
 
-#guide_meta {
+#intro_meta {
     margin: 0 auto;
     width: 72%; /* calculated to match .sect1 - 80% width of center column which is 90% of background_container */
     max-width: 1082px;
 }
 
-#guide_meta a {
+#intro_meta a {
     font-weight: 500;
     color: #E3700D;
     transition: color .2s;
@@ -50,65 +50,108 @@ section.banner {
     max-width: 1315px;
 }
 
-#guide_column {
+#intro_column {
     padding-top: 0px;
     padding-bottom: 0px;
 }
 
-#guide_content div.sect1 {
-    padding-left: 10%;
-    padding-right: 10%;
-    margin-bottom: 0px;
+#intro_content .sect1 > .sectionbody {
+    padding-top: 19px;
 }
 
-#guide_content div.sect1:not(#guide_meta) {
+#intro_content div.sect1 {
+    padding-left: 10%;
+    padding-right: 10%;
+    padding-bottom: 50px;
+    margin-left: -15px;
+    margin-right: -15px;
+    margin-bottom: 0px;
+    background-color: white;
+}
+
+#intro_content div.sect1:not(#intro_meta) {
     box-shadow: inset 0px 52px 0px 0px #F7F9E5;
 }
 
-#guide_content div.sect1:not(#guide_meta):not(:first-child) {
+#intro_content div.sect1:not(#intro_meta):not(:first-child) {
     border-top: 3px solid #d4d7e3;
 }
 
-#guide_content h1, 
-#guide_content h2, 
-#guide_content h3, 
-#guide_content h4, 
-#guide_content h5 {
+#intro_content h1, 
+#intro_content h2, 
+#intro_content h3, 
+#intro_content h4, 
+#intro_content h5 {
     color: #1B1C34;
 }
 
-#guide_content h1 {
-    font-family: BunueloLight;
-}
-
-#guide_content h2 {
+#intro_content h2 {
     font-family: BunueloBold;
     line-height: 26px;
+    font-size: 20px;
 }
 
-#guide_content h4 {
-    margin-bottom: 3px;
-}
-
-#guide_content h5 {
+#intro_content h3 {
+    font-size: 16px;
+    line-height: 26px;
+    font-weight: 500;
+    margin-top: 32px;
     margin-bottom: 0px;
 }
 
-#guide_content .sect1 h2 {
+#intro_content h4 {
+    font-size: 16px;
+    font-weight: 500;
+    margin-top: 18px;
+    margin-bottom: 3px;
+}
+
+#intro_content h5 {
+    margin-bottom: 0px;
+}
+
+#intro_content p {
+    padding-top: 15px;
+    padding-bottom: 15px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    line-height: 26px;
+}
+
+#intro_content a {
+    font-weight: 500;
+    color: #E3700D;
+    transition: color .2s;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+}
+
+#intro_content a:hover {
+    color: #F4914D;
+}
+
+#intro_content code {
+    /* Bootstrap override */
+    background-color: #F3F4F7;
+    color: #5e6b8d;
+    word-wrap: break-word;
+}
+
+#intro_content .sect1 h2 {
     padding-top: 14px;
     margin-top: 0px;
     margin-bottom: 0px;
 }
 
-#guide_content .sect3 {
+#intro_content .sect3 {
     padding-top: 10px;
 }
 
-#guide_content .sect4 p {
+#intro_content .sect4 p {
     padding-top: 5px;
 }
 
-#guide_content img {
+#intro_content img {
     width: 100%;
     max-width: 650px;
     margin: 0 auto;

--- a/src/main/content/_assets/js/intro.js
+++ b/src/main/content/_assets/js/intro.js
@@ -1,0 +1,3 @@
+$(document).ready(function() {
+    $('#preamble').detach().insertBefore('#duration_container');
+});

--- a/src/main/content/_drafts/blog_draft_kevin_mpee.adoc
+++ b/src/main/content/_drafts/blog_draft_kevin_mpee.adoc
@@ -9,6 +9,7 @@ blog_description: "Get Kevin Sutter's view on how the MicroProfile and Jakarta E
 ---
 = What's next for MicroProfile and Jakarta EE?
 Kevin Sutter <https://github.com/kwsutter>
+
 Eclipse MicroProfile co-lead and EE4J PMC member
 
 This is one of the most common questions I get on forums, conferences---even internally at IBM.  Eclipse MicroProfile is fairly well-established with several key features and releases under its belt and the future of Java EE is now being established with Eclipse Jakarta EE.  When will these two forces combine?  This is a difficult question.  Hopefully this post will help explain the circumstances that must occur for this integration.

--- a/src/main/content/_drafts/blog_draft_kevin_mpee.adoc
+++ b/src/main/content/_drafts/blog_draft_kevin_mpee.adoc
@@ -7,10 +7,8 @@ seo-title: What's next for MicroProfile and Jakarta EE? - OpenLiberty.io.
 seo-description: Get Kevin Sutter's view on how the MicroProfile and Jakarta EE projects could be combined at some point. He describes the progress in establishing each of the two projects, the issues to consider as the projects become more established, and current steps that are being made towards a more integrated future.
 blog_description: "Get Kevin Sutter's view on how the MicroProfile and Jakarta EE projects could be combined at some point. He describes the progress in establishing each of the two projects, the issues to consider as the projects become more established, and current steps that are being made towards a more integrated future."
 ---
-= What's next for MicroProfile and Jakarta EE?
-Kevin Sutter <https://github.com/kwsutter>
-
-Eclipse MicroProfile co-lead and EE4J PMC member
+= What{rsquo}s next for MicroProfile and Jakarta EE?
+Kevin Sutter, Eclipse MicroProfile co-lead and EE4J PMC member <https://github.com/kwsutter>
 
 This is one of the most common questions I get on forums, conferences---even internally at IBM.  Eclipse MicroProfile is fairly well-established with several key features and releases under its belt and the future of Java EE is now being established with Eclipse Jakarta EE.  When will these two forces combine?  This is a difficult question.  Hopefully this post will help explain the circumstances that must occur for this integration.
 
@@ -45,13 +43,13 @@ image::/img/logos/Jakarta_EE_logo.png[align="center",Jakarta EE logo.]
 
 Both of these Eclipse projects have merit and are making progress in their respective domains, with MicroProfile technologies building upon those being contributed to Jakarta EE.  But are the projects themselves ready to be merged?  IMHO, no.  MicroProfile has grown tremendously from its humble beginnings.  We have several new component features and versions that extend the Enterprise Java programming model for microservices development.  And we have done this in a relatively short amount of time: Six major MicroProfile releases with sixteen component releases in less than two years.
 
-Due to the enormity and complexities of this move, Jakarta EE is not yet ready to match this rate of progress.  And, as Jakarta EE has not yet completed the definition of its specification process, it is not yet ready to accept the fast-paced release cycle required by MicroProfile.  The big difference here is that MicroProfile has never tried to be https://en.wikipedia.org/wiki/Standards_organization[a standards body].  MicroProfile produces industry-accepted specifications, not standards.  Jakarta EE is trying to replace the JCP Standards body with a more modern, open, and lightweight implementation-first process.
+Due to the enormity and complexities of this move, Jakarta EE is not yet ready to match this rate of progress.  And, as Jakarta EE has not yet completed the definition of its specification process, it is not yet ready to accept the fast-paced release cycle required by MicroProfile.  The big difference here is that MicroProfile has never tried to be https://en.wikipedia.org/wiki/Standards_organization[a standards body].  MicroProfile produces industry-accepted specifications, not standards.  Jakarta EE is trying to replace the JCP Standards body with a more modern, open, and lightweight _implementation-first_ process.
 
 Until Jakarta EE has demonstrated a specification process that allows the rapid, innovative aspects of the MicroProfile project, MicroProfile will maintain its own project dynamics distinct from the EE4J projects.  MicroProfile can continue to iterate quickly in parallel to working with the Jakarta EE platform to adopt completed MicroProfile technologies into the next release of Jakarta EE. Over time, the need for this distinction is likely to reduce, especially as many of the same teams and people are involved with both projects.  Yours truly is one of the project leads for the MicroProfile project. I also participate on the EE4J PMC as well as the Jakarta EE Steering and Specification Committees.  We are working together to make this happen.
 
 == Baby steps
 
-In the meantime, there are a couple of activities that are demonstrating the coming together of these two projects and technologies...
+In the meantime, there are a few activities that are demonstrating the coming together of these two projects and technologies...
 
 * The JAX-RS project under EE4J is actively investigating the possibility of incorporating the MicroProfile Rest Client effort in an upcoming release.  This is actually the way we wanted and expected the MicroProfile technologies to grow.  We would first rapidly innovate in the MicroProfile arena and, when it was ready, attempt to incorporate the features into the next iteration of the Enterprise Java offering.
 * In a similar vein, the MicroProfile Config component is actively working on a https://www.jcp.org/en/jsr/detail?id=382[Java EE Configuration API JSR].  This effort was kicked off before Oracle announced the decision to move Java EE to the Eclipse Foundation.  A couple of early drafts of their specification have been made available for review.  Depending on the success and timing of finalizing the Jakarta EE specification process, maybe this Configuration API JSR would migrate to this new process.

--- a/src/main/content/_drafts/blog_draft_kevin_mpee.adoc
+++ b/src/main/content/_drafts/blog_draft_kevin_mpee.adoc
@@ -7,8 +7,8 @@ seo-title: What's next for MicroProfile and Jakarta EE? - OpenLiberty.io.
 seo-description: Get Kevin Sutter's view on how the MicroProfile and Jakarta EE projects could be combined at some point. He describes the progress in establishing each of the two projects, the issues to consider as the projects become more established, and current steps that are being made towards a more integrated future.
 blog_description: "Get Kevin Sutter's view on how the MicroProfile and Jakarta EE projects could be combined at some point. He describes the progress in establishing each of the two projects, the issues to consider as the projects become more established, and current steps that are being made towards a more integrated future."
 ---
-= What{rsquo}s next for MicroProfile and Jakarta EE?
-Kevin Sutter, Eclipse MicroProfile co-lead and EE4J PMC member <https://github.com/kwsutter>
+= What\'s next for MicroProfile and Jakarta EE?
+Kevin Sutter <https://github.com/kwsutter>
 
 This is one of the most common questions I get on forums, conferences---even internally at IBM.  Eclipse MicroProfile is fairly well-established with several key features and releases under its belt and the future of Java EE is now being established with Eclipse Jakarta EE.  When will these two forces combine?  This is a difficult question.  Hopefully this post will help explain the circumstances that must occur for this integration.
 
@@ -58,3 +58,5 @@ In the meantime, there are a few activities that are demonstrating the coming to
 == IMHO
 
 In conclusion, I do need to emphasize that this post is my view of where we stand and what needs to be done to better integrate MicroProfile with Jakarta EE.  This is not a collective view of the MicroProfile community, although they were made aware of this pending article.  I do believe that eventually this merging of MicroProfile and Jakarta EE must and will happen.  It’s just a matter of timing. 
+
+Kevin is Eclipse MicroProfile co-lead and EE4J PMC member.

--- a/src/main/content/_layouts/intro.html
+++ b/src/main/content/_layouts/intro.html
@@ -6,7 +6,7 @@ css:
 - doc-header
 js: guide
 ---
-<section class="banner">
+<section class="banner" aria-labelledby="guide_title">
     <!-- Guide header section -->
     <div id="guide_meta" class="sect1">
         <h1 id="guide_title">{{ page.title }}</h1>

--- a/src/main/content/_layouts/intro.html
+++ b/src/main/content/_layouts/intro.html
@@ -1,15 +1,14 @@
 ---
 layout: doc
 css: 
-- guide
 - intro
 - doc-header
-js: guide
+js: intro
 ---
-<section class="banner" aria-labelledby="guide_title">
+<section class="banner" aria-labelledby="intro_title">
     <!-- Guide header section -->
-    <div id="guide_meta" class="sect1">
-        <h1 id="guide_title">{{ page.title }}</h1>
+    <div id="intro_meta" class="sect1">
+        <h1 id="intro_title">{{ page.title }}</h1>
         <div id="duration_container"></div>
     </div>
 </section>
@@ -17,8 +16,8 @@ js: guide
     <div class="centered_column">
         <div class="row">
             <!-- Entire guide section -->
-            <div id="guide_column" class="col-sm-12 position_relative">
-                <div id="guide_content">
+            <div id="intro_column" class="col-sm-12 position_relative">
+                <div id="intro_content">
                     <!-- Guide content section -->
                     {{ content }}
                 </div>

--- a/src/main/java/io/openliberty/website/TLSFilter.java
+++ b/src/main/java/io/openliberty/website/TLSFilter.java
@@ -28,10 +28,11 @@ public class TLSFilter implements Filter {
     // A list of deprecated URLs that need to be redirected using the HTTP 302.
     private final Map<String, String> TEMP_REDIRECTS = 
         new HashMap<String, String>() {{
+            put("/index.html/", "/index.html");
             put("/docs/ref/javaee/", "/docs/ref/javaee/8/");
             put("/docs/ref/microprofile/", "/docs/ref/microprofile/1.3/");
-            put("/docs/ref/", "/docs/");        
-            put("/index.html/", "/index.html");  
+            put("/docs/ref/", "/docs/"); 
+            put("/docs/intro/", "/docs/");
             put("/guides/microprofile-intro.html", "/guides/cdi-intro.html");
             // put("old uri", "new uri");
     }};


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Redirect from /docs/intro to /docs
Recent refactor for the intro doc to use its own javascript/css to not affect normal guides
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
