### PR TITLE
Keep the title as is for the overview command doc

### DIFF
--- a/src/main/content/_layouts/server-command.html
+++ b/src/main/content/_layouts/server-command.html
@@ -1,6 +1,11 @@
 <div id="content">
-    {% assign titleWithNoCommand = page.title | split: ' command' %}
-    <div id="command_title"> {{ titleWithNoCommand }}
+    {% if page.type != "overview" %}
+        {% assign titleWithNoCommand = page.title | split: ' command' %}
+        <div id="command_title"> {{ titleWithNoCommand }}
+    {% else %}
+        <div id="command_title"> {{ page.title }}
+    {% endif %}
+
     </div>
 
     <!-- Command content section -->


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Do not change the title when the page type is overview for server command doc.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
