### PR TITLE
Add coloring and highlighting to <code> tags in code_column

### DIFF
--- a/src/main/content/_assets/css/iguide.css
+++ b/src/main/content/_assets/css/iguide.css
@@ -18,3 +18,14 @@
 #guide_content h4 {
     margin-bottom: 8px;
 }
+
+#code_column code  {
+    /* Bootstrap override */
+    background-color:#f4f4f4;
+    color: #5e6b8d;
+}
+
+#code_column code {
+    /* Bootstrap override */
+    word-wrap: break-word;
+}

--- a/src/main/content/_assets/css/iguide.css
+++ b/src/main/content/_assets/css/iguide.css
@@ -23,9 +23,5 @@
     /* Bootstrap override */
     background-color:#f4f4f4;
     color: #5e6b8d;
-}
-
-#code_column code {
-    /* Bootstrap override */
     word-wrap: break-word;
 }


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
For the interactive guides, descriptions that may appear in our pod elements on the right side, within the #code_column,  may contain \<code/> tags.   These tags need the same styling as those appearing in the #guide_content column.   Added styling to iguide.css.

#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [x] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
