### PR TITLE
Set #guide_column width accurately depending on TOC state

### DIFF
--- a/src/main/content/_assets/js/common-multipane.js
+++ b/src/main/content/_assets/js/common-multipane.js
@@ -85,6 +85,16 @@ function resizeGuideSections() {
         $('.sect1:not(#guide_meta):not(#related-guides)').css({
                 'min-height': newSectionHeight + 'px'
         });
+        if(window.innerWidth >= threeColumnBreakpoint){
+            // In three column view set the width of the #guide_column appropriately.
+            if ($("#toc_column").hasClass('in') || $("#toc_column").hasClass('inline')) {
+                // TOC is expanded.  Adjust #guide_column width to account for TOC column.
+                $("#guide_column").removeClass('expanded');
+            } else {
+                // TOC is closed.  Maximize width of #guide_column.
+                $("#guide_column").addClass('expanded');
+            }
+        }
     }
     // Use initial height for single column view / mobile
     else {


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Adjust the width of the #guide_column appropriately as the guide width is resized, depending if the TOC should be shown or not.

Scenario:

-  Go from 3-column view to 2-column view. Close the TOC.
-  Go from 2-column view to 3-column view width. TOC should remain closed. Guide content should flow in the left column as expected.
-  Go back to 2-column view width. Open the TOC.
-  Finally go back to 3-column view width. The TOC should be open and the guide content should flow appropriately within its skinny column without being cut off. Without this fix the guide content was cut off because the #guide_column was not being resized correctly.

#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [x] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
