### PR TITLE
Fix section title level

### DIFF
--- a/src/main/content/_posts/2018-10-18-meet-us-at-oc1-and-ece.adoc
+++ b/src/main/content/_posts/2018-10-18-meet-us-at-oc1-and-ece.adoc
@@ -37,7 +37,7 @@ We'll also be hosting quick labs on Open Liberty, MicroProfile, Kotlin and Sprin
 
 Below are many of the sessions either hosted, or co-hosted by, the Open Liberty team, and a few shout-outs from members of the OpenJ9 team too!
 
-==== Monday, 22 Oct 2018
+=== Monday, 22 Oct 2018
 - 9:00am - 11:00am - IBM Quantum Computer Workshop - BYOL [HOL6978] in Moscone West - Overlook 2B (HOL)
 - 10:30am - 11:15am - Serverless Architecture in the Java Ecosystem [DEV5327] in Moscone West - Room 2010
 - 12:30pm - 1:15pm - Condy? NestMates? Understanding JDK11’s JVM Features [DEV5652] in Moscone West - Room 2005
@@ -47,7 +47,7 @@ Below are many of the sessions either hosted, or co-hosted by, the Open Liberty 
 - 7:30pm - 8:15pm - Kotlin Back-End Services: What, Why, and How? [BOF5037] in Moscone West - Room 2011
 - 8:30pm - 9:15pm - How We Are Porting OpenJDK + Eclipse OpenJ9 to z/OS [BOF5341] in Moscone West - Room 2011
 
-==== Tuesday, 23 Oct 2018
+=== Tuesday, 23 Oct 2018
 - 9:00am - 11:00am - Reactive Java? Let Us Count the Ways - BYOL [HOL5361] in Moscone West - Overlook 2A (HOL)
 - 12:30pm - 1:15pm - Java with Node.js: Powering the Next Generation of Web Applications [DEV5492] in Moscone West - Room 2024
 - 1:30pm - 2:15pm - A Java Space Odyssey: Fun with Saucers, Lasers, Raspberry Pi’s, and Arduino [DEV6980] in Moscone West - Room 2012
@@ -57,7 +57,7 @@ Below are many of the sessions either hosted, or co-hosted by, the Open Liberty 
 - 8:30pm - 9:15pm - Are You Ready for Cloud-Native Java? [BOF5039] in Moscone West - Room 2003
 - 8:30pm - 9:15pm - Eclipse MicroProfile: What’s Next? [BOF5096] in Moscone West - Room 2001
 
-==== Wednesday, 24 Oct 2018
+=== Wednesday, 24 Oct 2018
 - 10:30am - 11:15am - A Modern Fairy Tale: Java Serialization [DEV5587] in Moscone West - Room 2005
 - 10:30am - 11:15am - Cloud Native Java with Eclipse OpenJ9: Fast, Lean, and Definitely Mean [DEV6975] in Moscone West - Room 2012
 - 10:30am - 11:15am - Running Applications with Response-Time Guarantees [DEV5644] in Moscone West - Room 2018
@@ -70,7 +70,7 @@ Below are many of the sessions either hosted, or co-hosted by, the Open Liberty 
 - 2:30pm - 3:15pm - JSR 382: Configuration [DEV5007] in Moscone West - Room 2003
 - 5:00pm - 5:30pm - You’ll Find Me Coding in the Cloud [KEY6961] in Moscone North - Hall D
 
-==== Thursday, 25 Oct 2018
+=== Thursday, 25 Oct 2018
 - 1:00pm - 1:45pm - JUnit 5: The Next Step in Automated Testing for Java [DEV5916] in Moscone West - Room 2007
 
 == EclipseCon Europe
@@ -88,16 +88,16 @@ Come visit the IBM booth right outside the Theater, check out some Open Liberty 
 
 Below are many of the sessions either hosted, or co-hosted by, the Open Liberty team, and a few shout-outs from members of the OpenJ9 team too!
 
-==== Monday, 22 Oct 2018
+=== Monday, 22 Oct 2018
 Kevin, Mike and Andy will be co-hosting the https://www.eclipsecon.org/europe2018/jakarta-ee-and-microprofile[Jakarta EE and MicroProfile] Community Day gathering throughout the day on Monday.
 
-==== Tuesday, 23 Oct 2018
+=== Tuesday, 23 Oct 2018
 - 09:00 - 12:00 - https://www.eclipsecon.org/europe2018/sessions/developing-cloud-native-java-microservices-eclipse-microprofile[Developing cloud-native Java microservices with Eclipse MicroProfile] in Silchersaal
 - 14:30 - 15:05 - https://www.eclipsecon.org/europe2018/sessions/osgi-action-how-we-use-osgi-build-open-liberty[OSGi in Action: How we use OSGi to build Open Liberty] in Schubartsaal
 - 16:15 - 16:50 - https://www.eclipsecon.org/europe2018/sessions/microprofile-its-all-fun-and-games[MicroProfile: It's All Fun and Games] in Bürgersaal 2
 - 17:00 - 17:35 - https://www.eclipsecon.org/europe2018/sessions/migrate-early-migrate-often-jdk-release-cadence-strategies[Migrate early, migrate often! JDK release cadence strategies] in the Theater
 
-==== Wednesday, 24 Oct 2018
+=== Wednesday, 24 Oct 2018
 - 10:25 - 11:00 - https://www.eclipsecon.org/europe2018/sessions/jakarta-ee-not-your-parents-java-ee[Jakarta EE - Not Your Parents' Java EE] in the Theater
 - 11:10 - 11:45 - https://www.eclipsecon.org/europe2018/sessions/integrating-slf4j-and-new-osgi-logservice-14[Integrating SLF4J and the new OSGi LogService 1.4] in Schubartsaal
 - 11:10 - 11:45 - https://www.eclipsecon.org/europe2018/sessions/practical-cloud-native-java-development-microprofile[Practical Cloud Native Java Development with MicroProfile] on the Theater Stage 
@@ -106,7 +106,7 @@ Kevin, Mike and Andy will be co-hosting the https://www.eclipsecon.org/europe201
 - 15:45 - 16:20 - https://www.eclipsecon.org/europe2018/sessions/microprofile-and-jakarta-ee-whats-next[MicroProfile and Jakarta EE -- What's Next?] on the Theater Stage
 - 16:30 - 17:05 - https://www.eclipsecon.org/europe2018/sessions/are-you-ready-cloud-native-java-sponsored-ibm[Are you ready for Cloud Native Java? (sponsored by IBM)] in Seminarraum 5
 
-==== Thursday, 25 Oct 2018
+=== Thursday, 25 Oct 2018
 - 10:00 - 10:35 - https://www.eclipsecon.org/europe2018/sessions/osgi-and-java-9[OSGi and Java 9+] in Schubartsaal
 - 10:00 - 10:35 - https://www.eclipsecon.org/europe2018/sessions/why-kotlin-my-favourite-example-functional-programming[Why Kotlin is my favourite example of Functional Programming?] in Seminarräume 1-3
 - 10:00 - 10:35 - https://www.eclipsecon.org/europe2018/sessions/build-12-factor-microservice-using-microprofile[Build a 12-factor microservice using MicroProfile] in Bürgersaal 2


### PR DESCRIPTION
Prevents warning message such as this one: asciidoctor: WARNING: 2018-10-18-meet-us-at-oc1-and-ece.adoc: line 30: section title out of sequence: expected level 2, got level 3

#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
