### PR TITLE
Maximize height of section in viewport

### DIFF
--- a/src/main/content/_assets/js/common-multipane.js
+++ b/src/main/content/_assets/js/common-multipane.js
@@ -80,7 +80,7 @@ function resizeGuideSections() {
         var viewportHeight = window.innerHeight;
         var headerHeight = $('header').height();
         var sectionTitleHeight = $("#guide_content h2").first().height();
-        var newSectionHeight = viewportHeight - headerHeight - (2 * sectionTitleHeight);
+        var newSectionHeight = viewportHeight - headerHeight - sectionTitleHeight;
         $('.sect1:not(#guide_meta):not(#related-guides)').css({
                 'min-height': newSectionHeight + 'px'
         });


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
ResizeGuideSections() in common-multipane.js resizes small guide sections to be at least as tall as the viewport so it displays better in multipane viewing.  The algorithm needed to be tweaked to maximize the height of these sections in the viewport.

#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [x] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
