### PR TITLE
Add system styling

### DIFF
--- a/src/main/content/_assets/css/guide.css
+++ b/src/main/content/_assets/css/guide.css
@@ -79,16 +79,6 @@
     margin-left: 23px;
 }
 
-#guide_content .sidebarblock > p {
-    margin-left: 23px;
-    background-color: #F1F4FE;
-    color: #5e6b8d;
-}
-
-#guide_content .sidebar pre {
-    background-color: #F1F4FE;
-}
-
 #guide_content code,
 #guide_content pre  {
     /* Bootstrap override */


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
To format different operating system instructions in the guide like this:
The OS specific instructions are indented and the OS names are darkened.
![image](https://user-images.githubusercontent.com/6392944/45504360-3b4cfa00-b74f-11e8-9f38-b1ead289f241.png)

#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
