### PR TITLE
Handle multiple code sections

### DIFF
--- a/src/main/content/_assets/css/guide-multipane.css
+++ b/src/main/content/_assets/css/guide-multipane.css
@@ -176,6 +176,7 @@ header {
     letter-spacing:0;
     line-height:24px;
     text-align:left;
+    white-space: pre-wrap;
 }
 
 #guide_content .code_command pre,  #guide_content .code_command code {

--- a/src/main/content/_assets/js/common-multipane.js
+++ b/src/main/content/_assets/js/common-multipane.js
@@ -117,8 +117,9 @@ function getScrolledVisibleSectionID(event) {
     var maxVisibleSectionHeight = 0;
 
     // Multipane view
-    if ($(window).width() > twoColumnBreakpoint) {
-        var sections = $('.sect1:not(#guide_meta):not(#related-guides)');
+    if ($(window).width() > twoColumnBreakpoint) {        
+        // Find the height of each section that has no subsections and the height of subsections and return the max.
+        var sections = $('.sect1:not(#guide_meta):not(#related-guides):not(:has(.sect2)), .sect2');
         sections.each(function(index) {
             var elem = $(sections.get(index));
             var windowHeight   = $(window).height();
@@ -139,7 +140,7 @@ function getScrolledVisibleSectionID(event) {
             }
             if(visibleElemHeight > maxVisibleSectionHeight){
                 maxVisibleSectionHeight = visibleElemHeight;
-                id = elem.children('h2')[0].id;
+                id = elem.children('h2, h3')[0].id;
             }
         });
     }

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -32,13 +32,18 @@ $(document).ready(function() {
             // Clone this code block so the full file can be shown in the right column and only a duplicate snippet will be shown in the single column view or mobile view.
             // The duplicated code block will be shown on the right column.
             var duplicate_code_block = code_block.clone();
-            // code_block.addClass('mobile_code_snippet'); // Add class to code snippet in the guide column to only show up in mobile view.
             code_block.hide();
 
-            var guide_section = code_block.parents('.sect1').first();
-            var header = guide_section.find('h2')[0];
+            var header;
+            var subsection = code_block.parents('.sect2');
+            if(subsection.length > 0){
+                header = subsection.find('h3')[0];
+            }
+            else{
+                var guide_section = code_block.parents('.sect1').first();
+                header = guide_section.find('h2')[0];
+            }                        
             guide_sections.push(header);
-
             code_sections[header.id] = duplicate_code_block;
 
             // Create a title pane for the code section


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Handle having multiple code files  for each guide section (yellow section) but there still should only be one code file on the right for each subsection (h3) of that section.
Fix overflow of hotspots and text wrapping.
Fixes a checkbox in #449 for overflowing hotspots.
#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
