### PR TITLE
Use the common function to get a section header in the hotspot code

### DIFF
--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -430,7 +430,7 @@ $(document).ready(function() {
         }
     }
 
-    $('#guide_content pre:not(.code_command pre):not(.hotspot pre)').hover(function(event) {
+    $('#guide_content pre:not(.no_copy pre):not(.code_command pre):not(.hotspot pre)').hover(function(event) {
          offset = $('#guide_column').position();	
         target = event.currentTarget;	
         var current_target_object = $(event.currentTarget);	

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -206,8 +206,7 @@ $(document).ready(function() {
         if(hotspot.data('hovering') == false){
             return;
         }
-        var section = hotspot.parents('.sect1').first();
-        var header = section.find('h2').get(0);
+        var header = get_header_from_element(hotspot);
         var code_block = code_sections[header.id];
         if(code_block){
             var fromLine = hotspot.data('highlight_from_line');
@@ -227,8 +226,7 @@ $(document).ready(function() {
     // When the mouse leaves a code 'hotspot', remove all highlighting in the corresponding code section.
     $('.hotspot').on('mouseleave', function(event){
         $(this).data('hovering', false);
-        var section = $(this).parents('.sect1').first();
-        var header = section.find('h2').get(0);
+        var header = get_header_from_element($(this));
         var code_block = code_sections[header.id];
         if(code_block){
             remove_highlighting(code_block);


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
In the hotspot hover/hoveroff code we were using a different way of checking what section the hotspots were in than the code blocks used.
Also re-enable the no_copy functionality to prevent the copy button from appearing on a code block.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
