### PR TITLE
Ordering basic essential guides; Indicate no search results

### DIFF
--- a/src/main/content/_assets/css/guides.scss
+++ b/src/main/content/_assets/css/guides.scss
@@ -199,7 +199,8 @@ $blue-grey-color: #5d6a8e;
 
 #guides_basic_container,
 #guides_microprofile_container,
-#guides_additional_container {
+#guides_additional_container,
+#no_search_results_container {
     @extend %full-width-and-padding;
     margin-top: 35px;
     margin-bottom: 40px;
@@ -259,4 +260,12 @@ $blue-grey-color: #5d6a8e;
     right: 0px;
     height: 185px;
     width: 708px;
+}
+
+#no_search_results_container {
+    font-family: BunueloLight;
+    font-size: 28px;
+    color: #24253A;
+    letter-spacing: 0;
+    display: none;
 }

--- a/src/main/content/_assets/js/guides.js
+++ b/src/main/content/_assets/js/guides.js
@@ -116,6 +116,13 @@ $(document).ready(function() {
         } else {
             $('.more_section').show();
         }
+        if(hideBasic && hideMP && hideAdditional) {
+            // All categories are hidden
+            // Show no results
+            $('#no_search_results_container').show();
+        } else {
+            $('#no_search_results_container').hide();
+        }
     }
 
     // Show everything on the guides page

--- a/src/main/content/guides.html
+++ b/src/main/content/guides.html
@@ -196,3 +196,14 @@ permalink: /guides/
         {% endfor %}
     </div>
 </div>
+
+
+<!-- Zero Search Results -->
+<!-- MORE GUIDES -->
+<div id="no_search_results_container" class="container">
+    <div class="row">
+        <div class="col-xs-12">
+            <h2>No Search Results</h2>
+        </div>
+    </div>
+</div>

--- a/src/main/content/guides.html
+++ b/src/main/content/guides.html
@@ -25,7 +25,7 @@ permalink: /guides/
 
 <!-- Basic guides -->
 {% assign basic-guides = all-guides | where: 'guide-category', 'basic' | where: 'essential', false | sort: 'releasedate' | reverse %}
-{% assign basic-essential-guides = all-guides | where: 'guide-category', 'basic' | where: 'essential', true | sort: 'releasedate' | reverse %}
+{% assign basic-essential-guides = all-guides | where: 'guide-category', 'basic' | where: 'essential', true | sort: 'essential-order' %}
 
 <!-- Microprofile guides -->
 {% assign microprofile-guides = all-guides | where: 'guide-category', 'microprofile' | where: 'essential', false | sort: 'releasedate' | reverse %}


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

Support ordering essential basic guides

**No Search Results**
![image](https://user-images.githubusercontent.com/31117513/44870334-97932280-ac55-11e8-8fb9-1b90b2efc287.png)

#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
