### PR TITLE
Fix the code commands in included mvn adoc sections from turning green

### DIFF
--- a/src/main/content/_assets/css/guide-multipane.scss
+++ b/src/main/content/_assets/css/guide-multipane.scss
@@ -158,7 +158,7 @@ header {
     padding: 30px;
 }
 
-#guide_content .command > div:not(.no_copy) pre {
+#guide_content .command .listingblock:not(.no_copy):not(.code_command) pre{
     background-color: #FFFFFF;
     border: 1px solid #96bc32;
     border-left: 8px solid #96bc32;


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Before fix:
![image](https://user-images.githubusercontent.com/6392944/50652593-95ffa100-0f4c-11e9-815e-05c1c1a8eafa.png)

After fix:
![image](https://user-images.githubusercontent.com/6392944/50652524-5f298b00-0f4c-11e9-9a92-84e8d2aa8c22.png)

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
