### PR TITLE
Flatten static guide TOC levels

### DIFF
--- a/src/main/content/_assets/css/table-of-contents.scss
+++ b/src/main/content/_assets/css/table-of-contents.scss
@@ -154,7 +154,7 @@
     }
 }
 
-/* After the sectlevel2 have been shifted to be at the same level as the sectlevel1 li */
+/* After the sectlevel2 have been shifted to from under the sectlevel1 li to directly underneath the sectlevel1 step */
 #toc_container .sectlevel1 > .sectlevel2 {
     padding-left: 0;
 

--- a/src/main/content/_assets/css/table-of-contents.scss
+++ b/src/main/content/_assets/css/table-of-contents.scss
@@ -129,19 +129,41 @@
     margin-top: 4px;
 }
 
-#toc_container > .sectlevel1 > li, #toc_container .sectlevel2 > li {
-    list-style: none;
-    font-weight: 300;
-    color: #5D6A8E;
-    font-size: 14px;
-    min-height: 30px;
-    border-left: 8px solid transparent;
-    padding-left: 19px;
-    padding-right: 19px;
-    word-wrap: break-word;
+#toc_container {
+    .sectlevel1 > li, .sectlevel2 > li {
+        list-style: none;
+        font-weight: 300;
+        color: #5D6A8E;
+        font-size: 14px;
+        min-height: 30px;
+        border-left: 8px solid transparent;        
+        word-wrap: break-word;
+    }
+
+    .sectlevel1 > li {
+        padding-left: 19px;
+        padding-right: 19px;
+    }    
+
+    .sectlevel2 {
+        padding-left: 0;
+    }
+
+    .sectlevel1 .sectlevel2 > li {
+        padding-left: 22px;        
+    }
 }
 
-#toc_container > .sectlevel1 > li:not(.liSelected):hover, #toc_container .sectlevel2 > li:hover {
+/* After the sectlevel2 have been shifted to be at the same level as the sectlevel1 li */
+#toc_container .sectlevel1 > .sectlevel2 {
+    padding-left: 0;
+
+    > li {
+        padding-left: 49px;
+    }
+}
+
+#toc_container > .sectlevel1 > li:not(.liSelected):hover, #toc_container .sectlevel2 > li:not(.liSelected):hover {
     border-left: 8px solid #fdf2ea;
     font-weight: 500;
     cursor: pointer;

--- a/src/main/content/_assets/js/toc-multipane.js
+++ b/src/main/content/_assets/js/toc-multipane.js
@@ -102,7 +102,7 @@ function handleFloatingTOCAccordion() {
  * @param {*} liElement TOC entry selected  
  * @param {*} event       
  */
-function TOCentryClick(liElement, event) {
+function TOCEntryClick(liElement, event) {
     // 'this' is the li element in the #toc_container.  
     // Its first child is the anchor tag pointing to the id of the section to go to.
     var hash = $(liElement).find('a').prop('hash');
@@ -132,8 +132,19 @@ function TOCentryClick(liElement, event) {
 
 }
 
+// Restructure the TOC because Asciidoc nests levels in the TOC and it creates bad CSS behavior.
+function reorganizeTOCElements(){
+    $('#toc_column .sectlevel2').each(function(){
+        var li = $(this).parent();
+        var sectlevel2 = $(this).detach();
+        li.after(sectlevel2);
+    });
+}
+
 
 $(document).ready(function() {
+
+    reorganizeTOCElements();
     
     $("#breadcrumb_hamburger").on('click', function(event){
         // Handle resizing of the guide column when collapsing/expanding the TOC in 3 column view.
@@ -182,7 +193,7 @@ $(document).ready(function() {
     // to set the same handlers there.
     $("#toc_container li").on('click', function(event) {
         // 'this' is the li element in the #toc_container
-        TOCentryClick(this, event);
+        TOCEntryClick(this, event);
     });
     $("#toc_container li").on("keydown", function(event) {
         // 'this' is the li element in the #toc_container

--- a/src/main/content/_assets/js/toc-multipane.js
+++ b/src/main/content/_assets/js/toc-multipane.js
@@ -132,7 +132,7 @@ function TOCEntryClick(liElement, event) {
 
 }
 
-// Restructure the TOC because Asciidoc nests levels in the TOC and it creates bad CSS behavior.
+// Restructure the TOC because Asciidoc nests levels in the TOC and it affects the CSS poorly.
 function reorganizeTOCElements(){
     $('#toc_column .sectlevel2').each(function(){
         var li = $(this).parent();


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Flatten the TOC so that there isn't nesting of levels which makes the selected step look bad when it includes the children steps.
Also start utilizing SCSS so we can nest styling.
#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
