### PR TITLE
Correct behavior for floating TOC in single column view

### DIFF
--- a/src/main/content/_assets/css/guide-multipane.css
+++ b/src/main/content/_assets/css/guide-multipane.css
@@ -483,12 +483,6 @@ header {
     padding: 5px;
 }
 
-@media (max-width: 767px) {
-    header {
-        position: static; /* Make the header non sticky in mobile view */
-    }
-}
-
 @media (max-width: 1199px) {
     .guide_item {
         width: 100%;
@@ -514,6 +508,9 @@ header {
 }
     
 @media (max-width: 1170px) {
+    header {
+        position: static; /* Make the header non sticky in mobile view */
+    }
 
     #github_clone_popup_container {
         display: none;

--- a/src/main/content/_assets/css/table-of-contents.css
+++ b/src/main/content/_assets/css/table-of-contents.css
@@ -91,6 +91,12 @@
     padding-top: 20px;
 }
 
+.scroller_anchor {
+    height: 0px;
+    margin: 0;
+    padding: 0;
+}
+
 #mobile_toc_accordion_container {
     display: none;
 }
@@ -268,7 +274,7 @@
         width: 100%;
         height: 41px;
         text-align: center;
-        border-top: 1px solid #d4d7e3;
+        border: 1px solid #d4d7e3;
         z-index: 1;
     }
 
@@ -277,11 +283,11 @@
         background: none;
     }
 
-    .floating_accordion {
-        position: fixed;
-        top: 0;
+    .fixed_toc_accordion {
         background-color: white;
-        border:1px solid #d4d7e3;
+        border: 1px solid #d4d7e3;
+        position: fixed;
+        top: 0px;
         overflow-y: auto;
     }
 

--- a/src/main/content/_assets/js/common-multipane.js
+++ b/src/main/content/_assets/js/common-multipane.js
@@ -269,10 +269,10 @@ $(document).ready(function() {
     });
 
     $(window).on('scroll', function(event) {
+        handleFloatingTOCAccordion();
         handleDownArrow();
         handleStickyHeader();
         handleFloatingTableOfContent();
-        handleFloatingTOCAccordion();
         handleFloatingCodeColumn();
     });
 

--- a/src/main/content/_assets/js/toc-multipane.js
+++ b/src/main/content/_assets/js/toc-multipane.js
@@ -64,26 +64,41 @@ function handleTOCScrolling() {
 
 function handleFloatingTOCAccordion() {
     var accordion = $('#mobile_toc_accordion_container');
-    var enableFloatingAccordion = function(){
-        accordion.addClass('floating_accordion');
-        $('.navbar').css('display', 'none');
+
+    var enableFloatingTOCAccordion = function(){ 
+        // Put the TOC accordion back into the page and remove the
+        // scroller_anchor <div>.
+        accordion.removeClass('fixed_toc_accordion');
+        $('.scroller_anchor').css('height', 0);
     };
     var disableFloatingTOCAccordion = function(){
-        accordion.removeClass('floating_accordion'); 
-        $('.navbar').css('display', 'block');
-    };
+        // Change the height of the scroller_anchor to that of the accordion
+        // so there is no change in the overall height of the page.
+        // Otherwise, when you fix the accordion to the top of the page the
+        // overall document height is lessened by the accordion's height
+        // which causes a bounce in the page.
+        $('.scroller_anchor').css('height', accordion.height());
+        // Fix the TOC accordion to the top of the page.
+        accordion.addClass('fixed_toc_accordion'); 
+    };    
+    
     if(inSingleColumnView()){
-        var isMobile = inMobile();
-        var transitionPoint = isMobile ? 428 : 400;        
-        var isPositionFixed = (accordion.css('position') === 'fixed');
-        if ($(this).scrollTop() > transitionPoint && !isPositionFixed) { 
-            enableFloatingAccordion();
-        } else if ($(this).scrollTop() < transitionPoint && isPositionFixed) {
+        // Get the accordion start location.  It is the same as
+        // scroller_anchor, a <div> that initially has a height of 0.
+        var scroller_anchor = $(".scroller_anchor").offset().top;
+        // Check if user has scrolled and the current scroll position is below
+        // where the scroller_anchor starts and the accordion has not yet been
+        // fixed to the top of the page.
+        if ($(this).scrollTop() >= scroller_anchor && accordion.css('position') !== 'fixed') {
             disableFloatingTOCAccordion();
+        } else if ($(this).scrollTop() < scroller_anchor && accordion.css('position') !== 'relative') {
+            // When the user scrolls back up past the scroller_anchor, put the 
+            // accordion back into the page and remove the scroller_anchor <div>.
+            enableFloatingTOCAccordion();
         }
     }
     else{
-        disableFloatingTOCAccordion();
+        enableFloatingTOCAccordion();
     }
 }
 

--- a/src/main/content/_layouts/guide-multipane.html
+++ b/src/main/content/_layouts/guide-multipane.html
@@ -62,6 +62,7 @@ js:
                         </div>
                     </div>
 
+                    <div class="scroller_anchor"></div>
                     <div id="mobile_toc_accordion_container" data-toggle="collapse" data-target="#toc_column" aria-expanded="false" aria-controls="toc_column">
                         <div id="mobile_toc_accordion">
                             <button class="breadcrumb_hamburger toc-toggle collapsed" type="button">

--- a/src/main/content/_layouts/iguide-multipane.html
+++ b/src/main/content/_layouts/iguide-multipane.html
@@ -55,6 +55,8 @@ js:
                         <p>{{ page.description }}</p>
                     </div>
                     
+                    <!-- This div is used to indicate the original position of the scrollable fixed div. -->
+                    <div class="scroller_anchor"></div>
                     <div id="mobile_toc_accordion_container" data-toggle="collapse" data-target="#toc_column" aria-expanded="false" aria-controls="toc_column">
                         <div id="mobile_toc_accordion">
                             <button class="breadcrumb_hamburger toc-toggle collapsed" type="button">


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
In single column view, the sticky header and the floating TOC did not play well.  The floating TOC could be scrolled under the sticky header and was "hidden" for a bit until it hit the top of the page.  Then, the sticky header would disappear. Worked with Steven and decided to un-stick the sticky header in single column view so that it could be scrolled off the page.

The second problem was that when the floating TOC hit the top of the page and became fixed there, the document would appear to jump underneath it.  So, fixed it so that the scrolling is smoother and when the TOC becomes fixed the header for the 1st section is still visible.

#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [x] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
