### PR TITLE
Support multiple files from each subsection

### DIFF
--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -30,7 +30,8 @@ $(document).ready(function() {
             var header = get_header_from_element(code_block);            
             header.setAttribute('data-has-code', 'true');
             var code_section = {};
-            code_section.code = duplicate_code_block;                       
+            code_section.code = duplicate_code_block;   
+            code_section.fileName = fileName;                    
 
             // Create a title pane for the code section
             duplicate_code_block.attr('fileName', fileName);

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -305,7 +305,7 @@ $(document).ready(function() {
             // Switch to the correct tab
             var tab = code_sections[header.id][fileIndex].tab;
             setActiveTab(tab);
-            showCorrectCodeBlock(header.id, fileIndex);
+            showCorrectCodeBlock(header.id, fileIndex, false);
 
             // Highlight the code
             var fromLine = hotspot.data('highlight_from_line');
@@ -493,7 +493,7 @@ $(document).ready(function() {
                     // Hide other tabs with the same name
                     var tab = code_section.tab;                
                     var fileName = tab.text();
-                    visibleTabs.filter(":contains('" + fileName + "')").hide();
+                    visibleTabs.not(tab).filter(":contains('" + fileName + "')").hide();
                 }
             }                        
         });
@@ -513,7 +513,7 @@ $(document).ready(function() {
     }
 
     // Hide other code blocks and show the correct code block based on provided id.
-    function showCorrectCodeBlock(id, index) {
+    function showCorrectCodeBlock(id, index, switchTabs) {
         if(!id){
             // At the start of the guide where there is no guide section.
             return;
@@ -528,10 +528,12 @@ $(document).ready(function() {
                 code_block.show();
                 hideDuplicateTabs(id);
 
-                var subsection_files = code_sections[id];
-                for(var i = subsection_files.length - 1; i >= 0; i--){
-                    setActiveTab(subsection_files[i].tab, true);
-                }
+                if(switchTabs){
+                    var subsection_files = code_sections[id];
+                    for(var i = subsection_files.length - 1; i >= 0; i--){
+                        setActiveTab(subsection_files[i].tab, true);
+                    }
+                }                
             }
         } catch(e) {
             console.log(e);
@@ -560,7 +562,7 @@ $(document).ready(function() {
             if(window.innerWidth > twoColumnBreakpoint) {
                 // multipane view
                 // Match the code block on the right to the new id
-                showCorrectCodeBlock(id);
+                showCorrectCodeBlock(id, null, true);
             }
         }
     }
@@ -624,7 +626,7 @@ $(document).ready(function() {
             handleFloatingTableOfContent();
             var hash = location.hash;
             accessContentsFromHash(hash);
-            showCorrectCodeBlock(hash.substring(1));  // Remove the '#' in front of the id
+            showCorrectCodeBlock(hash.substring(1), null, true);  // Remove the '#' in front of the id
         }
 
         if(window.location.hash === ""){

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -514,8 +514,15 @@ $(document).ready(function() {
 
     // Hide other code blocks and show the correct code block based on provided id.
     function showCorrectCodeBlock(id, index) {
+        if(!id){
+            // At the start of the guide where there is no guide section.
+            return;
+        }
         try{
-            var code_block = index ? code_sections[id][index].code : code_sections[id][0].code;
+            if(!index){
+                index = 0;
+            }
+            var code_block = code_sections[id][index].code;
             if(code_block){
                 $('#code_column .code_column').not(code_block).hide();
                 code_block.show();


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Enable the multipane guide to support having more than one file in a subsection. It will load all of the files into tabs and the hotspots will switch to the correct file when hovering. Clicking on tabs will still work of course. When scrolling, there isn't a good way to detect what file to switch to when scrolling into a subsection with multiple files so it will show the first one and they can click on another tab or a hotspot will switch to the other file.

If more than one file is in a subsection in the guide's .adoc file, all of the hotspots above where the file is placed in the subsection will map to that file. Guide authors can override this behavior by putting [hotspot=14 file=1] for inline hotspots to specify that the hotspot should belong to the second file in that section.
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [x] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
