### PR TITLE
Fix a case where there were 2 x buttons to close the TOC in 2 column …

### DIFF
--- a/src/main/content/_assets/css/table-of-contents.css
+++ b/src/main/content/_assets/css/table-of-contents.css
@@ -147,6 +147,10 @@
     font-weight: 500;
 }
 
+#close_container {
+    display: none;
+}
+
 #close_container:after{
     clear: both;
     content: "";
@@ -426,6 +430,10 @@
         background-color: white;
         margin-left: 0;
         margin-right: 0;
+    }
+
+    #close_container {
+        display: block;
     }
 
     #toc_title {


### PR DESCRIPTION
…view

#### What was fixed?  (Issue # or description of fix)
Before:
![image](https://user-images.githubusercontent.com/6392944/44269374-f1c5c980-a1f9-11e8-952a-17e16ae006f4.png)

After:
![image](https://user-images.githubusercontent.com/6392944/44269361-e8d4f800-a1f9-11e8-92b0-7851932332a4.png)

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
