### PR TITLE
Remove Open Liberty from the docs links

### DIFF
--- a/src/main/content/docs.html
+++ b/src/main/content/docs.html
@@ -52,12 +52,12 @@ permalink: /docs/
                         <h3 class="reference_title">MicroProfile API</h3>
                     </a> 
                     <a href="/docs/ref/config/" class="reference_item" aria-label="Open Liberty configuration documentation">
-                        <h3 class="reference_title">Open Liberty Config</h3>
+                        <h3 class="reference_title">Server Config</h3>
                     </a>                   
                 </div>
                 <div class="col-sm-6 reference_inner_padding">  
                     <a href="/docs/ref/feature/" class="reference_item" aria-label="Open Liberty feature documentation">
-                        <h3 class="reference_title">Open Liberty Features</h3>
+                        <h3 class="reference_title">Server Features</h3>
                     </a>
                     <a href="/docs/ref/command/" class="reference_item" aria-label="Open Liberty command documentation">
                         <h3 class="reference_title">Server Commands</h3>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
