### PR TITLE
Update .gitignore

### DIFF
--- a/src/main/content/.gitignore
+++ b/src/main/content/.gitignore
@@ -1,5 +1,6 @@
 _site
 guides
+docs
 .sass-cache
 .jekyll-metadata
 .asset-cache


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

Ignore the docs folder.  The folder is created when cloning OpenLiberty/docs

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
