### PR TITLE
Disable snap scrolling on IE/Edge

### DIFF
--- a/src/main/content/_assets/js/common-multipane.js
+++ b/src/main/content/_assets/js/common-multipane.js
@@ -23,6 +23,9 @@ function inMobile(){
 function onAppleDevice(){
     return (/(Mac|iPhone|iPod|iPad)/i.test(navigator.userAgent));
 }
+function onIE(){
+    return (/(MSIE|Trident\/|Edge\/)/i.test(navigator.userAgent));
+}
 
 // Handle sticky header in IE, because IE doesn't support position: sticky
 function handleStickyHeader() {
@@ -437,7 +440,7 @@ $(document).ready(function() {
     });
 
     // Check if on Apple device to disable inertia scrolling since the trackpad doesn't work well.
-    if(!onAppleDevice()){
+    if(!onAppleDevice() && !onIE()){
         $(window).on('mousewheel DOMMouseScroll', function(event){
             checkForInertialScrolling(event);
         });

--- a/src/main/content/_assets/js/common-multipane.js
+++ b/src/main/content/_assets/js/common-multipane.js
@@ -439,7 +439,7 @@ $(document).ready(function() {
         handleFloatingCodeColumn();
     });
 
-    // Check if on Apple device to disable inertia scrolling since the trackpad doesn't work well.
+    // Check if on Apple device or Internet Explorer/Edge before enabling inertia scrolling since it doesn't work well.
     if(!onAppleDevice() && !onIE()){
         $(window).on('mousewheel DOMMouseScroll', function(event){
             checkForInertialScrolling(event);


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [x] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
