### PR TITLE
Add outline to version selection

### DIFF
--- a/src/main/content/_assets/js/features.js
+++ b/src/main/content/_assets/js/features.js
@@ -46,9 +46,10 @@ function addTOCClick() {
         }
     });
 
+    addOutlineToTabFocus("#toc_container > ul > li > div");
     // events to detect keyboard focus and add outline to the element. Outline will not
     // be added if the focus is thru mouse event.
-    $("#toc_container > ul > li > div").off("blur").on("blur", function(event) {
+    /* $("#toc_container > ul > li > div").off("blur").on("blur", function(event) {
         if ($(this).hasClass('addFocus')) {
             $(this).removeClass('addFocus');
         }
@@ -66,7 +67,7 @@ function addTOCClick() {
             adjustParentWindow();
         }
         mousedown = false;
-    });
+    }); */
 }
 
 // highlight the selected TOC
@@ -161,6 +162,33 @@ function addVersionClick(hrefToClick) {
             $("#common_feature_title > .feature_version:first").trigger('click');
         }
     }
+
+    addOutlineToTabFocus("#common_feature_title > .feature_version");
+    
+}
+
+// events to detect keyboard focus and add outline to the element. Outline will not
+// be added if the focus is thru mouse event.
+function addOutlineToTabFocus(selector) {
+    $(selector).off("blur").on("blur", function(event) {
+        if ($(this).hasClass('addFocus')) {
+            $(this).removeClass('addFocus');
+        }
+    })
+
+    var mousedown = false;
+    $(selector).off('mousedown').on('mousedown', function(event) {
+        mousedown = true;
+    });
+
+    $(selector).off('focusin').on('focusin', function(event) {
+        if (!mousedown) {
+            $(this).addClass("addFocus");
+            // scroll the parent window back up if it is scroll down
+            adjustParentWindow();
+        }
+        mousedown = false;
+    });
 }
 
 // highlight the selected version


### PR DESCRIPTION
Add outline focus to feature version selection when using keyboard

#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
