### PR TITLE
Always float TOC in 3-column view

### DIFF
--- a/src/main/content/_assets/js/toc-multipane.js
+++ b/src/main/content/_assets/js/toc-multipane.js
@@ -12,19 +12,13 @@
 function handleFloatingTableOfContent() {
     if ($(window).width() >= 1440) {
         // CURRENTLY IN 3 COLUMN VIEW
-        if ($(window).scrollTop() >= $('#toc_column').offset().top) {
-            // The top of the TOC is scrolling off the screen, enable floating TOC.
-            if(isBackgroundBottomVisible()) {
-                handleTOCScrolling();
-            } else {
-                // The entire viewport is filled with the background, so
-                // do not need to worry about the TOC flowing out of the background.
-                enableFloatingTOC();
-            }
+        // The top of the TOC is scrolling off the screen, enable floating TOC.
+        if(isBackgroundBottomVisible()) {
+            handleTOCScrolling();
         } else {
-            // TOC no longer needs to float,
-            // remove all the custom styling for floating TOC
-            disableFloatingTOC();
+            // The entire viewport is filled with the background, so
+            // do not need to worry about the TOC flowing out of the background.
+            enableFloatingTOC();
         }
     } else {
         // CURRENTLY IN MOBILE VIEW OR 2 COLUMN VIEW


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
In 3-column multipane mode, as the user was scrolling down the page, the TOC was "jumping" as the window scrollTop hit the 100 px mark.  It appeared that the TOC scrolled up under the static header.  To fix, I made the TOC always position fixed in 3-column mode, until we get to the bottom of the page where it scrolls up if necessary.

#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [x] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
