### PR TITLE
Fix getScrolledVisibleSectionID for sections with subsections

### DIFF
--- a/src/main/content/_assets/js/common-multipane.js
+++ b/src/main/content/_assets/js/common-multipane.js
@@ -138,7 +138,7 @@ function getScrolledVisibleSectionID() {
         var sect1s = $('.sect1:not(#guide_meta):not(#related-guides):has(.sect2)');
         var sections = $('.sect1:not(#guide_meta):not(#related-guides), .sect2');
         var navHeight = $('.navbar').height();
-        var topBorder = $(sections[0]).offset().top - navHeight;  // Border point between
+        var topBorder = $("#guide_meta").height() - navHeight;  // Border point between
                                                                   // guide meta and 1st section
         if ($(window).scrollTop() < topBorder) {
             // scroll is within guide meta.
@@ -146,14 +146,23 @@ function getScrolledVisibleSectionID() {
         } else {
             // Determine which section has the majority of the vertical height on 
             // the page.
-            sect1s.each(function(index){
+            sect1s.each(function(){
                 var elem = $(this);
-                var rect = elem[0].getBoundingClientRect();
                 var navHeight = $('.navbar').height();
-                var top = rect.top;
-                if(top >= 0 && top <= navHeight){
+                var elemHeader = elem.find('h2').first();
+                var elemHeaderHeight = elemHeader.height();
+                var elemHeaderTop = elemHeader.offset().top - navHeight;
+
+                
+                var scrollTop = $(window).scrollTop();
+                // var rect = elem[0].getBoundingClientRect();
+                // var sect2 = elem.find('.sect2')[0]; // Find the first sect2 to calculate the distance from the top.
+                // var sect2Top = sect2.getBoundingClientRect().top;                
+                // var top = rect.top - navHeight;
+
+                if(scrollTop >= elemHeaderTop && scrollTop <= (elemHeaderTop + elemHeaderHeight)){
                     // Section is at the top of the page
-                    id = elem.children('h2, h3')[0].id;
+                    id = elemHeader[0].id;
                     return false; // Break out of the loop.
                 }
             });
@@ -164,8 +173,8 @@ function getScrolledVisibleSectionID() {
             }
 
             // Find the height of each section that has no subsections and the height of subsections and return the max.
-            sections.each(function(index) {
-                var elem = $(sections.get(index));
+            sections.each(function() {
+                var elem = $(this);
                 var windowHeight = $(window).height();
 
                 var elemHeight = elem.outerHeight();

--- a/src/main/content/_assets/js/common-multipane.js
+++ b/src/main/content/_assets/js/common-multipane.js
@@ -134,15 +134,36 @@ function getScrolledVisibleSectionID() {
 
     // Multipane view
     if (window.innerWidth > twoColumnBreakpoint) {
+        // Look for any sect1 that has a sect2 subsection, where the sect1 is at the top of the page
+        var sect1s = $('.sect1:not(#guide_meta):not(#related-guides):has(.sect2)');
         var sections = $('.sect1:not(#guide_meta):not(#related-guides), .sect2');
-        var topBorder = $('#guide_meta').outerHeight();  // Border point between
-                                                         // guide meta and 1st section
-        if ($(window).scrollTop() <= topBorder) {
+        var navHeight = $('.navbar').height();
+        var topBorder = $(sections[0]).offset().top - navHeight;  // Border point between
+                                                                  // guide meta and 1st section
+        if ($(window).scrollTop() < topBorder) {
             // scroll is within guide meta.
             id = "";
         } else {
             // Determine which section has the majority of the vertical height on 
             // the page.
+            sect1s.each(function(index){
+                var elem = $(this);
+                var rect = elem[0].getBoundingClientRect();
+                var navHeight = $('.navbar').height();
+                var top = rect.top;
+                if(top >= 0 && top <= navHeight){
+                    // Section is at the top of the page
+                    id = elem.children('h2, h3')[0].id;
+                    return false; // Break out of the loop.
+                }
+            });
+
+            if(id){
+                // Return the section id that contains subsections if it is displayed at the top.
+                return id;
+            }
+
+            // Find the height of each section that has no subsections and the height of subsections and return the max.
             sections.each(function(index) {
                 var elem = $(sections.get(index));
                 var windowHeight = $(window).height();
@@ -240,9 +261,9 @@ function accessContentsFromHash(hash) {
             scrollSpot -= stickyHeaderAdjustment;
         }
         $("body").data('scrolling', true); // Prevent the default window scroll from triggering until the animation is done.
-        $("html, body").animate({scrollTop: scrollSpot}, 400, function() {
+        $("html, body").first().animate({scrollTop: scrollSpot}, 400, function() {            
             // Callback after animation.  Change the focus.
-            $focusSection.focus();
+            $focusSection.focus();            
             // Check if the section was actually focused
             if ($focusSection.is(":focus")) {
                 return false;
@@ -252,8 +273,8 @@ function accessContentsFromHash(hash) {
                 // but not via sequential keyboard navigation.
                 $focusSection.attr('tabindex', '-1');
                 $focusSection.focus();                
-            }        
-            $("body").data('scrolling', false);   // Allow the default window scroll listener to process scrolls again. 
+            }    
+            $("body").data('scrolling', false);   // Allow the default window scroll listener to process scrolls again.
         });
     } else {
         defaultToFirstPage();


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Before when clicking on a step in the TOC, it would select the first child step when it should have chosen the step you clicked on.
#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
