### PR TITLE
End of guide right side css adjustment

### DIFF
--- a/src/main/content/_assets/css/end-of-guide.css
+++ b/src/main/content/_assets/css/end-of-guide.css
@@ -51,6 +51,14 @@
     margin-top: 41px;
 }
 
+#where_to_next {
+    font-family: BunueloBold;
+    font-size: 20px;
+    color: #1b1c34;
+    letter-spacing: 0;
+    line-height: 26px;
+}
+
 #feedback_ratings > img{
     width: 39px;
     height: 39px;
@@ -103,5 +111,9 @@
     #end_of_guide_right_section {
         width: auto;
         padding: 0 37px;
+    }
+
+    #end_of_guide_right_section h3 {
+        margin-top: 41px;
     }
 }


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
The 'Where to next?' section header on the right side of the End of Guide section did not have the same font as the rest of the headers.  This was more obvious in single column view as the heading did not stand out.  Also, in single column view the 'Where to next?' heading did not have space between it and the 'What did you think of this guide?' faces.  CSS was updated to correct these things.

![image](https://user-images.githubusercontent.com/29490139/44275949-c1872680-a20b-11e8-9be7-5efda16393bf.png)

#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [x] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
