### PR TITLE
Multipane 3-column view: Hold section location following collapse/expand of TOC

### DIFF
--- a/src/main/content/_assets/js/common-multipane.js
+++ b/src/main/content/_assets/js/common-multipane.js
@@ -11,6 +11,7 @@
 // The background is shortened by 200px
 var backgroundSizeAdjustment = 200;
 var twoColumnBreakpoint = 1170;
+var threeColumnBreakpoint = 1440;
 
 function inSingleColumnView(){
     return($(window).width() <= twoColumnBreakpoint);
@@ -117,7 +118,7 @@ function handleFloatingCodeColumn() {
  * Returns "" (empty string, not NULL) if the window scrollTop is within the
  * guide's meta.
  */
-function getScrolledVisibleSectionID(event) {
+function getScrolledVisibleSectionID() {
     var id = null;
     var maxVisibleSectionHeight = 0;
 

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -403,7 +403,7 @@ $(document).ready(function() {
     function handleSectionSnapping(event){
         // Multipane view
         if($(window).width() > twoColumnBreakpoint) {
-            var id = getScrolledVisibleSectionID(event);
+            var id = getScrolledVisibleSectionID();
             if (id !== null) {
                 var windowHash = window.location.hash;
                 var scrolledToHash = id === "" ? id : '#' + id;

--- a/src/main/content/_assets/js/toc-multipane.js
+++ b/src/main/content/_assets/js/toc-multipane.js
@@ -10,7 +10,7 @@
  *******************************************************************************/
 // Keep the table of contents (TOC) in view while scrolling (Desktop only)
 function handleFloatingTableOfContent() {
-    if ($(window).width() >= 1440) {
+    if ($(window).width() >= threeColumnBreakpoint) {
         // CURRENTLY IN 3 COLUMN VIEW
         // The top of the TOC is scrolling off the screen, enable floating TOC.
         if(isBackgroundBottomVisible()) {
@@ -137,7 +137,7 @@ $(document).ready(function() {
     
     $("#breadcrumb_hamburger").on('click', function(event){
         // Handle resizing of the guide column when collapsing/expanding the TOC in 3 column view.
-        if($(window).width() >= 1440){
+        if($(window).width() >= threeColumnBreakpoint){
             if ($("#toc_column").hasClass('in')) {
                 // TOC is expanded
                 $("#guide_column").addClass('expanded');
@@ -146,6 +146,9 @@ $(document).ready(function() {
                 // TOC is closed
                 $("#guide_column").removeClass('expanded');
             }
+            // Restore user to section they were viewing after collapsing/expanding the TOC.
+            var hash = window.location.hash;
+            accessContentsFromHash(hash);
         }
         // Handle table of content floating if in the middle of the guide.
         handleFloatingTableOfContent();


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
When in the 3-column view of the multipane design, the TOC is located on the left of the page.  The TOC  can be collapsed by selecting the TOC hamburger icon, and then expanded by selecting the same.  When either of these activities occur, the guide content is re-flowed and often the user ends up in a section different from the one they just selected.   Since we cannot prevent the guide text from being re-flowed, add code in the hamburger onclick handler to reset the user to the beginning of the section they were on before expanding/contracting the TOC area.

#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [x] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
