### PR TITLE
Do not dismiss github popup when copying so it does not confuse user

### DIFF
--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -374,10 +374,7 @@ $(document).ready(function() {
             selection.addRange(range);
             
             // Try to copy the selection and if it fails display a popup to copy manually.
-            if(document.execCommand('copy')) {                
-                $("#github_clone_popup_container").fadeOut("slow");
-                $(".code_column").removeClass('dimmed_code_column', {duration:400});
-            } else {
+            if(!document.execCommand('copy')) {
                 alert('Copy failed. Copy the command manually: ' + target.innerText);
             } 
             temp.remove(); // Remove temporary element.


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [x] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
