### PR TITLE
Fix header id mistmatch

### DIFF
--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -34,15 +34,7 @@ $(document).ready(function() {
             var duplicate_code_block = code_block.clone();
             code_block.hide();
 
-            var header;
-            var subsection = code_block.parents('.sect2');
-            if(subsection.length > 0){
-                header = subsection.find('h3')[0];
-            }
-            else{
-                var guide_section = code_block.parents('.sect1').first();
-                header = guide_section.find('h2')[0];
-            }                        
+            var header = get_header_from_element(code_block);                       
             guide_sections.push(header);
             code_sections[header.id] = duplicate_code_block;
 
@@ -137,7 +129,7 @@ $(document).ready(function() {
     }
 
     // Returns the header of the element passed in. This checks if the element is in a subsection first before checking the main section header.
-    function get_header(element){
+    function get_header_from_element(element){
         var header;
         var subsection = element.parents('.sect2');
         if(subsection.length > 0){
@@ -153,7 +145,7 @@ $(document).ready(function() {
     // Returns the code block associated with a code hotspot.
     // Inputs: hotspot: The 'hotspot' in desktop view where hovering over the block will highlight certain lines of code in the code column relevant to what the guide is talking about.
     function get_code_block_from_hotspot(hotspot){
-        var header = get_header(hotspot);
+        var header = get_header_from_element(hotspot);
         return code_sections[header.id];
     }
 

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -136,11 +136,24 @@ $(document).ready(function() {
         snippet.after(duplicate_code_block);
     }
 
+    // Returns the header of the element passed in. This checks if the element is in a subsection first before checking the main section header.
+    function get_header(element){
+        var header;
+        var subsection = element.parents('.sect2');
+        if(subsection.length > 0){
+            header = subsection.find('h3')[0];
+        }
+        else{
+            var section = element.parents('.sect1').first();
+            header = section.find('h2')[0];
+        }  
+        return header;
+    }
+
     // Returns the code block associated with a code hotspot.
     // Inputs: hotspot: The 'hotspot' in desktop view where hovering over the block will highlight certain lines of code in the code column relevant to what the guide is talking about.
     function get_code_block_from_hotspot(hotspot){
-        var section = hotspot.parents('.sect1').first();
-        var header = section.find('h2').get(0);
+        var header = get_header(hotspot);
         return code_sections[header.id];
     }
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
When storing the id's of each code section on the right, the way we looked for the id of the section before did not match the way we checked what section a hotspot belonged to. This will create a common function that they use so they won't be mismatched again. 
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
