### PR TITLE
Introduce multi-threaded DHE parser

### DIFF
--- a/src/main/java/io/openliberty/website/BuildsManager.java
+++ b/src/main/java/io/openliberty/website/BuildsManager.java
@@ -10,227 +10,47 @@
  *******************************************************************************/
 package io.openliberty.website;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import javax.json.Json;
-import javax.json.JsonArray;
-import javax.json.JsonArrayBuilder;
-import javax.json.JsonNumber;
-import javax.json.JsonObject;
-import javax.json.JsonString;
-import javax.json.JsonValue;
 
+import io.openliberty.website.data.BuildData;
+import io.openliberty.website.data.BuildLists;
 import io.openliberty.website.data.LastUpdate;
 import io.openliberty.website.data.LatestReleases;
-import io.openliberty.website.data.BuildLists;
-import io.openliberty.website.data.BuildData;
-import io.openliberty.website.data.BuildInfo;
+import io.openliberty.website.dheclient.DHEBuildParser;
 
 @ApplicationScoped
 public class BuildsManager {
 	@Inject
-	private DHEClient dheParser;
-
-	private LastUpdate lastUpdate = new LastUpdate();
-	private volatile BuildData buildData = new BuildData(new LatestReleases(), new BuildLists());
+	private DHEBuildParser dheBuilds;
 
 	/** Defined default constructor */
 	public BuildsManager() {
 	}
 
 	/** Allow for unittest injection */
-	BuildsManager(DHEClient client) {
-		dheParser = client;
+	BuildsManager(DHEBuildParser dheBuilds) {
+		this.dheBuilds = dheBuilds;
 	}
 
 	public BuildData getData() {
-		if (isBuildUpdateAllowed()) {
-			updateBuilds();
-		}
-		return buildData;
+		return dheBuilds.getBuildData();
 	}
 
 	public BuildLists getBuilds() {
-		return getData().getBuilds();
+		return dheBuilds.getBuildData().getBuilds();
 	}
 
 	public LatestReleases getLatestReleases() {
-		return getData().getLatestReleases();
+		return dheBuilds.getBuildData().getLatestReleases();
 	}
 
 	public LastUpdate getStatus() {
-		return lastUpdate;
+		return dheBuilds.getLastUpdate();
 	}
 
-	public synchronized LastUpdate updateBuilds() {
-		lastUpdate.setLastUpdateAttempt(new Date());
-		List<BuildInfo> updatedRuntimeReleases = retrieveBuildData(Constants.DHE_RUNTIME_PATH_SEGMENT,
-				Constants.DHE_RELEASE_PATH_SEGMENT);
-		List<BuildInfo> updatedRuntimeNightlyBuilds = retrieveBuildData(Constants.DHE_RUNTIME_PATH_SEGMENT,
-				Constants.DHE_NIGHTLY_PATH_SEGMENT);
-		List<BuildInfo> updatedToolsReleases = retrieveBuildData(Constants.DHE_TOOLS_PATH_SEGMENT,
-				Constants.DHE_RELEASE_PATH_SEGMENT);
-		List<BuildInfo> updatedToolsNightlyBuilds = retrieveBuildData(Constants.DHE_TOOLS_PATH_SEGMENT,
-				Constants.DHE_NIGHTLY_PATH_SEGMENT);
-		if (!updatedRuntimeReleases.isEmpty() && !updatedToolsReleases.isEmpty()) {
-			BuildInfo latestRuntimeRelease = getLatestBuild(updatedRuntimeReleases);
-			BuildInfo latestToolsRelease = getLatestBuild(updatedToolsReleases);
-			if (latestRuntimeRelease != null) {
-				LatestReleases latest = new LatestReleases(latestRuntimeRelease, latestToolsRelease);
-				BuildLists all = new BuildLists();
-				all.setRuntimeReleases(updatedRuntimeReleases);
-				all.setRuntimeNightlyBuilds(updatedRuntimeNightlyBuilds);
-				all.setToolsReleases(updatedToolsReleases);
-				all.setToolsNightlyBuild(updatedToolsNightlyBuilds);
-
-				buildData = new BuildData(latest, all);
-				lastUpdate.markSuccessfulUpdate();
-			}
-		}
-		return getStatus();
-	}
-
-	private BuildInfo getLatestBuild(List<BuildInfo> buildsList) {
-		BuildInfo latest = null;
-
-		for (BuildInfo info : buildsList) {
-			if (latest == null) {
-				latest = info;
-			}
-			if (info.getDateTime().compareTo(latest.getDateTime()) > 0) {
-				latest = info;
-			}
-		}
-		return latest;
-	}
-
-	private List<BuildInfo> retrieveBuildData(String artifactPath, String buildTypePath) {
-		List<BuildInfo> builds = new ArrayList<BuildInfo>();
-		String versionsURL = Constants.DHE_URL + artifactPath + buildTypePath + Constants.DHE_INFO_JSON_FILE_NAME;
-		JsonObject versions = dheParser.retrieveJSON(versionsURL);
-		if (versions != null) {
-			JsonArrayBuilder jsonArray = Json.createArrayBuilder();
-			JsonValue versionsObject = versions.get(Constants.VERSIONS);
-			if (versionsObject instanceof JsonArray) {
-				for (JsonValue value : (JsonArray) versionsObject) {
-					if (value instanceof JsonString) {
-						BuildInfo info = loadBuildVersion(artifactPath, buildTypePath, jsonArray, (JsonString) value);
-						if (info != null) {
-							builds.add(info);
-						}
-					}
-				}
-			}
-		}
-		return builds;
-	}
-
-	private BuildInfo loadBuildVersion(String artifactPath, String buildTypePath, JsonArrayBuilder jsonArray,
-			JsonString value) {
-		String version = ((JsonString) value).getString();
-		String versionPath = version + '/';
-		String informationFileURL = Constants.DHE_URL + artifactPath + buildTypePath + versionPath
-				+ Constants.DHE_INFO_JSON_FILE_NAME;
-		JsonObject buildInformationSrc = dheParser.retrieveJSON(informationFileURL);
-		if (buildInformationSrc != null) {
-			return parseBuildInformation(artifactPath, buildTypePath, version, versionPath, buildInformationSrc);
-		}
-		return null;
-	}
-
-	private BuildInfo parseBuildInformation(String artifactPath, String buildTypePath, String version,
-			String versionPath, JsonObject buildInformationSrc) {
-		BuildInfo info = new BuildInfo();
-		info.addDateTime(version);
-
-		JsonValue versionObject = buildInformationSrc.get(Constants.VERSION);
-		if (versionObject instanceof JsonString) {
-			info.addVersion(((JsonString) versionObject).getString());
-		}
-
-		JsonValue testsPassedObject = buildInformationSrc.get(Constants.TESTS_PASSED);
-		if (testsPassedObject instanceof JsonString) {
-			info.addTestPassed(((JsonString) testsPassedObject).getString());
-		}
-		if (testsPassedObject instanceof JsonNumber) {
-			info.addTestPassed(((JsonNumber) testsPassedObject).toString());
-		}
-
-		JsonValue totalTestsObject = buildInformationSrc.get(Constants.TOTAL_TESTS);
-		if (totalTestsObject instanceof JsonString) {
-			info.addTotalTests(((JsonString) totalTestsObject).getString());
-		}
-		if (totalTestsObject instanceof JsonNumber) {
-			info.addTotalTests(((JsonNumber) totalTestsObject).toString());
-		}
-
-		JsonValue buildLogObject = buildInformationSrc.get(Constants.BUILD_LOG);
-		if (buildLogObject instanceof JsonString) {
-			String buildLog = ((JsonString) buildLogObject).getString();
-			String newBuildLog = Constants.DHE_URL + artifactPath + buildTypePath + versionPath + buildLog;
-			info.addBuildLog(newBuildLog);
-		}
-
-		JsonValue testLogObject = buildInformationSrc.get(Constants.TESTS_LOG);
-		if (testLogObject instanceof JsonString) {
-			String testsLog = ((JsonString) testLogObject).getString();
-			String newTestsLog = Constants.DHE_URL + artifactPath + buildTypePath + versionPath + testsLog;
-			info.addTestLog(newTestsLog);
-		}
-
-		JsonValue driverLocationObject = buildInformationSrc.get(Constants.DRIVER_LOCATION);
-		if (driverLocationObject instanceof JsonString) {
-			String driverLocation = ((JsonString) driverLocationObject).getString();
-			String newDrvierLocation = Constants.DHE_URL + artifactPath + buildTypePath + versionPath + driverLocation;
-			info.addDriverLocation(newDrvierLocation);
-
-			String size = dheParser.retrieveSize(newDrvierLocation);
-			if (size != null) {
-				info.addSizeInBytes(size);
-			}
-		}
-
-		JsonValue packageLocationsObject = buildInformationSrc.get(Constants.PACKAGE_LOCATIONS);
-		if (packageLocationsObject instanceof JsonArray) {
-			JsonArray packageLocations = (JsonArray) packageLocationsObject;
-			// Form an array of packageName=packageLocation
-			for (int i = 0; i < packageLocations.size(); i++) {
-				String packageLocation = ((JsonString) packageLocations.get(i)).getString();
-				String[] parts = packageLocation.split("-");
-				if (parts.length == 3) {
-					String packageName = parts[1];
-					String extension = parts[2];
-					String packageVersion = ((JsonString) buildInformationSrc.get(Constants.VERSION)).getString();
-					extension = extension.substring(extension.indexOf(packageVersion) + packageVersion.length());
-					String newLocation = Constants.DHE_URL + artifactPath + buildTypePath + versionPath
-							+ packageLocation;
-					info.addPackageLocation(packageName + extension, newLocation);
-				}
-			}
-		}
-		return info;
-	}
-
-	// Compare the current time with the time the last build request is run. Allow
-	// the next
-	// build request to go through if the last build request was run an hour ago or
-	// more.
-	boolean isBuildUpdateAllowed() {
-		boolean isBuildUpdateAllowed = true;
-		if (lastUpdate.lastSuccessfulUpdate() != null) {
-			long currentTime = new Date().getTime();
-			long lastUpdateTime = lastUpdate.lastSuccessfulUpdate().getTime();
-			// 1 hour = 3600000 ms
-			if (currentTime - lastUpdateTime < 3600000) {
-				isBuildUpdateAllowed = false;
-			}
-		}
-
-		return isBuildUpdateAllowed;
+	public LastUpdate updateBuilds() {
+		return dheBuilds.update();
 	}
 
 }

--- a/src/main/java/io/openliberty/website/dheclient/DHEBuildParser.java
+++ b/src/main/java/io/openliberty/website/dheclient/DHEBuildParser.java
@@ -30,8 +30,8 @@ public class DHEBuildParser {
 	@Inject
 	private DHEClient dheClient;
 
+	private volatile BuildData buildData = new BuildData(new LatestReleases(), new BuildLists());
 	private LastUpdate lastUpdate = new LastUpdate();
-	private BuildData buildData = new BuildData(new LatestReleases(), new BuildLists());
 
 	/** Defined default constructor */
 	public DHEBuildParser() {
@@ -43,6 +43,7 @@ public class DHEBuildParser {
 	}
 
 	public BuildData getBuildData() {
+		updateAsNeeded();
 		return buildData;
 	}
 
@@ -65,11 +66,10 @@ public class DHEBuildParser {
 		return isBuildUpdateAllowed;
 	}
 
-	public synchronized LastUpdate updateAsNeeded() {
+	private synchronized void updateAsNeeded() {
 		if (isBuildUpdateAllowed()) {
 			update();
 		}
-		return lastUpdate;
 	}
 
 	public synchronized LastUpdate update() {
@@ -88,7 +88,7 @@ public class DHEBuildParser {
 		List<BuildInfo> updatedRuntimeNightlyBuilds = getSafe(runtimeNightly);
 		List<BuildInfo> updatedToolsReleases = getSafe(toolsReleases);
 		List<BuildInfo> updatedToolsNightlyBuilds = getSafe(toolsNightly);
-		if (!updatedRuntimeReleases.isEmpty() && !updatedToolsReleases.isEmpty()) {
+		if (isNotEmpty(updatedRuntimeReleases) && isNotEmpty(updatedToolsReleases)) {
 			BuildInfo latestRuntimeRelease = pickLastestBuild(updatedRuntimeReleases);
 			BuildInfo latestToolsRelease = pickLastestBuild(updatedToolsReleases);
 			if (latestRuntimeRelease != null) {
@@ -105,6 +105,10 @@ public class DHEBuildParser {
 		}
 
 		return lastUpdate;
+	}
+
+	private boolean isNotEmpty(List<BuildInfo> updatedRuntimeReleases) {
+		return (updatedRuntimeReleases != null) && (!updatedRuntimeReleases.isEmpty());
 	}
 
 	private List<BuildInfo> getSafe(Future<List<BuildInfo>> future) {

--- a/src/main/java/io/openliberty/website/dheclient/DHEBuildParser.java
+++ b/src/main/java/io/openliberty/website/dheclient/DHEBuildParser.java
@@ -1,0 +1,286 @@
+package io.openliberty.website.dheclient;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Future;
+
+import javax.inject.Inject;
+import javax.json.JsonArray;
+import javax.json.JsonNumber;
+import javax.json.JsonObject;
+import javax.json.JsonString;
+import javax.json.JsonValue;
+
+import io.openliberty.website.Constants;
+import io.openliberty.website.data.BuildData;
+import io.openliberty.website.data.BuildInfo;
+import io.openliberty.website.data.BuildLists;
+import io.openliberty.website.data.LastUpdate;
+import io.openliberty.website.data.LatestReleases;
+
+public class DHEBuildParser {
+
+	private ExecutorService exec = new ForkJoinPool();
+
+	@Inject
+	private DHEClient dheClient;
+
+	private LastUpdate lastUpdate = new LastUpdate();
+	private BuildData buildData = new BuildData(new LatestReleases(), new BuildLists());
+
+	/** Defined default constructor */
+	public DHEBuildParser() {
+	}
+
+	/** Allow for unittest injection */
+	public DHEBuildParser(DHEClient client) {
+		dheClient = client;
+	}
+
+	public BuildData getBuildData() {
+		return buildData;
+	}
+
+	// Compare the current time with the time the last build request is run. Allow
+	// the next
+	// build request to go through if the last build request was run an hour ago or
+	// more.
+	boolean isBuildUpdateAllowed() {
+		boolean isBuildUpdateAllowed = true;
+		Date lastSuccessfulUpdate = lastUpdate.lastSuccessfulUpdate();
+		if (lastSuccessfulUpdate != null) {
+			long currentTime = new Date().getTime();
+			long lastUpdateTime = lastSuccessfulUpdate.getTime();
+			// 1 hour = 3600000 ms
+			if (currentTime - lastUpdateTime < 3600000) {
+				isBuildUpdateAllowed = false;
+			}
+		}
+
+		return isBuildUpdateAllowed;
+	}
+
+	public synchronized LastUpdate updateAsNeeded() {
+		if (isBuildUpdateAllowed()) {
+			update();
+		}
+		return lastUpdate;
+	}
+
+	public synchronized LastUpdate update() {
+		lastUpdate.setLastUpdateAttempt(new Date());
+
+		Future<List<BuildInfo>> runtimeReleases = exec.submit(
+				new RetrieveBuildList(Constants.DHE_RUNTIME_PATH_SEGMENT, Constants.DHE_RELEASE_PATH_SEGMENT));
+		Future<List<BuildInfo>> runtimeNightly = exec.submit(
+				new RetrieveBuildList(Constants.DHE_RUNTIME_PATH_SEGMENT, Constants.DHE_NIGHTLY_PATH_SEGMENT));
+		Future<List<BuildInfo>> toolsReleases = exec.submit(
+				new RetrieveBuildList(Constants.DHE_TOOLS_PATH_SEGMENT, Constants.DHE_RELEASE_PATH_SEGMENT));
+		Future<List<BuildInfo>> toolsNightly = exec.submit(
+				new RetrieveBuildList(Constants.DHE_TOOLS_PATH_SEGMENT, Constants.DHE_NIGHTLY_PATH_SEGMENT));
+
+		List<BuildInfo> updatedRuntimeReleases = getSafe(runtimeReleases);
+		List<BuildInfo> updatedRuntimeNightlyBuilds = getSafe(runtimeNightly);
+		List<BuildInfo> updatedToolsReleases = getSafe(toolsReleases);
+		List<BuildInfo> updatedToolsNightlyBuilds = getSafe(toolsNightly);
+		if (!updatedRuntimeReleases.isEmpty() && !updatedToolsReleases.isEmpty()) {
+			BuildInfo latestRuntimeRelease = pickLastestBuild(updatedRuntimeReleases);
+			BuildInfo latestToolsRelease = pickLastestBuild(updatedToolsReleases);
+			if (latestRuntimeRelease != null) {
+				LatestReleases latest = new LatestReleases(latestRuntimeRelease, latestToolsRelease);
+				BuildLists all = new BuildLists();
+				all.setRuntimeReleases(updatedRuntimeReleases);
+				all.setRuntimeNightlyBuilds(updatedRuntimeNightlyBuilds);
+				all.setToolsReleases(updatedToolsReleases);
+				all.setToolsNightlyBuild(updatedToolsNightlyBuilds);
+
+				buildData = new BuildData(latest, all);
+				lastUpdate.markSuccessfulUpdate();
+			}
+		}
+
+		return lastUpdate;
+	}
+
+	private List<BuildInfo> getSafe(Future<List<BuildInfo>> future) {
+		try {
+			return future.get();
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		} catch (ExecutionException e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
+
+	private BuildInfo pickLastestBuild(List<BuildInfo> buildsList) {
+		BuildInfo latest = null;
+
+		for (BuildInfo info : buildsList) {
+			if (latest == null) {
+				latest = info;
+			}
+			if (info.getDateTime().compareTo(latest.getDateTime()) > 0) {
+				latest = info;
+			}
+		}
+		return latest;
+	}
+
+	public LastUpdate getLastUpdate() {
+		return lastUpdate;
+	}
+
+	class RetrieveBuildInfo implements Callable<BuildInfo> {
+		private String artifactPath;
+		private String buildTypePath;
+		private String dateTime;
+
+		RetrieveBuildInfo(String artifactPath, String buildTypePath, String dateTime) {
+			this.artifactPath = artifactPath;
+			this.buildTypePath = buildTypePath;
+			this.dateTime = dateTime;
+		}
+
+		@Override
+		public BuildInfo call() throws Exception {
+			String dateTimePath = dateTime + '/';
+			String informationFileURL = Constants.DHE_URL + artifactPath + buildTypePath + dateTimePath
+					+ Constants.DHE_INFO_JSON_FILE_NAME;
+			JsonObject buildInformationSrc = dheClient.retrieveJSON(informationFileURL);
+			if (buildInformationSrc != null) {
+				return parseBuildInformation(artifactPath, buildTypePath, dateTime, dateTimePath, buildInformationSrc);
+			}
+			return null;
+		}
+
+		private BuildInfo parseBuildInformation(String artifactPath, String buildTypePath, String dateTime,
+				String dateTimePath, JsonObject buildInformationSrc) {
+			BuildInfo info = new BuildInfo();
+			info.addDateTime(dateTime);
+
+			JsonValue versionObject = buildInformationSrc.get(Constants.VERSION);
+			if (versionObject instanceof JsonString) {
+				info.addVersion(((JsonString) versionObject).getString());
+			}
+
+			JsonValue testsPassedObject = buildInformationSrc.get(Constants.TESTS_PASSED);
+			if (testsPassedObject instanceof JsonString) {
+				info.addTestPassed(((JsonString) testsPassedObject).getString());
+			}
+			if (testsPassedObject instanceof JsonNumber) {
+				info.addTestPassed(((JsonNumber) testsPassedObject).toString());
+			}
+
+			JsonValue totalTestsObject = buildInformationSrc.get(Constants.TOTAL_TESTS);
+			if (totalTestsObject instanceof JsonString) {
+				info.addTotalTests(((JsonString) totalTestsObject).getString());
+			}
+			if (totalTestsObject instanceof JsonNumber) {
+				info.addTotalTests(((JsonNumber) totalTestsObject).toString());
+			}
+
+			JsonValue buildLogObject = buildInformationSrc.get(Constants.BUILD_LOG);
+			if (buildLogObject instanceof JsonString) {
+				String buildLog = ((JsonString) buildLogObject).getString();
+				String newBuildLog = Constants.DHE_URL + artifactPath + buildTypePath + dateTimePath + buildLog;
+				info.addBuildLog(newBuildLog);
+			}
+
+			JsonValue testLogObject = buildInformationSrc.get(Constants.TESTS_LOG);
+			if (testLogObject instanceof JsonString) {
+				String testsLog = ((JsonString) testLogObject).getString();
+				String newTestsLog = Constants.DHE_URL + artifactPath + buildTypePath + dateTimePath + testsLog;
+				info.addTestLog(newTestsLog);
+			}
+
+			JsonValue driverLocationObject = buildInformationSrc.get(Constants.DRIVER_LOCATION);
+			if (driverLocationObject instanceof JsonString) {
+				String driverLocation = ((JsonString) driverLocationObject).getString();
+				String newDrvierLocation = Constants.DHE_URL + artifactPath + buildTypePath + dateTimePath + driverLocation;
+				info.addDriverLocation(newDrvierLocation);
+
+				String size = dheClient.retrieveSize(newDrvierLocation);
+				if (size != null) {
+					info.addSizeInBytes(size);
+				}
+			}
+
+			JsonValue packageLocationsObject = buildInformationSrc.get(Constants.PACKAGE_LOCATIONS);
+			if (packageLocationsObject instanceof JsonArray) {
+				JsonArray packageLocations = (JsonArray) packageLocationsObject;
+				// Form an array of packageName=packageLocation
+				for (int i = 0; i < packageLocations.size(); i++) {
+					String packageLocation = ((JsonString) packageLocations.get(i)).getString();
+					String[] parts = packageLocation.split("-");
+					if (parts.length == 3) {
+						String packageName = parts[1];
+						String extension = parts[2];
+						String packageVersion = ((JsonString) buildInformationSrc.get(Constants.VERSION)).getString();
+						extension = extension.substring(extension.indexOf(packageVersion) + packageVersion.length());
+						String newLocation = Constants.DHE_URL + artifactPath + buildTypePath + dateTimePath
+								+ packageLocation;
+						info.addPackageLocation(packageName + extension, newLocation);
+					}
+				}
+			}
+			return info;
+		}
+
+	}
+
+	class RetrieveBuildList implements Callable<List<BuildInfo>> {
+		private String artifactPath;
+		private String buildTypePath;
+
+		RetrieveBuildList(String artifactPath, String buildTypePath) {
+			this.artifactPath = artifactPath;
+			this.buildTypePath = buildTypePath;
+		}
+
+		@Override
+		public List<BuildInfo> call() throws Exception {
+			List<BuildInfo> builds = new ArrayList<BuildInfo>();
+			String versionsURL = Constants.DHE_URL + artifactPath + buildTypePath + Constants.DHE_INFO_JSON_FILE_NAME;
+			JsonObject versions = dheClient.retrieveJSON(versionsURL);
+			if (versions != null) {
+				JsonValue versionsObject = versions.get(Constants.VERSIONS);
+				if (versionsObject instanceof JsonArray) {
+
+					List<Future<BuildInfo>> buildInfoFutures = new ArrayList<>();
+					for (JsonValue value : (JsonArray) versionsObject) {
+						if (value instanceof JsonString) {
+							buildInfoFutures.add(exec.submit(new RetrieveBuildInfo(artifactPath, buildTypePath,
+									((JsonString) value).getString())));
+						}
+					}
+
+					for (Future<BuildInfo> f : buildInfoFutures) {
+						BuildInfo info = getSafe(f);
+						if (info != null) {
+							builds.add(info);
+						}
+					}
+
+				}
+			}
+			return builds;
+		}
+
+		private BuildInfo getSafe(Future<BuildInfo> future) {
+			try {
+				return future.get();
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+			} catch (ExecutionException e) {
+				e.printStackTrace();
+			}
+			return null;
+		}
+	}
+}

--- a/src/main/java/io/openliberty/website/dheclient/DHEClient.java
+++ b/src/main/java/io/openliberty/website/dheclient/DHEClient.java
@@ -1,4 +1,4 @@
-package io.openliberty.website;
+package io.openliberty.website.dheclient;
 
 import java.io.StringReader;
 
@@ -10,6 +10,8 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.client.Invocation.Builder;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
+import io.openliberty.website.Constants;
 
 public class DHEClient {
 	private Client client = null;

--- a/src/test/java/io/openliberty/website/BuildsManagerTest.java
+++ b/src/test/java/io/openliberty/website/BuildsManagerTest.java
@@ -16,6 +16,7 @@ import io.openliberty.website.data.BuildLists;
 import io.openliberty.website.data.BuildData;
 import io.openliberty.website.data.BuildInfo;
 import io.openliberty.website.data.LastUpdate;
+import io.openliberty.website.dheclient.DHEBuildParser;
 import io.openliberty.website.mock.EmptyVersionsDHEClient;
 import io.openliberty.website.mock.MockDHEClient;
 import io.openliberty.website.mock.NullDHEClient;
@@ -24,30 +25,17 @@ public class BuildsManagerTest {
 
     @Test
     public void default_initialized_BuildManager() {
-        BuildsManager bm = new BuildsManager();
+        BuildsManager bm = new BuildsManager(new DHEBuildParser(new NullDHEClient()));
 
         LastUpdate status = bm.getStatus();
         assertEquals(Constants.NEVER_ATTEMPTED, status.getLastUpdateAttempt());
         assertEquals(Constants.NEVER_UPDATED, status.getLastSuccessfulUpdate());
     }
 
-    @Test
-    public void isAllowedToRun() {
-        BuildsManager bm = new BuildsManager(new MockDHEClient());
-
-        assertTrue("The first call to isBuildUpdateAllowed should always return true", bm.isBuildUpdateAllowed());
-        assertTrue("The second call to isBuildUpdateAllowed should return true if no update has been attempted",
-                bm.isBuildUpdateAllowed());
-
-        bm.updateBuilds();
-
-        assertFalse("Calls to isBuildUpdateAllowed should return false if a successful update recently occurred",
-                bm.isBuildUpdateAllowed());
-    }
 
     @Test
     public void validate_state_of_BuildManager_after_failed_update() {
-        BuildsManager bm = new BuildsManager(new NullDHEClient());
+        BuildsManager bm = new BuildsManager(new DHEBuildParser(new NullDHEClient()));
         LastUpdate status = bm.updateBuilds();
 
         assertEquals(status, bm.getStatus());
@@ -66,7 +54,7 @@ public class BuildsManagerTest {
 
 	@Test
 	public void validate_state_of_BuildManager_with_no_releases() {
-		BuildsManager bm = new BuildsManager(new EmptyVersionsDHEClient());
+		BuildsManager bm = new BuildsManager(new DHEBuildParser(new EmptyVersionsDHEClient()));
 		LastUpdate status = bm.updateBuilds();
 
 		assertEquals(status, bm.getStatus());
@@ -122,7 +110,7 @@ public class BuildsManagerTest {
 
     @Test
     public void validate_state_of_BuildManager_after_successful_update() {
-        BuildsManager bm = new BuildsManager(new MockDHEClient());
+        BuildsManager bm = new BuildsManager(new DHEBuildParser(new MockDHEClient()));
         LastUpdate status = bm.updateBuilds();
 
         assertEquals(status, bm.getStatus());
@@ -178,7 +166,7 @@ public class BuildsManagerTest {
 
     @Test
     public void getData_after_failed_update() {
-        BuildsManager bm = new BuildsManager(new NullDHEClient());
+        BuildsManager bm = new BuildsManager(new DHEBuildParser(new NullDHEClient()));
         BuildData data = bm.getData();
         assertEquals("{\"latest_releases\":{},\"builds\":{}}", data.asJsonObject().toString());
     }

--- a/src/test/java/io/openliberty/website/DHEClientTest.java
+++ b/src/test/java/io/openliberty/website/DHEClientTest.java
@@ -2,6 +2,8 @@ package io.openliberty.website;
 
 import org.junit.Test;
 
+import io.openliberty.website.dheclient.DHEClient;
+
 public class DHEClientTest {
 
 	@Test

--- a/src/test/java/io/openliberty/website/dheclient/DHEBuildsParserTest.java
+++ b/src/test/java/io/openliberty/website/dheclient/DHEBuildsParserTest.java
@@ -7,12 +7,13 @@ import org.junit.Test;
 import io.openliberty.website.data.BuildData;
 import io.openliberty.website.dheclient.DHEBuildParser;
 import io.openliberty.website.mock.MockDHEClient;
+import io.openliberty.website.mock.NullDHEClient;
 
 public class DHEBuildsParserTest {
 
 	@Test
 	public void constructor() {
-		DHEBuildParser parser = new DHEBuildParser();
+		DHEBuildParser parser = new DHEBuildParser(new NullDHEClient());
 		BuildData data = parser.getBuildData();
 		assertNotNull(data.getLatestReleases());
 		assertNotNull(data.getBuilds());

--- a/src/test/java/io/openliberty/website/dheclient/DHEBuildsParserTest.java
+++ b/src/test/java/io/openliberty/website/dheclient/DHEBuildsParserTest.java
@@ -1,0 +1,35 @@
+package io.openliberty.website.dheclient;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.openliberty.website.data.BuildData;
+import io.openliberty.website.dheclient.DHEBuildParser;
+import io.openliberty.website.mock.MockDHEClient;
+
+public class DHEBuildsParserTest {
+
+	@Test
+	public void constructor() {
+		DHEBuildParser parser = new DHEBuildParser();
+		BuildData data = parser.getBuildData();
+		assertNotNull(data.getLatestReleases());
+		assertNotNull(data.getBuilds());
+	}
+
+	@Test
+	public void isAllowedToRun() {
+		DHEBuildParser parser = new DHEBuildParser(new MockDHEClient());
+
+		assertTrue("The first call to isBuildUpdateAllowed should always return true", parser.isBuildUpdateAllowed());
+		assertTrue("The second call to isBuildUpdateAllowed should return true if no update has been attempted",
+				parser.isBuildUpdateAllowed());
+
+		parser.updateAsNeeded();
+
+		assertFalse("Calls to isBuildUpdateAllowed should return false if a successful update recently occurred",
+				parser.isBuildUpdateAllowed());
+	}
+
+}

--- a/src/test/java/io/openliberty/website/dheclient/DHEBuildsParserTest.java
+++ b/src/test/java/io/openliberty/website/dheclient/DHEBuildsParserTest.java
@@ -26,7 +26,7 @@ public class DHEBuildsParserTest {
 		assertTrue("The second call to isBuildUpdateAllowed should return true if no update has been attempted",
 				parser.isBuildUpdateAllowed());
 
-		parser.updateAsNeeded();
+		parser.getBuildData();
 
 		assertFalse("Calls to isBuildUpdateAllowed should return false if a successful update recently occurred",
 				parser.isBuildUpdateAllowed());

--- a/src/test/java/io/openliberty/website/mock/EmptyVersionsDHEClient.java
+++ b/src/test/java/io/openliberty/website/mock/EmptyVersionsDHEClient.java
@@ -5,7 +5,7 @@ import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 
 import io.openliberty.website.Constants;
-import io.openliberty.website.DHEClient;
+import io.openliberty.website.dheclient.DHEClient;
 
 public class EmptyVersionsDHEClient extends DHEClient {
 

--- a/src/test/java/io/openliberty/website/mock/MockDHEClient.java
+++ b/src/test/java/io/openliberty/website/mock/MockDHEClient.java
@@ -6,7 +6,7 @@ import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 
 import io.openliberty.website.Constants;
-import io.openliberty.website.DHEClient;
+import io.openliberty.website.dheclient.DHEClient;
 
 public class MockDHEClient extends DHEClient {
 

--- a/src/test/java/io/openliberty/website/mock/NullDHEClient.java
+++ b/src/test/java/io/openliberty/website/mock/NullDHEClient.java
@@ -2,7 +2,7 @@ package io.openliberty.website.mock;
 
 import javax.json.JsonObject;
 
-import io.openliberty.website.DHEClient;
+import io.openliberty.website.dheclient.DHEClient;
 
 public class NullDHEClient extends DHEClient {
 


### PR DESCRIPTION
This change introduces a multi-threaded approach to parsing DHE information, which yields a reduction in rendering time when the Downloads page data needs to be updated.


#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
