### PR TITLE
Update builds async, responding with a cached response if available

### DIFF
--- a/src/main/java/io/openliberty/website/BuildsManager.java
+++ b/src/main/java/io/openliberty/website/BuildsManager.java
@@ -50,7 +50,7 @@ public class BuildsManager {
 	}
 
 	public LastUpdate updateBuilds() {
-		return dheBuilds.update();
+		return dheBuilds.blockingUpdate();
 	}
 
 }

--- a/src/main/java/io/openliberty/website/data/LastUpdate.java
+++ b/src/main/java/io/openliberty/website/data/LastUpdate.java
@@ -9,6 +9,8 @@ import javax.json.JsonObjectBuilder;
 import io.openliberty.website.Constants;
 
 public class LastUpdate {
+	private static final int ONE_HOUR_MILLIS = 3600000;
+
 	private Date lastAttempt;
 	private Date lastSuccess;
 
@@ -16,7 +18,7 @@ public class LastUpdate {
 		return lastAttempt == null ? Constants.NEVER_ATTEMPTED : DateUtil.asUTCString(lastAttempt);
 	}
 
-	public void setLastUpdateAttempt(Date date) {
+	void setLastUpdateAttempt(Date date) {
 		lastAttempt = date;
 	}
 
@@ -24,12 +26,12 @@ public class LastUpdate {
 		return lastSuccess == null ? Constants.NEVER_UPDATED : DateUtil.asUTCString(lastSuccess);
 	}
 
-	public void markSuccessfulUpdate() {
-		lastSuccess = lastAttempt;
+	public void markUpdateAttempt() {
+		lastAttempt = new Date();
 	}
 
-	public Date lastSuccessfulUpdate() {
-		return lastSuccess;
+	public void markSuccessfulUpdate() {
+		lastSuccess = lastAttempt;
 	}
 
 	public JsonObject asJsonObject() {
@@ -37,5 +39,27 @@ public class LastUpdate {
 		builder.add(Constants.LAST_UPDATE_ATTEMPT, getLastUpdateAttempt());
 		builder.add(Constants.LAST_SUCCESSFULL_UPDATE, getLastSuccessfulUpdate());
 		return builder.build();
+	}
+
+	public boolean hasNeverSuccessfullyUpdated() {
+		return lastSuccess == null;
+	}
+
+	/**
+	 * Compare the current time with the time the last successful update completed.
+	 * An update is needed if the last successful update was more than an hour ago.
+	 */
+	public boolean isUpdateNeeded() {
+		boolean isBuildUpdateAllowed = true;
+
+		if (lastSuccess != null) {
+			long currentTime = new Date().getTime();
+			long lastUpdateTime = lastSuccess.getTime();
+			if ((currentTime - lastUpdateTime) < ONE_HOUR_MILLIS) {
+				isBuildUpdateAllowed = false;
+			}
+		}
+
+		return isBuildUpdateAllowed;
 	}
 }

--- a/src/test/java/io/openliberty/website/data/LastUpdateTest.java
+++ b/src/test/java/io/openliberty/website/data/LastUpdateTest.java
@@ -1,12 +1,10 @@
 package io.openliberty.website.data;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Date;
-
-import javax.json.Json;
-import javax.json.JsonObject;
 
 import org.junit.Test;
 
@@ -17,35 +15,77 @@ public class LastUpdateTest {
 	@Test
 	public void ctor() {
 		LastUpdate lastUpdate = new LastUpdate();
+
 		assertEquals(Constants.NEVER_ATTEMPTED, lastUpdate.getLastUpdateAttempt());
 		assertEquals(Constants.NEVER_UPDATED, lastUpdate.getLastSuccessfulUpdate());
-		assertNull(lastUpdate.lastSuccessfulUpdate());
+		assertTrue(lastUpdate.hasNeverSuccessfullyUpdated());
+		assertEquals("{\"last_update_attempt\":\"never_attempted\",\"last_successful_update\":\"never_updated\"}",
+				lastUpdate.asJsonObject().toString());
 	}
 
 	@Test
-	public void set_last_attempt() {
+	public void setLastUpdateAttempt() {
 		LastUpdate lastUpdate = new LastUpdate();
 		lastUpdate.setLastUpdateAttempt(new Date(1000));
+
 		assertEquals("Thu Jan 01 00:00:01 UTC 1970", lastUpdate.getLastUpdateAttempt());
+		assertEquals(Constants.NEVER_UPDATED, lastUpdate.getLastSuccessfulUpdate());
+		assertTrue(lastUpdate.hasNeverSuccessfullyUpdated());
+		assertEquals("{\"last_update_attempt\":\"Thu Jan 01 00:00:01 UTC 1970\",\"last_successful_update\":\"never_updated\"}",
+				lastUpdate.asJsonObject().toString());
 	}
 
 	@Test
-	public void set_last_success() {
+	public void markUpdateAttempt() {
+		LastUpdate lastUpdate = new LastUpdate();
+		lastUpdate.markUpdateAttempt();
+
+		@SuppressWarnings("deprecation")
+		Date updated = new Date(lastUpdate.getLastUpdateAttempt());
+
+		assertTrue(updated.getTime() <= new Date().getTime());
+	}
+
+	@Test
+	public void markSuccessfulUpdate() {
 		LastUpdate lastUpdate = new LastUpdate();
 		lastUpdate.setLastUpdateAttempt(new Date(2000));
 		lastUpdate.markSuccessfulUpdate();
+
+		assertEquals("Thu Jan 01 00:00:02 UTC 1970", lastUpdate.getLastUpdateAttempt());
 		assertEquals("Thu Jan 01 00:00:02 UTC 1970", lastUpdate.getLastSuccessfulUpdate());
-		assertEquals(new Date(2000), lastUpdate.lastSuccessfulUpdate());
+		assertFalse(lastUpdate.hasNeverSuccessfullyUpdated());
+		assertEquals("{\"last_update_attempt\":\"Thu Jan 01 00:00:02 UTC 1970\",\"last_successful_update\":\"Thu Jan 01 00:00:02 UTC 1970\"}",
+				lastUpdate.asJsonObject().toString());
 	}
 
 	@Test
-	public void asJson_never_attempted() {
+	public void isUpdateNeeded_never_attempted() {
 		LastUpdate lastUpdate = new LastUpdate();
+		assertTrue(lastUpdate.isUpdateNeeded());
+	}
 
-		JsonObject expected = Json.createObjectBuilder().add(Constants.LAST_UPDATE_ATTEMPT, Constants.NEVER_ATTEMPTED)
-				.add(Constants.LAST_SUCCESSFULL_UPDATE, Constants.NEVER_UPDATED).build();
-		assertEquals(expected, lastUpdate.asJsonObject());
+	@Test
+	public void isUpdateNeeded_never_updated() {
+		LastUpdate lastUpdate = new LastUpdate();
+		lastUpdate.markUpdateAttempt();
+		assertTrue(lastUpdate.isUpdateNeeded());
+	}
 
+	@Test
+	public void isUpdateNeeded_successfully_updated() {
+		LastUpdate lastUpdate = new LastUpdate();
+		lastUpdate.markUpdateAttempt();
+		lastUpdate.markSuccessfulUpdate();
+		assertFalse(lastUpdate.isUpdateNeeded());
+	}
+
+	@Test
+	public void isUpdateNeeded_updated_over_an_hour_ago() {
+		LastUpdate lastUpdate = new LastUpdate();
+		lastUpdate.setLastUpdateAttempt(new Date(2000));
+		lastUpdate.markSuccessfulUpdate();
+		assertTrue(lastUpdate.isUpdateNeeded());
 	}
 
 }

--- a/src/test/java/io/openliberty/website/dheclient/DHEBuildsParserTest.java
+++ b/src/test/java/io/openliberty/website/dheclient/DHEBuildsParserTest.java
@@ -5,12 +5,13 @@ import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 import io.openliberty.website.data.BuildData;
+import io.openliberty.website.mock.NullDHEClient;
 
 public class DHEBuildsParserTest {
 
 	@Test
 	public void constructor() {
-		DHEBuildParser parser = new DHEBuildParser();
+		DHEBuildParser parser = new DHEBuildParser(new NullDHEClient());
 		BuildData data = parser.getBuildData();
 		assertNotNull(data.getLatestReleases());
 		assertNotNull(data.getBuilds());

--- a/src/test/java/io/openliberty/website/dheclient/DHEBuildsParserTest.java
+++ b/src/test/java/io/openliberty/website/dheclient/DHEBuildsParserTest.java
@@ -1,36 +1,19 @@
 package io.openliberty.website.dheclient;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
 
 import io.openliberty.website.data.BuildData;
-import io.openliberty.website.dheclient.DHEBuildParser;
-import io.openliberty.website.mock.MockDHEClient;
-import io.openliberty.website.mock.NullDHEClient;
 
 public class DHEBuildsParserTest {
 
 	@Test
 	public void constructor() {
-		DHEBuildParser parser = new DHEBuildParser(new NullDHEClient());
+		DHEBuildParser parser = new DHEBuildParser();
 		BuildData data = parser.getBuildData();
 		assertNotNull(data.getLatestReleases());
 		assertNotNull(data.getBuilds());
-	}
-
-	@Test
-	public void isAllowedToRun() {
-		DHEBuildParser parser = new DHEBuildParser(new MockDHEClient());
-
-		assertTrue("The first call to isBuildUpdateAllowed should always return true", parser.isBuildUpdateAllowed());
-		assertTrue("The second call to isBuildUpdateAllowed should return true if no update has been attempted",
-				parser.isBuildUpdateAllowed());
-
-		parser.getBuildData();
-
-		assertFalse("Calls to isBuildUpdateAllowed should return false if a successful update recently occurred",
-				parser.isBuildUpdateAllowed());
 	}
 
 }


### PR DESCRIPTION
This PR builds on #704.

The proposed change is to update the builds off the main thread. This will only happen when a previous successful update has occurred. This change intends to improve the responsiveness of the openliberty.io/downloads page when a new build or the one hour window has elapsed. A user should not be forced to block, no matter how long, for a build data update. The user could choose to refresh their browser for updates.

#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
