### PR TITLE
Include scroll width when checking window width

### DIFF
--- a/src/main/content/_assets/js/common-multipane.js
+++ b/src/main/content/_assets/js/common-multipane.js
@@ -14,7 +14,7 @@ var twoColumnBreakpoint = 1170;
 var threeColumnBreakpoint = 1440;
 
 function inSingleColumnView(){
-    return($(window).width() <= twoColumnBreakpoint);
+    return(window.innerWidth <= twoColumnBreakpoint);
 }
 
 function inMobile(){
@@ -77,7 +77,7 @@ function isBackgroundBottomVisible() {
 // in two and three column view at least as tall as the viewport.
 function resizeGuideSections() {
         // Two column view or three column view.
-    if ($(window).width() > twoColumnBreakpoint) {
+    if (window.innerWidth > twoColumnBreakpoint) {
         var viewportHeight = window.innerHeight;
         var headerHeight = $('header').height();
         var sectionTitleHeight = $("#guide_content h2").first().height();
@@ -95,7 +95,7 @@ function resizeGuideSections() {
 }
 
 function handleFloatingCodeColumn() {
-    if($(window).width() > twoColumnBreakpoint) {
+    if(window.innerWidth > twoColumnBreakpoint) {
         // CURRENTLY IN DESKTOP VIEW
         if(isBackgroundBottomVisible()) {
             // Set the bottom of the code column to the distance between the top of the end of guide section and the bottom of the page.
@@ -123,7 +123,7 @@ function getScrolledVisibleSectionID() {
     var maxVisibleSectionHeight = 0;
 
     // Multipane view
-    if ($(window).width() > twoColumnBreakpoint) {
+    if (window.innerWidth > twoColumnBreakpoint) {
         var sections = $('.sect1:not(#guide_meta):not(#related-guides):not(:has(.sect2)), .sect2');
         var navHeight = $('.navbar').height();
         var topBorder = $(sections[0]).offset().top - navHeight;  // Border point between
@@ -261,7 +261,7 @@ function defaultToFirstPage() {
 
 $(document).ready(function() {
     function handleDownArrow() {
-        if ($(window).width() < 1171) {
+        if (window.innerWidth <= twoColumnBreakpoint) {
             $("#down_arrow").hide();
             return;
         }

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -403,7 +403,7 @@ $(document).ready(function() {
     function handleSectionSnapping(event){
         // Multipane view
         if(window.innerWidth > twoColumnBreakpoint) {
-            var id = getScrolledVisibleSectionID(event);
+            var id = getScrolledVisibleSectionID();
             if (id !== null) {
                 var windowHash = window.location.hash;
                 var scrolledToHash = id === "" ? id : '#' + id;

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -402,8 +402,8 @@ $(document).ready(function() {
     // Slow the scrolling over section headers in the guide
     function handleSectionSnapping(event){
         // Multipane view
-        if($(window).width() > twoColumnBreakpoint) {
-            var id = getScrolledVisibleSectionID();
+        if(window.innerWidth > twoColumnBreakpoint) {
+            var id = getScrolledVisibleSectionID(event);
             if (id !== null) {
                 var windowHash = window.location.hash;
                 var scrolledToHash = id === "" ? id : '#' + id;

--- a/src/main/content/_assets/js/toc-multipane.js
+++ b/src/main/content/_assets/js/toc-multipane.js
@@ -10,7 +10,7 @@
  *******************************************************************************/
 // Keep the table of contents (TOC) in view while scrolling (Desktop only)
 function handleFloatingTableOfContent() {
-    if ($(window).width() >= threeColumnBreakpoint) {
+    if (window.innerWidth >= threeColumnBreakpoint) {
         // CURRENTLY IN 3 COLUMN VIEW
         // The top of the TOC is scrolling off the screen, enable floating TOC.
         if(isBackgroundBottomVisible()) {
@@ -137,7 +137,7 @@ $(document).ready(function() {
     
     $("#breadcrumb_hamburger").on('click', function(event){
         // Handle resizing of the guide column when collapsing/expanding the TOC in 3 column view.
-        if($(window).width() >= threeColumnBreakpoint){
+        if(window.innerWidth >= threeColumnBreakpoint){
             if ($("#toc_column").hasClass('in')) {
                 // TOC is expanded
                 $("#guide_column").addClass('expanded');


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
In widening the browser window from 2-column to 3-column I noticed that the guide content column did not change width at the appropriate time.   Also, I frequently got "stuck" with a bare column the width of the TOC, but located vertically in the middle of the page.  The cause was that the JavaScript code would check for $(window).width() being greater or less than the set twoColumnBreakpoint or threeColumnBreakpoint.  

$(window).width() does not include the width of the scrollbar present on the page.  CSS media queries react to the width of the browser window including the scrollbars. In other words: The viewport, not the window (the width of the html element).  So to have our JavaScript fire at the same time a CSS media query evaluates to true I changed all the $(window).width() to  window.innerWidth, which returns the width of the window including scrollbars.

#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [x] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
