### PR TITLE
Fix symmetry in the TOC/Guide columns

### DIFF
--- a/src/main/content/_assets/css/guide-multipane.css
+++ b/src/main/content/_assets/css/guide-multipane.css
@@ -236,10 +236,8 @@ header {
 
 #guide_content div.sect1 {
     padding-bottom: 50px;
-    padding-left: 60px;
-    padding-right: 60px;
-    margin-left: -15px;
-    margin-right: -15px;
+    padding-left: 45px;
+    padding-right: 45px;
     background-color: white;
 }
 
@@ -251,8 +249,8 @@ header {
     font-family: BunueloBold;
     line-height: 1.3;
     outline: none;
-    margin: 0 -60px;
-    padding: 16px 60px 16px 60px;
+    margin: 0 -45px;
+    padding: 16px 45px 16px 45px;
     background: #F7F9E5;
 }
 

--- a/src/main/content/_assets/css/toc-multipane.scss
+++ b/src/main/content/_assets/css/toc-multipane.scss
@@ -246,7 +246,8 @@
 #toc_container a {
     display: inline-block;
     color:#5d6a8e;
-    margin-bottom: 10px;
+    margin-top: 5px;
+    margin-bottom: 5px;
 }
 
 #toc_container a:hover {

--- a/src/main/content/_assets/css/toc-multipane.scss
+++ b/src/main/content/_assets/css/toc-multipane.scss
@@ -137,7 +137,8 @@
         color: #5D6A8E;
         font-size: 14px;
         min-height: 30px;
-        border-left: 8px solid transparent;        
+        border-left: 8px solid transparent;   
+        border-right: 8px solid transparent;     
         word-wrap: break-word;
     }
 
@@ -190,8 +191,8 @@
     & > img {
         position: absolute;
         top: -5px;
-        right: 27px;
-        margin-top: 20px;
+        right: 12px;
+        margin-top: 20px;    
 
         &:hover {
             cursor: pointer;
@@ -264,12 +265,13 @@
     font-size:14px;
     color:#313653;
     margin-left: 27px;
+    margin-right: 27px;
     margin-bottom: 22px;
 }
 
 #tags_container {
     margin-left: 27px;
-    padding-right: 19px;
+    margin-right: 27px;
 }
 
 #tags_container a {


### PR DESCRIPTION
Fix symmetry of left and right padding/margin in the toc and guide columns.

#### What was fixed?  (Issue # or description of fix)
Made the left/right padding/margin/border equal in the multipane columns.
As you can see, the right padding was overflowing into the code column before. With the new changes the content will be within the column's boundaries.
Guide column before:
![image](https://user-images.githubusercontent.com/6392944/48375380-64c1cd80-e68d-11e8-9b5e-1d88a67785dd.png)
After:
![image](https://user-images.githubusercontent.com/6392944/48375383-69868180-e68d-11e8-8246-e8a9fd17efd6.png)

The TOC also had some mismatched padding/margins which were changed to be equal on both sides as well as adding a transparent border-right equal to the one on the left that becomes orange so the spacing is equal.

#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
