### PR TITLE
Fix the mvn command block styling in the rest client java guide

### DIFF
--- a/src/main/content/_assets/css/guide-multipane.scss
+++ b/src/main/content/_assets/css/guide-multipane.scss
@@ -158,7 +158,8 @@ header {
     padding: 30px;
 }
 
-#guide_content .command .listingblock:not(.no_copy):not(.code_command) pre{
+#guide_content .listingblock.command .content pre,
+#guide_content .command .listingblock:not(.no_copy):not(.code_command) .content pre {
     background-color: #FFFFFF;
     border: 1px solid #96bc32;
     border-left: 8px solid #96bc32;


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Fixed some of the maven commands that turned gray after a recent css change: https://qa-guides-multipane.mybluemix.net/guides/maven-multimodules.html#starting-the-application

These 2 code blocks should be green.

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
