### PR TITLE
Make the code highlighting css more specific

### DIFF
--- a/src/main/content/_assets/css/guide-multipane.css
+++ b/src/main/content/_assets/css/guide-multipane.css
@@ -159,7 +159,7 @@ header {
     word-wrap: break-word;  
 }
 
-#guide_content .command code {
+#guide_content .command .CodeRay code {
     background-color: transparent;
 }
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Make the code highlighting transparent in code blocks more specific as to not affect other text in the guide.
Fixes part of #449. 
Before:
![image](https://user-images.githubusercontent.com/6392944/44488412-4ca65900-a61e-11e8-9235-fecaed341c37.png)

After:
![image](https://user-images.githubusercontent.com/6392944/44488402-44e6b480-a61e-11e8-8ed4-359eb303661a.png)

#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
