### PR TITLE
Prevent any no_copy blocks from becoming green

### DIFF
--- a/src/main/content/_assets/css/guide-multipane.scss
+++ b/src/main/content/_assets/css/guide-multipane.scss
@@ -158,7 +158,7 @@ header {
     padding: 30px;
 }
 
-#guide_content .command pre {
+#guide_content .command > div:not(.no_copy) pre {
     background-color: #FFFFFF;
     border: 1px solid #96bc32;
     border-left: 8px solid #96bc32;


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Sometimes including a file and adding role='command' to it will influence the other blocks around it. This is to add code to prevent no_copy blocks from turning green like commands. I confirmed with Justine that no_copy blocks will always be gray.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
