### PR TITLE
One line hotspots

### DIFF
--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -383,7 +383,7 @@ $(document).ready(function() {
             // Check if the first guide section that has code to show on the right has been scrolled past yet.
             var firstCodeSectionTop = Math.round($('[data-has-code]')[0].getBoundingClientRect().top);
             var navHeight = $('.navbar').height();
-            var showGithubPopup = (firstCodeSectionTop - navHeight) > 0;
+            var showGithubPopup = (firstCodeSectionTop - navHeight) > 1;
             if(showGithubPopup){
                 githubPopup.fadeIn();
                 $("#code_column .code_column").addClass('dimmed_code_column', {duration:400});

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -176,19 +176,26 @@ $(document).ready(function() {
             var className = classList[i];
             if(className.indexOf('hotspot=') === 0){
                 line_nums = className.substring(8);
+                var fromLine, toLine;
                 if(line_nums.indexOf('-') > -1){
+                    // Highlight a range of lines.
                     var lines = line_nums.split('-');
-                    var fromLine = parseInt(lines[0]);
-                    var toLine = parseInt(lines[1]);
-                    // Set data attributes to save the lines to highlight
-                    snippet.data('highlight_from_line', fromLine);
-                    snippet.data('highlight_to_line', toLine);
-                    snippet.removeClass(className);
-                    snippet.addClass('hotspot');
-
-                    var code_block = get_code_block_from_hotspot(snippet);
-                    create_mobile_code_snippet(snippet, code_block, fromLine, toLine);
+                    fromLine = parseInt(lines[0]);
+                    toLine = parseInt(lines[1]);                    
                 }
+                else {
+                    // Only one line to highlight.
+                    fromLine = parseInt(line_nums);
+                    toLine = parseInt(line_nums);
+                }
+                // Set data attributes to save the lines to highlight
+                snippet.data('highlight_from_line', fromLine);
+                snippet.data('highlight_to_line', toLine);
+                snippet.removeClass(className);
+                snippet.addClass('hotspot');
+
+                var code_block = get_code_block_from_hotspot(snippet);
+                create_mobile_code_snippet(snippet, code_block, fromLine, toLine);
                 break;
             }
         }


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Allow authors to highlight 1 line of code while hovering over a hotspot.
Fix github popup off by one pixel so it will disappear when clicking on the TOC first step that has code.
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
