### PR TITLE
Fix Guide attribution styling

### DIFF
--- a/src/main/content/_assets/css/end-of-guide.css
+++ b/src/main/content/_assets/css/end-of-guide.css
@@ -40,14 +40,13 @@
 }
 
 #guide_attribution {
-    font-family: Bunuelo;
     font-weight: 500;
     color:#5d6a8e;
     letter-spacing:0;
     line-height:24px;
 }
 
-.licenseClass {
+.licensedClass {
     font-weight: 400;
 }
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Change font to Asap medium.
Fix the css selector for the 'is licensed by' text in the middle.
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
