### PR TITLE
Update pom.xml to use EE 8 dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,13 +19,13 @@
 		<dependency>
 			<groupId>javax.ws.rs</groupId>
 			<artifactId>javax.ws.rs-api</artifactId>
-			<version>2.0</version>
+			<version>2.1</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
-			<version>3.1.0</version>
+			<version>4.0.1</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -36,7 +36,7 @@
 		<dependency>
 			<groupId>javax.enterprise</groupId>
 			<artifactId>cdi-api</artifactId>
-			<version>1.2</version>
+			<version>2.0</version>
 		</dependency>
 		<!-- BEGIN: Needed to compile and run unit tests -->
 		<dependency>


### PR DESCRIPTION
Update the pom.xml to use EE 8 features for jaxrs 2.0 -> 2.1, jsonp 1.0 -> 1.1 and cdi 1.2 -> 2.0