### PR TITLE
Adjust algorithm for getScrolledVisibleSectionID()

### DIFF
--- a/src/main/content/_assets/js/common-multipane.js
+++ b/src/main/content/_assets/js/common-multipane.js
@@ -134,22 +134,31 @@ function getScrolledVisibleSectionID() {
 
     // Multipane view
     if (window.innerWidth > twoColumnBreakpoint) {
-        var sections = $('.sect1:not(#guide_meta):not(#related-guides):not(:has(.sect2)), .sect2');
-        var navHeight = $('.navbar').height();
-        var topBorder = $(sections[0]).offset().top - navHeight;  // Border point between
-                                                                  // guide meta and 1st section
-        if ($(window).scrollTop() < topBorder) {
+        var sections = $('.sect1:not(#guide_meta):not(#related-guides), .sect2');
+        var topBorder = $('#guide_meta').outerHeight();  // Border point between
+                                                         // guide meta and 1st section
+        if ($(window).scrollTop() <= topBorder) {
             // scroll is within guide meta.
             id = "";
         } else {
-            // Find the height of each section that has no subsections and the height of subsections and return the max.
+            // Determine which section has the majority of the vertical height on 
+            // the page.
             sections.each(function(index) {
                 var elem = $(sections.get(index));
-                var windowHeight   = $(window).height();
+                var windowHeight = $(window).height();
+
                 var elemHeight = elem.outerHeight();
                 var rect = elem[0].getBoundingClientRect();
                 var top = rect.top;
                 var bottom = rect.bottom;
+                if (elem.find('.sect2').length > 0) {
+                    // Section contains a subsection.  It's height should end
+                    // where the subsection begins.
+                    var sect2s = elem.find('.sect2');
+                    bottom = sect2s[0].getBoundingClientRect().top;
+                    elemHeight = bottom - top;
+                } 
+
                 var visibleElemHeight = 0;
                 if(top > 0){
                      // Top of element is below the top of the viewport


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Adjust the algorithm in getScrolledVisibleSectionID() to account for the new sect2 divs which are contained within the sect1 divs.  We need to adjust the height of the sect1 divs to end when the sect2 divs begin instead of including them in their height value as laid out in the DOM.

#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
