### PR TITLE
Reenable the copy button for code snippets and commands, excluding co…

### DIFF
--- a/src/main/content/_assets/css/guide-multipane.css
+++ b/src/main/content/_assets/css/guide-multipane.css
@@ -438,6 +438,23 @@ header {
     color: #5e6b8d;
 }
 
+#copy_to_clipboard {	
+    position: absolute;	
+    display: block;	
+    background-color: #eeeff3;	
+    background-image: url('/img/guide_copy_button.svg');	
+    background-repeat: no-repeat;	
+    background-position: center center;	
+    height: 63px;	
+    width: 58px;	
+}	
+ #copy_to_clipboard:hover {	
+    border: solid 1px #b2bbd1;	
+}	
+ #copy_to_clipboard:active {	
+    border: solid 1px #5e6b8d;	
+}
+
 .code_column .CodeRay {
     border: none;
     border-radius: 0;

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -406,6 +406,47 @@ $(document).ready(function() {
             }   
         }            
     }
+
+    $('#guide_content pre:not(.code_command pre):not(.hotspot pre)').hover(function(event) {
+         offset = $('#guide_column').position();	
+        target = event.currentTarget;	
+        var current_target_object = $(event.currentTarget);	
+        target_position = current_target_object.position();	
+        target_width = current_target_object.outerWidth();	
+        target_height = current_target_object.outerHeight();	
+         $('#copy_to_clipboard').css({	
+            top: target_position.top + 8,	
+            right: parseInt($('#guide_column').css('padding-right')) + 55	
+        });	
+        $('#copy_to_clipboard').stop().fadeIn();	
+     }, function(event) {	
+         var x = event.clientX - offset.left;	
+        var y = event.clientY - offset.top + $(window).scrollTop();	
+        if(!(x > target_position.left	
+        && x < target_position.left + target_width	
+        && y > target_position.top	
+        && y < target_position.top + target_height)) {	
+            $('#copy_to_clipboard').stop().fadeOut();	
+            $('#copied_to_clipboard_confirmation').stop().fadeOut();	
+        }  	
+     });	
+
+     $('#copy_to_clipboard').click(function(event) {	        	
+        event.preventDefault();	
+        window.getSelection().selectAllChildren(target);	
+        if(document.execCommand('copy')) {	
+            window.getSelection().removeAllRanges();	
+            var current_target_object = $(event.currentTarget);	
+            var position = current_target_object.position();	
+            $('#copied_to_clipboard_confirmation').css({	
+                top: position.top - 25,	
+                right: 50	
+            }).stop().fadeIn().delay(3500).fadeOut();	
+        } else {	
+            alert('To copy press CTRL + C');	
+        }	
+    });
+
     $(window).on('scroll', function(event) {
         handleGithubPopup(false);
         handleSectionSnapping(event);


### PR DESCRIPTION
…de commands to allow readers to copy small code blocks.
Fixes a checkbox in #449
#### What was fixed?  (Issue # or description of fix)
Reenable the copy button on snippets.
#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
