### PR TITLE
Update hash as you scroll through sections in single col mode

### DIFF
--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -397,26 +397,26 @@ $(document).ready(function() {
     }
 
     function handleSectionChanging(event){
-        // Multipane view
-        if(window.innerWidth > twoColumnBreakpoint) {
-            // Get the id of the section most in view
-            var id = getScrolledVisibleSectionID();
-            if (id !== null) {
-                var windowHash = window.location.hash;
-                var scrolledToHash = id === "" ? id : '#' + id;
-                if (windowHash !== scrolledToHash) {
-                    // Update the URL hash with new section we scrolled into....
-                    var currentPath = window.location.pathname;
-                    var newPath = currentPath.substring(currentPath.lastIndexOf('/')+1) + scrolledToHash;
-                    // Not setting window.location.hash here because that causes an
-                    // onHashChange event to fire which will scroll to the top of the
-                    // section.  pushState updates the URL without causing an
-                    // onHashChange event.
-                    history.pushState(null, null, newPath);
+        // Get the id of the section most in view
+        var id = getScrolledVisibleSectionID();
+        if (id !== null) {
+            var windowHash = window.location.hash;
+            var scrolledToHash = id === "" ? id : '#' + id;
+            if (windowHash !== scrolledToHash) {
+                // Update the URL hash with new section we scrolled into....
+                var currentPath = window.location.pathname;
+                var newPath = currentPath.substring(currentPath.lastIndexOf('/')+1) + scrolledToHash;
+                // Not setting window.location.hash here because that causes an
+                // onHashChange event to fire which will scroll to the top of the
+                // section.  pushState updates the URL without causing an
+                // onHashChange event.
+                history.pushState(null, null, newPath);
 
-                    // Update the selected TOC entry
-                    updateTOCHighlighting(id);                    
-                }
+                // Update the selected TOC entry
+                updateTOCHighlighting(id);                    
+            }
+            if(window.innerWidth > twoColumnBreakpoint) {
+                // multipane view
                 // Match the code block on the right to the new id
                 showCorrectCodeBlock(id);
             }


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Update the hash as you scroll through the sections in single column mode.  We decided that in single column mode the hash should change as the section header (h2 or h3) reaches the TOC header.  This also helps with small sections being identified since we don't have to worry about them never getting the majority of the vertical space.  In multi-column mode, the hash changes as a section takes over the majority of the screen space.

#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [x] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
