### PR TITLE
Static tab bar

### DIFF
--- a/src/main/content/_assets/css/guide-multipane.scss
+++ b/src/main/content/_assets/css/guide-multipane.scss
@@ -554,6 +554,7 @@ header {
 .code_column .CodeRay code, .code_column .CodeRay .highlightSection {
     padding-left: 23px;
     padding-right: 31px;
+    padding-bottom: 34px;
 }
 
 .codeTitle {

--- a/src/main/content/_assets/css/guide-multipane.scss
+++ b/src/main/content/_assets/css/guide-multipane.scss
@@ -343,6 +343,10 @@ header {
     left: calc(100% - 780px); /* Adjust for the width and padding */
     top: 100px;
     bottom: 0; /* Initially extend the code column the full height */
+}
+
+#code_column_content {
+    height: calc(100% - 34px); /* Take up the remaining height from the tabs container */
     overflow-y: scroll;
 }
 

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -371,23 +371,18 @@ $(document).ready(function() {
         $(this).stop(); // Stop animations taking place with this code section.
 
         var event0 = event.originalEvent;
-        var dir = (event0.deltaY) < 0 ? 'up' : 'down';        
-        var hasVerticalScrollbar = false;
+        var dir = (event0.deltaY) < 0 ? 'up' : 'down';
         var codeColumn = $("#code_column")[0];
         var codeColumnContent = $("#code_column_content").get(0);
 
-        // Check if element is scrollable.
-        if(this.scrollTop > 0 || this.offsetHeight > codeColumn.offsetHeight){
-            hasVerticalScrollbar = true;
-        }
-
-        if(!hasVerticalScrollbar){
-            // If the code file has no scrollbar, the page will still scroll if the event is propagated to the window scroll listener.
+        if(!(this.scrollTop > 0 || this.offsetHeight > codeColumn.offsetHeight)){
+            // Element is not scrollable. If the code file has no scrollbar, the page will still scroll if the event is propagated to the window scroll listener so we need to prevent propagation.
             event.stopPropagation();
             event.preventDefault();
         }
+
         // If the code column is at the top and the browser is scrolled down, the element has no scrollTop and does not respond to changing its scrollTop.
-        else if(!(dir == 'down' && codeColumn.scrollTop === 0)){
+        else if(!(dir == 'down' && this.parentElement.scrollTop === 0)){
             var delta = event0.wheelDelta || -event0.detail || -event0.deltaY;
             // Firefox's scroll value is always 1 so multiply by 150 to scroll faster.
             if(delta === 1 || delta === -1){
@@ -397,6 +392,7 @@ $(document).ready(function() {
             codeColumnContent.scrollTop -= delta;
             handleGithubPopup();
             event.preventDefault();  
+            event.stopPropagation();
         }            
     });
 

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -375,7 +375,7 @@ $(document).ready(function() {
         var codeColumn = $("#code_column")[0];
         var codeColumnContent = $("#code_column_content").get(0);
 
-        if(!(this.scrollTop > 0 || this.offsetHeight > codeColumn.offsetHeight)){
+        if(!(this.scrollTop > 0 || this.offsetHeight > codeColumnContent.offsetHeight)){
             // Element is not scrollable. If the code file has no scrollbar, the page will still scroll if the event is propagated to the window scroll listener so we need to prevent propagation.
             event.stopPropagation();
             event.preventDefault();

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -62,7 +62,7 @@ $(document).ready(function() {
             
             $('#code_column_tabs').append(tab);
             duplicate_code_block.addClass('dimmed_code_column'); // Dim the code at first while the github popup takes focus.
-            duplicate_code_block.appendTo('#code_column'); // Move code to the right column
+            duplicate_code_block.appendTo('#code_column_content'); // Move code to the right column
         }
     });
 
@@ -152,9 +152,9 @@ $(document).ready(function() {
         var highlight_end = code_section.find('.line-numbers:contains(' + (toLine + 1) + ')').first();        
         var range = highlight_start.nextUntil(highlight_end);
         range.wrapAll("<div class='highlightSection'></div>");
-        var scrollTop = $("#code_column")[0].scrollTop;
+        var scrollTop = $("#code_column_content")[0].scrollTop;
         var position = range.position().top;
-        $("#code_column").animate({scrollTop: scrollTop + position - 50});
+        $("#code_column_content").animate({scrollTop: scrollTop + position - 50});
     }
 
     // Remove all highlighting for the code section.
@@ -373,10 +373,11 @@ $(document).ready(function() {
         var event0 = event.originalEvent;
         var dir = (event0.deltaY) < 0 ? 'up' : 'down';        
         var hasVerticalScrollbar = false;
-        var codeColumn = $("#code_column").get(0);
+        var codeColumn = $("#code_column")[0];
+        var codeColumnContent = $("#code_column_content").get(0);
 
         // Check if element is scrollable.
-        if(this.scrollTop > 0 || this.offsetHeight > this.parentElement.offsetHeight){
+        if(this.scrollTop > 0 || this.offsetHeight > codeColumn.offsetHeight){
             hasVerticalScrollbar = true;
         }
 
@@ -392,7 +393,8 @@ $(document).ready(function() {
             if(delta === 1 || delta === -1){
                 delta *= 150;
             }
-            codeColumn.scrollTop -= delta;
+            // this.scrollTop -= delta;
+            codeColumnContent.scrollTop -= delta;
             handleGithubPopup();
             event.preventDefault();  
         }            
@@ -423,7 +425,7 @@ $(document).ready(function() {
             var position = current_target_object.position();	
             $('#code_section_copied_confirmation').css({	
                 top: position.top + 30,	
-                right: 5	
+                right: 25	
             }).stop().fadeIn().delay(1000).fadeOut();
         } else {
             alert('Copy failed. Copy the code manually: ' + target.text());

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -388,7 +388,6 @@ $(document).ready(function() {
             if(delta === 1 || delta === -1){
                 delta *= 150;
             }
-            // this.scrollTop -= delta;
             codeColumnContent.scrollTop -= delta;
             handleGithubPopup();
             event.preventDefault();  
@@ -530,7 +529,12 @@ $(document).ready(function() {
         if(setAsFirstTab){
             activeTab.detach();
             $('#code_column_tabs').prepend(activeTab);
-        }        
+        }
+        // Adjust the code content to take up the remaining height
+        var tabListHeight = $("#code_column_tabs").outerHeight();
+        $("code_column_content").css({
+            "height": "calc(100% - " + tabListHeight + "px)"
+        });
     }
 
     // Hide other code blocks and show the correct code block based on provided id.

--- a/src/main/content/_layouts/guide-multipane.html
+++ b/src/main/content/_layouts/guide-multipane.html
@@ -102,6 +102,7 @@ js:
                         <img src='/img/guide_copy_button.svg' alt='Copy file contents' />
                     </div>
                 </div>
+                <div id="code_column_content"></div>
 
                 <div id="github_clone_popup_container" style="display: none">
                     <div id="github_clone_popup" tabindex="0">


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Made the tabs always sticky to the top of the code panel:
![image](https://user-images.githubusercontent.com/6392944/51119328-2bfebb80-17d8-11e9-891b-6966425de0c4.png)

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
