### PR TITLE
Fix the logic in the clone blogs script

### DIFF
--- a/scripts/build_clone_blogs.sh
+++ b/scripts/build_clone_blogs.sh
@@ -8,8 +8,10 @@ echo "Start cloning blogs repository..."
 
 git clone https://github.com/OpenLiberty/blogs.git --branch master blogs_temp
 
-mv blogs_temp/_drafts/ .
-mv blogs_temp/_posts/ .
+mv blogs_temp/drafts/ .
+mv drafts/ _drafts
+mv blogs_temp/publish/ .
+mv publish/ _posts
 
 rm -rf blogs_temp
 popd


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
The old logic did not work for cloning the dirs in https://github.com/OpenLiberty/blogs
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
