### PR TITLE
Fix scrollTo on Safari and IE

### DIFF
--- a/src/main/content/_assets/js/common-multipane.js
+++ b/src/main/content/_assets/js/common-multipane.js
@@ -367,7 +367,7 @@ function accessContentsFromHash(hash, callback) {
             scrollSpot -= stickyHeaderAdjustment;
         }
         $("body").data('scrolling', true); // Prevent the default window scroll from triggering until the animation is done.
-        $("html").animate({scrollTop: scrollSpot}, 400, function() {
+        $("html, body").animate({scrollTop: scrollSpot}, 400, function() {
             // Callback after animation.  Change the focus.
             $focusSection.focus();
             $("body").data('scrolling', false);   // Allow the default window scroll listener to process scrolls again.


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Need to animate both html and body for all browsers to work.
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [x] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
