### PR TITLE
Change the BuildsManager to expect test data to be both String and Nu…

### DIFF
--- a/src/test/java/io/openliberty/website/BuildsManagerTest.java
+++ b/src/test/java/io/openliberty/website/BuildsManagerTest.java
@@ -85,14 +85,14 @@ public class BuildsManagerTest {
 
     private JsonObject getExpectedBuilds() {
         JsonObjectBuilder expected = Json.createObjectBuilder();
-        expected.add("runtime_releases", Json.createArrayBuilder().add(createTestRelease("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release", "runtime-release-v1")).build());
-        expected.add("runtime_nightly_builds", Json.createArrayBuilder().add(createTestRelease("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/nightly", "runtime-nightly-v1")).build());
-        expected.add("tools_releases", Json.createArrayBuilder().add(createTestRelease("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/tools/release", "tools-release-v1")).build());
-        expected.add("tools_nightly_builds", Json.createArrayBuilder().add(createTestRelease("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/tools/nightly", "tools-nightly-v1")).build());
+        expected.add("runtime_releases", Json.createArrayBuilder().add(createRuntimeTestRelease("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release", "runtime-release-v1")).build());
+        expected.add("runtime_nightly_builds", Json.createArrayBuilder().add(createRuntimeTestRelease("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/nightly", "runtime-nightly-v1")).build());
+        expected.add("tools_releases", Json.createArrayBuilder().add(createToolsTestRelease("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/tools/release", "tools-release-v1")).build());
+        expected.add("tools_nightly_builds", Json.createArrayBuilder().add(createToolsTestRelease("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/tools/nightly", "tools-nightly-v1")).build());
         return expected.build();
     }
 
-    private JsonObject createTestRelease(String urlPath, String date_time) {
+    private JsonObject createRuntimeTestRelease(String urlPath, String date_time) {
         JsonObjectBuilder releaseInfo = Json.createObjectBuilder();
         releaseInfo.add(Constants.VERSION, "v1");
         releaseInfo.add(Constants.BUILD_LOG, urlPath+"/"+date_time+"/build-log-path");
@@ -101,6 +101,20 @@ public class BuildsManagerTest {
         releaseInfo.add(Constants.PACKAGE_LOCATIONS, Json.createArrayBuilder().add("package="+urlPath+"/"+date_time+"/my-package-v1").build());
         releaseInfo.add(Constants.TESTS_PASSED, "8500");
         releaseInfo.add(Constants.TOTAL_TESTS, "8501");
+        releaseInfo.add("date_time", date_time);
+        releaseInfo.add("size_in_bytes", "1234");
+        return releaseInfo.build();
+    }
+
+    private JsonObject createToolsTestRelease(String urlPath, String date_time) {
+        JsonObjectBuilder releaseInfo = Json.createObjectBuilder();
+        releaseInfo.add(Constants.VERSION, "v1");
+        releaseInfo.add(Constants.BUILD_LOG, urlPath+"/"+date_time+"/build-log-path");
+        releaseInfo.add(Constants.TESTS_LOG, urlPath+"/"+date_time+"/test-log-path");
+        releaseInfo.add(Constants.DRIVER_LOCATION, urlPath+"/"+date_time+"/driver-location");
+        releaseInfo.add(Constants.PACKAGE_LOCATIONS, Json.createArrayBuilder().add("package="+urlPath+"/"+date_time+"/my-package-v1").build());
+        releaseInfo.add(Constants.TESTS_PASSED, "114");
+        releaseInfo.add(Constants.TOTAL_TESTS, "115");
         releaseInfo.add("date_time", date_time);
         releaseInfo.add("size_in_bytes", "1234");
         return releaseInfo.build();
@@ -123,13 +137,13 @@ public class BuildsManagerTest {
         assertEquals(expectedBuilds, bm.getBuilds().asJsonObject());
 
         BuildLists all = bm.getBuilds();
-        validBuildsList(all.getRuntimeReleases(), "https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release", "runtime-release-v1");
-        validBuildsList(all.getRuntimeNightlyBuilds(), "https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/nightly", "runtime-nightly-v1");
-        validBuildsList(all.getToolsReleases(), "https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/tools/release", "tools-release-v1");
-        validBuildsList(all.getToolsNightlyBuilds(), "https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/tools/nightly", "tools-nightly-v1");
+        validRuntimeBuildsList(all.getRuntimeReleases(), "https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release", "runtime-release-v1");
+        validRuntimeBuildsList(all.getRuntimeNightlyBuilds(), "https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/nightly", "runtime-nightly-v1");
+        validToolsBuildsList(all.getToolsReleases(), "https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/tools/release", "tools-release-v1");
+        validToolsBuildsList(all.getToolsNightlyBuilds(), "https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/tools/nightly", "tools-nightly-v1");
     }
 
-	private void validBuildsList(List<BuildInfo> list, String urlPath, String date_time) {
+	private void validRuntimeBuildsList(List<BuildInfo> list, String urlPath, String date_time) {
 		assertEquals(1, list.size());
         BuildInfo info = list.get(0);
         assertEquals(urlPath+"/"+date_time+"/build-log-path", info.getBuildLog());
@@ -142,10 +156,23 @@ public class BuildsManagerTest {
         assertEquals("v1", info.getVersion());
 	}
 
+	private void validToolsBuildsList(List<BuildInfo> list, String urlPath, String date_time) {
+		assertEquals(1, list.size());
+        BuildInfo info = list.get(0);
+        assertEquals(urlPath+"/"+date_time+"/build-log-path", info.getBuildLog());
+        assertEquals(date_time, info.getDateTime());
+        assertEquals(urlPath+"/"+date_time+"/driver-location", info.getDriverLocation());
+        assertEquals("1234", info.getSizeInBytes());
+        assertEquals(urlPath+"/"+date_time+"/test-log-path", info.getTestLog());
+        assertEquals("114", info.getTestPassed());
+        assertEquals("115", info.getTotalTests());
+        assertEquals("v1", info.getVersion());
+	}
+
     private JsonObject getExpectedReleases() {
         JsonObjectBuilder expected = Json.createObjectBuilder();
-        expected.add("runtime", createTestRelease("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release", "runtime-release-v1"));
-        expected.add("tools", createTestRelease("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/tools/release", "tools-release-v1"));
+        expected.add("runtime", createRuntimeTestRelease("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release", "runtime-release-v1"));
+        expected.add("tools", createToolsTestRelease("https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/tools/release", "tools-release-v1"));
         return expected.build();
     }
 

--- a/src/test/java/io/openliberty/website/mock/MockDHEClient.java
+++ b/src/test/java/io/openliberty/website/mock/MockDHEClient.java
@@ -58,7 +58,7 @@ public class MockDHEClient extends DHEClient {
 			runtimeReleaseVersions.add(Constants.VERSIONS, runtimeVersions.build());
 			return runtimeReleaseVersions.build();
 		}
-		if (url.contains("v1")) {
+		if (url.contains("runtime")) {
 			JsonObjectBuilder releaseInfo = Json.createObjectBuilder();
 			releaseInfo.add(Constants.VERSION, "v1");
 			releaseInfo.add(Constants.BUILD_LOG, "build-log-path");
@@ -66,6 +66,19 @@ public class MockDHEClient extends DHEClient {
 			releaseInfo.add(Constants.DRIVER_LOCATION, "driver-location");
 			releaseInfo.add(Constants.TESTS_PASSED, "8500");
 			releaseInfo.add(Constants.TOTAL_TESTS, "8501");
+			releaseInfo.add(Constants.PACKAGE_LOCATIONS,
+					Json.createArrayBuilder().add("my-package-v1").build());
+			return releaseInfo.build();
+		}
+		// For some reason, the tools info.json has the test data as INT, rather than STRING
+		if (url.contains("tools")) {
+			JsonObjectBuilder releaseInfo = Json.createObjectBuilder();
+			releaseInfo.add(Constants.VERSION, "v1");
+			releaseInfo.add(Constants.BUILD_LOG, "build-log-path");
+			releaseInfo.add(Constants.TESTS_LOG, "test-log-path");
+			releaseInfo.add(Constants.DRIVER_LOCATION, "driver-location");
+			releaseInfo.add(Constants.TESTS_PASSED, 114);
+			releaseInfo.add(Constants.TOTAL_TESTS, 115);
 			releaseInfo.add(Constants.PACKAGE_LOCATIONS,
 					Json.createArrayBuilder().add("my-package-v1").build());
 			return releaseInfo.build();


### PR DESCRIPTION
…mber, to match the differences in runtimes and tools info.json

See [runtime info.json](https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/nightly/2018-05-23_2237/info.json)
See [tools info.json](https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/tools/nightly/2018-09-20_0037/info.json)

#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
