### PR TITLE
Convert some pages to jQuery v3.3.1

### DIFF
--- a/src/main/content/404.html
+++ b/src/main/content/404.html
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: default-jquery3
 title: 404
 css: 404page
 permalink: /404.html

--- a/src/main/content/_assets/js/builds.js
+++ b/src/main/content/_assets/js/builds.js
@@ -113,7 +113,7 @@ function sort_builds(builds, key, descending) {
 
 $(document).ready(function() {
 
-    $('.builds_expand_link').click(function(event) {
+    $('.builds_expand_link').on('click', (function(event) {
         event.preventDefault();
         var table_container = $('#' + event.currentTarget.getAttribute('data-table-container-id'));
 
@@ -134,11 +134,11 @@ $(document).ready(function() {
             });
         }
        
-    });
+    }));
 
 
 
-    $('.build_table thead tr th a').click(function(event) {
+    $('.build_table thead tr th a').on('click', (function(event) {
         event.preventDefault();
 
         var table = $(event.currentTarget).closest('table');
@@ -155,7 +155,7 @@ $(document).ready(function() {
         $('th .table_header_arrow', table).removeClass('table_header_arrow_down table_header_arrow_up');
         $('.table_header_arrow', event.currentTarget).addClass(descending? 'table_header_arrow_down' : 'table_header_arrow_up');
 
-    });
+    }));
 
 
 

--- a/src/main/content/_assets/js/guides.js
+++ b/src/main/content/_assets/js/guides.js
@@ -166,17 +166,17 @@ $(document).ready(function() {
     }
 
 
-    $('#guide_search_input').keyup(function(event) {
+    $('#guide_search_input').on('keyup', (function(event) {
         var input_value = event.currentTarget.value.toLowerCase();
         processSearch(input_value);        
-    });
+    }));
 
-    $('#guide_search_input').keypress(function(event) {
+    $('#guide_search_input').on('keypress', (function(event) {
         if(event.which == 13) { // 13 is the enter key
             var searchInput = $('#guide_search_input').val();
             updateSearchUrl(searchInput);
         }
-    });
+    }));
 
     function updateSearchUrl(value) {
         if(! value) {

--- a/src/main/content/_assets/js/issues.js
+++ b/src/main/content/_assets/js/issues.js
@@ -14,17 +14,17 @@ var focus_issue_index = 0;
 var scroll_in_progress = false;
 var issues_url = '/api/github/issues';
 
-$('#issues_up_arrow').click(function(event) {
+$('#issues_up_arrow').on('click', (function(event) {
     event.preventDefault();
     scroll(true);
-});
+}));
 
 
 
-$('#issues_down_arrow').click(function(event) {
+$('#issues_down_arrow').on('click', (function(event) {
     event.preventDefault();
     scroll();
-});
+}));
 
 
 

--- a/src/main/content/_includes/javascript-jquery3.html
+++ b/src/main/content/_includes/javascript-jquery3.html
@@ -1,0 +1,12 @@
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+
+{% js devEnvironment %}
+
+{% for js_name in page.js %}
+  {% js {{js_name}} %}
+{% endfor %}
+
+{% for js_name in layout.js %}
+  {% js {{js_name}} %}
+{% endfor %}

--- a/src/main/content/_layouts/default-jquery3.html
+++ b/src/main/content/_layouts/default-jquery3.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="{{ page.lang | default: site.lang | default: "en" }}">
+
+  {% include head.html %}
+
+  <body>
+    
+    {% include analytics.html %}
+
+    {% include header.html %}
+
+    <main aria-label="Content">
+
+      {{ content }}
+
+    </main>
+
+    {% include footer.html %}
+    
+    {% include javascript-jquery3.html %}
+
+  </body>
+
+</html>

--- a/src/main/content/about.html
+++ b/src/main/content/about.html
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: default-jquery3
 title: About
 css: about
 js: download

--- a/src/main/content/blog.html
+++ b/src/main/content/blog.html
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: default-jquery3
 title: Blog
 css: blog
 permalink: /blog/

--- a/src/main/content/community.html
+++ b/src/main/content/community.html
@@ -1,5 +1,5 @@
 --- 
-layout: default 
+layout: default-jquery3 
 title: Community 
 css: 
  - community 

--- a/src/main/content/contribute.html
+++ b/src/main/content/contribute.html
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: default-jquery3
 title: Contribute
 css:
  - contribute

--- a/src/main/content/downloads.html
+++ b/src/main/content/downloads.html
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: default-jquery3
 title: Downloads
 css: downloads
 js: builds

--- a/src/main/content/index.html
+++ b/src/main/content/index.html
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: default-jquery3
 home: true
 js: download
 css: home


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

I used the jQuery-migrate tool to find what needed to be changed in order to migrate to jQuery v3.x.

I would like to gradually move a set of pages to jQuery v3.x at a time.  This is the first set. 

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
