### PR TITLE
Update the algorithm to return id of small sections when selected

### DIFF
--- a/src/main/content/_assets/js/common-multipane.js
+++ b/src/main/content/_assets/js/common-multipane.js
@@ -222,23 +222,42 @@ function getScrolledVisibleSectionID() {
                 var rect = elem[0].getBoundingClientRect();
                 var top = rect.top;
                 var bottom = rect.bottom;
-                if (elem.find('.sect2').length > 0) {
-                    // Section contains a subsection.  It's height should end
-                    // where the subsection begins.
-                    var sect2s = elem.find('.sect2');
-                    bottom = sect2s[0].getBoundingClientRect().top;
+
+                var $sect2s = elem.find('.sect2');
+                if ($sect2s.length > 0) {
+                    // Section contains a subsection.  The section's height 
+                    // really ends where the subsection begins.
+                    bottom = $sect2s[0].getBoundingClientRect().top;
                     elemHeight = bottom - top;
-                } 
-    
+                }
+
                 var visibleElemHeight = 0;
                 if(top > 0){
-                     // Top of element is below the top of the viewport
-                     // Calculate the visible element height as the min of the whole element (if the whole element is in the viewport) and the top of the element to the bottom of the window (if only part of the element is visible and extends beyond the bottom of the viewport).
-                     visibleElemHeight = Math.min(elemHeight, windowHeight - top);
+                    // Top of element is below the top of the viewport
+
+                    if (top < ($('header').height() + 1)) {
+                        // We have a header at the very top of the page.
+                        // Return this as the ID.  This helps small sections
+                        // that never take up the vertical majority of the
+                        // window to be identified as the main element.
+                        id =  elem.children('h2, h3')[0].id;
+                        return false;  // Leave the loop
+                    } else {
+                        // Calculate the visible element height as the min of the
+                        // whole element (if the whole element is in the viewport)
+                        // and the top of the element to the bottom of the window
+                        // (if only part of the element is visible and extends beyond
+                        // the bottom of the viewport).
+                        visibleElemHeight = Math.min(elemHeight, windowHeight - top);
+                    }            
                 }
                 else {
                     // Top of element is at or above the top of the viewport
-                    // Calculate the visible element height as the min between the bottom (if the element starts above the viewport and ends before the bottom of the viewport) or the windowHeight(the element extends beyond the top and bottom of viewport in both diretions).
+                    // Calculate the visible element height as the min between
+                    // the bottom (if the element starts above the viewport and
+                    // ends before the bottom of the viewport) or the windowHeight
+                    // (the element extends beyond the top and bottom of viewport
+                    // in both diretions).
                     visibleElemHeight = Math.min(bottom, windowHeight);
                 }
                 if(visibleElemHeight > maxVisibleSectionHeight){


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
When smaller sections were selected from the TOC, they did not have enough content to take up the majority of the vertical space on the browser.  Therefore, they would not stay selected and their content in the code column may not be shown.  

I adjusted the algorithm that returns the ID of the currently selected section to return the ID of these smaller sections when they are right at the bottom of the page header.  That is where the page goes to when selected from the TOC.  They won't remain selected for long....but at least they will be selected for a bit.

#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
