### PR TITLE
Default to the first file if no fileIndex was specified

### DIFF
--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -301,6 +301,9 @@ $(document).ready(function() {
         }
         var header = get_header_from_element(hotspot);
         var fileIndex = hotspot.data('file-index');
+        if(!fileIndex){
+            fileIndex = 0;
+        }
         var code_block = code_sections[header.id][fileIndex].code;
         if(code_block){
             // Switch to the correct tab


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Add default fileIndex of 0 if not specified.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
