### PR TITLE
SEO description fallback to page description

### DIFF
--- a/src/main/content/_includes/head.html
+++ b/src/main/content/_includes/head.html
@@ -1,11 +1,19 @@
-<head>
+{% assign description = '' %}
+  {% if page.seo-description %}    
+    {% assign description = page.seo-description | escape %}
+  {% elsif page.description %}
+    {% assign description = page.description | escape %}
+  {% else %}
+      {% assign description = site.description | strip_html | normalize_whitespace | truncate: 160 | escape %}
+{% endif %}
 
+<head> 
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <title>{% if page.seo-title %}{{ page.seo-title | escape }}{% else %}{% if page.title %}{{ page.title | append: ' - ' | append: site.title | escape }}{% else %}{{ site.title | escape }}{% endif %}{% endif %}</title>
-  <meta name="description" content="{% if page.seo-description %}{{ page.seo-description | escape }}{% elsif page.description %}{{ page.description | escape }}{% else %}{{page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}{% endif %}">
+  <meta name="description" content="{{ description }}">
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
   <link rel="icon" type="image/x-icon" href="/favicon.ico">
@@ -32,7 +40,7 @@
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:site" content="@OpenLibertyIO" />
   <meta name="twitter:title" content="{% if page.seo-title %}{{ page.seo-title }}{% else %}{{site.title}}{% endif %}" />
-  <meta name="twitter:description" content="{% if page.seo-description %}{{ page.seo-description | escape }}{% elsif page.description %}{{ page.description | escape }}{% else %}{{site.description | normalize_whitespace }}{% endif %}" />
+  <meta name="twitter:description" content="{{ description }}" />
   <meta name="twitter:image" content="https://openliberty.io/img/twitter_card.jpg" />
   
   <meta name="google-site-verification" content="h2P030H9b66CyL1nEmWfrZB8Fr14h9LmVMG7Ur0caBs" />

--- a/src/main/content/_includes/head.html
+++ b/src/main/content/_includes/head.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <title>{% if page.seo-title %}{{ page.seo-title | escape }}{% else %}{% if page.title %}{{ page.title | append: ' - ' | append: site.title | escape }}{% else %}{{ site.title | escape }}{% endif %}{% endif %}</title>
-  <meta name="description" content="{% if page.seo-description %}{{ page.seo-description | escape }}{% else %}{{ page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}{% endif %}">
+  <meta name="description" content="{% if page.seo-description %}{{ page.seo-description | escape }}{% elsif page.description %}{{ page.description | escape }}{% else %}{{page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}{% endif %}">
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
   <link rel="icon" type="image/x-icon" href="/favicon.ico">
@@ -32,7 +32,7 @@
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:site" content="@OpenLibertyIO" />
   <meta name="twitter:title" content="{% if page.seo-title %}{{ page.seo-title }}{% else %}{{site.title}}{% endif %}" />
-  <meta name="twitter:description" content="{% if page.seo-description %}{{ page.seo-description | escape }}{% else %}{{site.description | normalize_whitespace }}{% endif %}" />
+  <meta name="twitter:description" content="{% if page.seo-description %}{{ page.seo-description | escape }}{% elsif page.description %}{{ page.description | escape }}{% else %}{{site.description | normalize_whitespace }}{% endif %}" />
   <meta name="twitter:image" content="https://openliberty.io/img/twitter_card.jpg" />
   
   <meta name="google-site-verification" content="h2P030H9b66CyL1nEmWfrZB8Fr14h9LmVMG7Ur0caBs" />

--- a/src/main/content/_includes/head.html
+++ b/src/main/content/_includes/head.html
@@ -1,13 +1,13 @@
 {% assign description = '' %}
-  {% if page.seo-description %}    
-    {% assign description = page.seo-description | escape %}
-  {% elsif page.description %}
-    {% assign description = page.description | escape %}
-  {% else %}
-      {% assign description = site.description | strip_html | normalize_whitespace | truncate: 160 | escape %}
+{% if page.seo-description %}    
+  {% assign description = page.seo-description | escape %}
+{% elsif page.description %}
+  {% assign description = page.description | escape %}
+{% else %}
+  {% assign description = site.description | strip_html | normalize_whitespace | truncate: 160 | escape %}
 {% endif %}
 
-<head> 
+<head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Add a default description for meta tags when no seo-description is provided and the page has a description.

Title will be seo title, page title appended by site title, or fallback to the site title only in that order.
Description will be seo description, page description, or fallback to the site description only in that order.

#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
