### PR TITLE
Support anchor scrolling in iframe

### DIFF
--- a/src/main/content/configs.html
+++ b/src/main/content/configs.html
@@ -34,7 +34,6 @@ permalink: /docs/ref/config/
                     <li>
                         {% assign splitOpenParen = config.title | split: '(' %}
                         {% assign splitCloseParen = splitOpenParen[1] | split: ')' %}
-                        <!-- <a href="{{ config.url }}" target="contentFrame">{{ config.title }}</a> -->
                         <a href="{{ config.url }}" target="contentFrame">{{ splitCloseParen[0] }}</a>
                     </li>
                     {% endfor %}


### PR DESCRIPTION
- Existing CSS selectors are now scoped to only the server configuration pages.  They will avoid modifying overview pages.
- Remove commented out code

#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
