### PR TITLE
Fix TOC highlighting in static guides

### DIFF
--- a/src/main/content/_assets/css/table-of-contents.css
+++ b/src/main/content/_assets/css/table-of-contents.css
@@ -129,7 +129,7 @@
     margin-top: 4px;
 }
 
-#toc_container > .sectlevel1 > li {
+#toc_container > .sectlevel1 > li, #toc_container .sectlevel2 > li {
     list-style: none;
     font-weight: 300;
     color: #5D6A8E;
@@ -141,13 +141,13 @@
     word-wrap: break-word;
 }
 
-#toc_container > .sectlevel1 > li:not(.liSelected):hover {
+#toc_container > .sectlevel1 > li:not(.liSelected):hover, #toc_container .sectlevel2 > li:hover {
     border-left: 8px solid #fdf2ea;
     font-weight: 500;
     cursor: pointer;
 }
 
-#toc_container > .sectlevel1 > .liSelected {
+#toc_container > .sectlevel1 > .liSelected, #toc_container .sectlevel2 > .liSelected {
     background: #fdf2ea;
     border-left: 8px solid #f4914d;
     font-weight: 500;

--- a/src/main/content/_assets/js/common-multipane.js
+++ b/src/main/content/_assets/js/common-multipane.js
@@ -198,12 +198,12 @@ function shiftWindow() {
  *                      from window.location.
  */
 function accessContentsFromHash(hash) {
-    var $focusSection = $(hash);
-    // Update the TOC
-    updateTOCHighlighting(hash.substring(1));  // Remove the '#' in the hash
-
+    var $focusSection = $(hash);    
+    
     // If section is found, scroll to it
     if ($focusSection.length > 0) {        
+        // Update the TOC
+        updateTOCHighlighting(hash.substring(1));  // Remove the '#' in the hash
         var scrollSpot = $focusSection.offset().top;
         // Implement smooth scrolling to the section's header.
         if (inSingleColumnView()) {

--- a/src/main/content/_assets/js/common-multipane.js
+++ b/src/main/content/_assets/js/common-multipane.js
@@ -199,11 +199,11 @@ function shiftWindow() {
  */
 function accessContentsFromHash(hash) {
     var $focusSection = $(hash);
+    // Update the TOC
+    updateTOCHighlighting(hash.substring(1));  // Remove the '#' in the hash
 
     // If section is found, scroll to it
-    if ($focusSection.length > 0) {
-        // Update the TOC
-        updateTOCHighlighting(hash.substring(1));  // Remove the '#' in the hash
+    if ($focusSection.length > 0) {        
         var scrollSpot = $focusSection.offset().top;
         // Implement smooth scrolling to the section's header.
         if (inSingleColumnView()) {
@@ -219,6 +219,7 @@ function accessContentsFromHash(hash) {
             var stickyHeaderAdjustment = $('.container-fluid').height() || 0;
             scrollSpot -= stickyHeaderAdjustment;
         }
+        $("body").data('scrolling', true); // Prevent the default window scroll from triggering until the animation is done.
         $("html, body").animate({scrollTop: scrollSpot}, 400, function() {
             // Callback after animation.  Change the focus.
             $focusSection.focus();
@@ -230,8 +231,9 @@ function accessContentsFromHash(hash) {
                 // tabindex = -1 means that the element should be focusable,
                 // but not via sequential keyboard navigation.
                 $focusSection.attr('tabindex', '-1');
-                $focusSection.focus();
-            }
+                $focusSection.focus();                
+            }        
+            $("body").data('scrolling', false);   // Allow the default window scroll listener to process scrolls again. 
         });
     } else {
         defaultToFirstPage();

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -427,6 +427,10 @@ $(document).ready(function() {
         }
     }
     $(window).on('scroll', function(event) {
+        // Check if a scroll animation from another piece of code is taking place and prevent normal behavior.
+        if($("body").data('scrolling') === true){
+            return;
+        }
         handleGithubPopup(false);
         handleSectionSnapping(event);
     });


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
The previous implementation of TOC highlighting left a few bugs in the static multipane guide. This pull request will fix the sublevels of the TOC being highlighted when clicked and also prevent the default window scroll listener from running and changing the TOC highlighting while performing the animation in accessContentsFromHash() inside common-multipane.js.
#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
