### PR TITLE
Multipane: Update the URL as you scroll through the guide's sections.

### DIFF
--- a/src/main/content/_assets/js/common-multipane.js
+++ b/src/main/content/_assets/js/common-multipane.js
@@ -112,39 +112,50 @@ function handleFloatingCodeColumn() {
         }
     }
 }
-
-/* Find the section that is most visible in the viewport and return the id */
+/**
+ * Find the section that is most visible in the viewport and return the id.
+ * Returns "" (empty string, not NULL) if the window scrollTop is within the
+ * guide's meta.
+ */
 function getScrolledVisibleSectionID(event) {
     var id = null;
     var maxVisibleSectionHeight = 0;
 
     // Multipane view
-    if ($(window).width() > twoColumnBreakpoint) {        
-        // Find the height of each section that has no subsections and the height of subsections and return the max.
+    if ($(window).width() > twoColumnBreakpoint) {
         var sections = $('.sect1:not(#guide_meta):not(#related-guides):not(:has(.sect2)), .sect2');
-        sections.each(function(index) {
-            var elem = $(sections.get(index));
-            var windowHeight   = $(window).height();
-            var elemHeight = elem.outerHeight();
-            var rect = elem[0].getBoundingClientRect();
-            var top = rect.top;
-            var bottom = rect.bottom;
-            var visibleElemHeight = 0;
-            if(top > 0){
-                 // Top of element is below the top of the viewport
-                 // Calculate the visible element height as the min of the whole element (if the whole element is in the viewport) and the top of the element to the bottom of the window (if only part of the element is visible and extends beyond the bottom of the viewport).
-                 visibleElemHeight = Math.min(elemHeight, windowHeight - top);
-            }
-            else {
-                // Top of element is at or above the top of the viewport
-                // Calculate the visible element height as the min between the bottom (if the element starts above the viewport and ends before the bottom of the viewport) or the windowHeight(the element extends beyond the top and bottom of viewport in both diretions).
-                visibleElemHeight = Math.min(bottom, windowHeight);
-            }
-            if(visibleElemHeight > maxVisibleSectionHeight){
-                maxVisibleSectionHeight = visibleElemHeight;
-                id = elem.children('h2, h3')[0].id;
-            }
-        });
+        var navHeight = $('.navbar').height();
+        var topBorder = $(sections[0]).offset().top - navHeight;  // Border point between
+                                                                  // guide meta and 1st section
+        if ($(window).scrollTop() < topBorder) {
+            // scroll is within guide meta.
+            id = "";
+        } else {
+            // Find the height of each section that has no subsections and the height of subsections and return the max.
+            sections.each(function(index) {
+                var elem = $(sections.get(index));
+                var windowHeight   = $(window).height();
+                var elemHeight = elem.outerHeight();
+                var rect = elem[0].getBoundingClientRect();
+                var top = rect.top;
+                var bottom = rect.bottom;
+                var visibleElemHeight = 0;
+                if(top > 0){
+                     // Top of element is below the top of the viewport
+                     // Calculate the visible element height as the min of the whole element (if the whole element is in the viewport) and the top of the element to the bottom of the window (if only part of the element is visible and extends beyond the bottom of the viewport).
+                     visibleElemHeight = Math.min(elemHeight, windowHeight - top);
+                }
+                else {
+                    // Top of element is at or above the top of the viewport
+                    // Calculate the visible element height as the min between the bottom (if the element starts above the viewport and ends before the bottom of the viewport) or the windowHeight(the element extends beyond the top and bottom of viewport in both diretions).
+                    visibleElemHeight = Math.min(bottom, windowHeight);
+                }
+                if(visibleElemHeight > maxVisibleSectionHeight){
+                    maxVisibleSectionHeight = visibleElemHeight;
+                    id = elem.children('h2, h3')[0].id;
+                }
+            });
+        }
     }
     return id;
 }

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -386,30 +386,45 @@ $(document).ready(function() {
         }                
     }
 
+    // Hide other code blocks and show the correct code block based on provided id.
+    function showCorrectCodeBlock(id) {
+        try{
+            var code_block = code_sections[id];
+            if(code_block){
+                $('#code_column .code_column').not(code_block).hide();
+                code_block.show();
+            }
+        } catch(e) {
+            console.log(e);
+        }
+    }
+
     // Slow the scrolling over section headers in the guide
     function handleSectionSnapping(event){
         // Multipane view
         if($(window).width() > twoColumnBreakpoint) {
             var id = getScrolledVisibleSectionID(event);
-            if (id) {
-                if ($("html, body").scrollTop() !== 0) {
-                    // Remove previous TOC section highlighted and highlight correct step
-                    updateTOCHighlighting(id);                      
-                }
+            if (id !== null) {
+                var windowHash = window.location.hash;
+                var scrolledToHash = id === "" ? id : '#' + id;
+                if (windowHash !== scrolledToHash) {
+                    // Update the URL hash with new section we scrolled into....
+                    var currentPath = window.location.pathname;
+                    var newPath = currentPath.substring(currentPath.lastIndexOf('/')+1) + scrolledToHash;
+                    // Not setting window.location.hash here because that causes an
+                    // onHashChange event to fire which will scroll to the top of the
+                    // section.  pushState updates the URL without causing an
+                    // onHashChange event.
+                    history.pushState(null, null, newPath);
 
-                // Hide other code blocks and show the correct code block.                  
-                try{
-                    var code_block = code_sections[id];
-                    if(code_block){
-                        $('#code_column .code_column').not(code_block).hide();
-                        code_block.show();
-                    }
-                       
-                } catch(e) {
-                    console.log(e);
-                }                
-            }   
-        }            
+                    // Update the selected TOC entry
+                    updateTOCHighlighting(id);
+
+                    // Match the code block on the right to the new id
+                    showCorrectCodeBlock(id);
+                }
+            }
+        }
     }
     $(window).on('scroll', function(event) {
         handleGithubPopup(false);
@@ -424,6 +439,7 @@ $(document).ready(function() {
             handleFloatingTableOfContent();
             var hash = location.hash;
             accessContentsFromHash(hash);
+            showCorrectCodeBlock(hash.substring(1));  // Remove the '#' in front of the id
         }
 
         if(window.location.hash === ""){


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
As you scroll through the guide sections, the TOC updates to show which section you are on (when in multi-column view).  The URL should also be updating with the correct hash to match the currently selected TOC item.

I updated the current behavior of the guide to not select any TOC item or have any hash on the URL when the window scrollTop is within the  #guide_meta section.

This fix is for static guides only.
#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [x] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
