### PR TITLE
Style the first line of a code command action

### DIFF
--- a/src/main/content/_assets/css/guide-multipane.scss
+++ b/src/main/content/_assets/css/guide-multipane.scss
@@ -218,6 +218,19 @@ header {
     border-top:1px solid #c8d6fb;
     border-bottom:1px solid #c8d6fb;
     width: 90%;
+
+    & pre {
+        font-size: 14px;
+        font-family: 'Courier New', Courier, monospace;
+
+        & mark {
+            font-family: Asap;
+            font-weight: 600;
+            color: inherit;
+            background: inherit;
+            padding: 0;
+        }
+    }
 }
 
 #guide_content .code_command > .content:after, #guide_content .code_command > .content:before {


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Style the first line of the code command per this comment:
https://github.com/OpenLiberty/openliberty.io/issues/801#issuecomment-447116765

The first line can be styled by using hashtags around it:
```
[role="code_command hotspot=18-106", subs="quotes"]
----
#Create the `ConsumingRestTest` class#
`src/test/java/it/io/openliberty/guides/consumingrest/ConsumingRestTest.java` 
----
```

![image](https://user-images.githubusercontent.com/6392944/50838735-59ed8700-1324-11e9-98d7-5c9f9ea2ecce.png)

#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [x] Dymanic Accessability Plugin (DAP)
