### PR TITLE
Embedded Hotspots

### DIFF
--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -167,13 +167,14 @@ $(document).ready(function() {
     }
 
     // Parse the hotspot lines to highlight and store them as a data attribute.
-    $('.hotspot').each(function(){
+    $('code[class*=hotspot], span[class*=hotspot], div[class*=hotspot]').each(function(){
         var snippet = $(this);
-        var metadata = snippet.prev().find('p');
-        if(metadata.length > 0){
-            var metadata_text = metadata[0].innerText;
-            if(metadata_text.indexOf('highlight_lines=') > -1){
-                var line_nums = metadata_text.substring(16);
+        var classList = this.classList;
+        var line_nums;
+        for(var i = 0; i < classList.length; i++){
+            var className = classList[i];
+            if(className.indexOf('hotspot=') > -1){
+                line_nums = className.substring(8);
                 if(line_nums.indexOf('-') > -1){
                     var lines = line_nums.split('-');
                     var fromLine = parseInt(lines[0]);
@@ -181,14 +182,15 @@ $(document).ready(function() {
                     // Set data attributes to save the lines to highlight
                     snippet.data('highlight_from_line', fromLine);
                     snippet.data('highlight_to_line', toLine);
+                    snippet.removeClass(className);
+                    snippet.addClass('hotspot');
 
                     var code_block = get_code_block_from_hotspot(snippet);
                     create_mobile_code_snippet(snippet, code_block, fromLine, toLine);
                 }
-            }             
+                break;
+            }
         }
-        // Remove old title from the DOM
-        metadata.detach();
     });
 
     // Returns a function, that, as long as it continues to be invoked, will not


### PR DESCRIPTION
Add a way to make a piece of text in a paragraph a hotspot to highlight the code on the right when this piece of text is hovered over. This makes it more intuitive for the guide author as well because they don't need to specify highlight_lines above code blocks anymore.

Embedded hotspot example:
The [hotspot=1-5]`@Inject` annotation indicates a dependency injection.
 You are injecting your `InventoryManager` bean into the `InventoryResource` class.
 This injects the bean in its specified context (application-scoped) and makes all of its functionalities
 available without the need of instantiating it yourself.

Making a whole code block a hotspot example:
[role='hotspot=89-115']
 ----
 `testSystemPropertiesMatch()` verifies that the JVM system properties returned by the `system` service match
 the ones stored in the `inventory` service.
 ----

#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
