### PR TITLE
Decode featureIndex before converting to string

### DIFF
--- a/scripts/parse-feature-toc.py
+++ b/scripts/parse-feature-toc.py
@@ -94,4 +94,4 @@ for commonTOC in commonTOCKeys:
 # rename the original index.html and write the new index.html with version control in it
 os.rename('./target/jekyll-webapp/docs/ref/feature/index.html', './target/jekyll-webapp/docs/ref/feature/index.html.orig')
 with open('./target/jekyll-webapp/docs/ref/feature/index.html', "w") as file:
-    file.write(u' '.join([str(i) for i in featureIndex]))
+    file.write(str(featureIndex.decode('ascii')))


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
