### PR TITLE
Load most recently viewed tab

### DIFF
--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -13,6 +13,7 @@ $(document).ready(function() {
     $('#preamble').detach().insertAfter('#duration_container');
 
     var code_sections = {}; // Map guide sections to code blocks to show on the right column. Each guide section maps to its tab and code block.
+    var recent_sections = {}; // Store the most recently viewed code_section for each guide section
 
     // Move the code snippets to the code column on the right side.
     // Each code section is duplicated to show the full file in the right column and just the snippet of code relevant to the guide in the left column in single column / mobile view.
@@ -123,6 +124,8 @@ $(document).ready(function() {
             // Show the code block
             var data_id = $(this).attr('data-section-id');
             var code_block = $($("#code_column .code_column[data-section-id='" + data_id + "']").get(fileIndex));
+            // Save the code section for later when the user comes back to this section and we want to show the most recent code viewed.
+            recent_sections[data_id] = code_sections[data_id][fileIndex];
             $('#code_column .code_column').not(code_block).hide();
             code_block.show();
         }
@@ -311,10 +314,12 @@ $(document).ready(function() {
             fileIndex = 0;
         }
         var code_block = code_sections[header.id][fileIndex].code;
-        if(code_block){
+        if(code_block){            
+            // Save the code section for later when the user comes back to this section and we want to show the most recent code viewed.
+            recent_sections[header.id] = code_sections[header.id][fileIndex];
             // Switch to the correct tab
             var tab = code_sections[header.id][fileIndex].tab;
-            setActiveTab(tab);
+            setActiveTab(tab);                       
             showCorrectCodeBlock(header.id, fileIndex, false);
 
             // Highlight the code
@@ -552,10 +557,17 @@ $(document).ready(function() {
                 hideDuplicateTabs(id);
 
                 if(switchTabs){
-                    var subsection_files = code_sections[id];
-                    for(var i = subsection_files.length - 1; i >= 0; i--){
-                        setActiveTab(subsection_files[i].tab, true);
+                    // Load the most recently viewed tab for this section if viewed before.
+                    if(recent_sections[id]){
+                        setActiveTab(recent_sections[id].tab, true);
                     }
+                    else {
+                        var subsection_files = code_sections[id];
+                        for(var i = subsection_files.length - 1; i >= 0; i--){
+                            setActiveTab(subsection_files[i].tab, true);
+                        }
+                    }
+                    
                 }                
             }
         } catch(e) {

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -531,6 +531,9 @@ $(document).ready(function() {
     // activeTab: tab to set active
     // setAsFirstTab: boolean whether to move this active tab to the front or not.
     function setActiveTab(activeTab, setAsFirstTab){
+        if(activeTab.children('a').hasClass('active')){
+            return;
+        }
         $('.code_column_tab > a').removeClass('active');
         activeTab.children('a').addClass('active');
         activeTab.show();


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Save the most recently viewed tab that the user clicked on or switched to via a hotspot so when they scroll back to that section their tab will be restored instead of always the first tab of that section.
#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
