### PR TITLE
Prevent TOC headers from jumping around when scrolling

### DIFF
--- a/src/main/content/_assets/js/javadocs.js
+++ b/src/main/content/_assets/js/javadocs.js
@@ -183,7 +183,7 @@ function addLeftFrameScrollListener(frameToListen, frameElementToListen) {
     'border-top-width: ' + origBorderTopWidth + '; border-top-style: ' + origBorderTopStyle + '; border-top-color: ' + origBorderTopColor +';}</style>';
     frame.contents().off('scroll').on('scroll', function(event){
         var topPos = $(this).scrollTop();
-        if (topPos >= offsetTop) {
+        if (topPos >= offsetTop - 20) {
             if (!frameHeader.hasClass("sticky")) {
                 // sticky css will set margin-top to 0, otherwise the rolling content will appear in the margin-top area.
                 // To maintain the spacing and look with margin-top removed, replace padding-top and border-top
@@ -225,18 +225,16 @@ function hideFooter(element) {
     var footer = $("footer");        
 
     // Show footer if the scrollTop plus the viewport height of the right iFrame is at least 85% past the bottom of the right iFrame.
-    if ((scrollTop + rightFrameViewportHeight) > height * .85) {         
+    if ((scrollTop + rightFrameViewportHeight) > height * .85) {
         if(!footer.data('visible') || footer.data('visible') === "false"){
             footer.data('visible', true);
             footer.css('display', 'block');
-            resizeJavaDocWindow();
         }
     }
-    else{   
+    else{
         if(footer.data('visible')){
             footer.data('visible', 'false'); 
             footer.css('display', 'none');
-            resizeJavaDocWindow();
         }
     }
 }
@@ -464,7 +462,7 @@ function getJavaDocHtmlPath(href, returnBase) {
 }
 
 $(document).ready(function() {
-
+    
     $(window).on('resize', function(){
         resizeJavaDocWindow();
     });


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
