### PR TITLE
Move the Cookie Preference button for all pages

### DIFF
--- a/src/main/content/_layouts/config-content.html
+++ b/src/main/content/_layouts/config-content.html
@@ -13,6 +13,9 @@
 
     </main>
 
+    <!-- Cookie preference button -->
+    <div id="teconsent" style="display: none"></div>
+
     {% include javascript.html %}
 
   </body>

--- a/src/main/content/_layouts/doc.html
+++ b/src/main/content/_layouts/doc.html
@@ -17,6 +17,9 @@
 
     {% include footer.html %}
 
+    <!-- Cookie preference button -->
+    <div id="teconsent" style="display: none"></div>
+
     {% include javascript.html %}
 
   </body>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

I forgot to specify where the `Cookie Preference` should be on other parts of the website.

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
