### PR TITLE
Use unicode character join instead of str() for feature parse toc script

### DIFF
--- a/scripts/parse-feature-toc.py
+++ b/scripts/parse-feature-toc.py
@@ -2,11 +2,6 @@ from bs4 import BeautifulSoup
 from pkg_resources import parse_version
 import os
 import re
-import sys
-from importlib import reload
-
-reload(sys)
-sys.setdefaultencoding('utf8')
 
 def getTOCVersion(tocString):
     versionPattern = re.compile('^([\s\D]*)(?P<version>\d+[.]?\d*)([\s\D]*)')
@@ -99,4 +94,4 @@ for commonTOC in commonTOCKeys:
 # rename the original index.html and write the new index.html with version control in it
 os.rename('./target/jekyll-webapp/docs/ref/feature/index.html', './target/jekyll-webapp/docs/ref/feature/index.html.orig')
 with open('./target/jekyll-webapp/docs/ref/feature/index.html', "w") as file:
-    file.write(str(featureIndex))
+    file.write(u' '.join(featureIndex).encode("utf-8"))

--- a/scripts/parse-feature-toc.py
+++ b/scripts/parse-feature-toc.py
@@ -94,4 +94,4 @@ for commonTOC in commonTOCKeys:
 # rename the original index.html and write the new index.html with version control in it
 os.rename('./target/jekyll-webapp/docs/ref/feature/index.html', './target/jekyll-webapp/docs/ref/feature/index.html.orig')
 with open('./target/jekyll-webapp/docs/ref/feature/index.html', "w") as file:
-    file.write(u' '.join(featureIndex).encode("utf-8"))
+    file.write(u' '.join(featureIndex))


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
