### PR TITLE
Highligh Open Liberty in download statement

### DIFF
--- a/src/main/content/_includes/end-of-guide.html
+++ b/src/main/content/_includes/end-of-guide.html
@@ -27,7 +27,7 @@
             <h3 id="where_to_next">Where to next?</h3>
 
             {% if page.layout == 'iguide-multipane' %}
-                <p><a target="_blank" rel="noopener noreferrer" href="https://github.com/OpenLiberty/iguide-{{page.url | replace: '/guides/', ''}}/tree/master/finish">Download the sample application for this guide on github</a></p>
+                <p><a target="_blank" rel="noopener noreferrer" href="https://github.com/OpenLiberty/iguide-{{page.url | replace: '/guides/', ''}}/tree/master/finish">Download the sample application for this guide bundled with Open Liberty on github</a></p>
                 <br>
             {% endif %}
             {% if page.categories %}


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
For interactive guides, add reference to Open Liberty in the download statement:

"Download the sample application for this guide bundled with Open Liberty on github."

Request made via issue OpenLiberty/iguides-common#121

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
