### PR TITLE
Hide the github popup when the first hotspot is visible

### DIFF
--- a/src/main/content/_assets/css/guide-multipane.scss
+++ b/src/main/content/_assets/css/guide-multipane.scss
@@ -346,7 +346,7 @@ header {
     overflow-y: scroll;
 }
 
-.dimmed_code_column {
+.dimmed {
     opacity: .19;
     filter: blur(1px);
 }

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -62,7 +62,7 @@ $(document).ready(function() {
             metadata_sect.detach();            
             $('#code_column_tabs').append(tab);            
 
-            duplicate_code_block.addClass('dimmed_code_column'); // Dim the code at first while the github popup takes focus.
+            duplicate_code_block.addClass('dimmed'); // Dim the code at first while the github popup takes focus.
             duplicate_code_block.appendTo('#code_column'); // Move code to the right column
         }
     });
@@ -177,7 +177,7 @@ $(document).ready(function() {
     //         toLine: The line in the code block to end copying.
     function create_mobile_code_snippet(snippet, code_block, fromLine, toLine){
         var duplicate_code_block = code_block.clone();
-        duplicate_code_block.removeClass('dimmed_code_column'); // Remove the blur from the original code block;
+        duplicate_code_block.removeClass('dimmed'); // Remove the blur from the original code block;
         duplicate_code_block.addClass('mobile_code_snippet'); // Add class to this code snippet in the guide column to only show up in mobile view.
         duplicate_code_block.removeClass('code_columnn');
         duplicate_code_block.removeAttr('filename');
@@ -483,6 +483,20 @@ $(document).ready(function() {
         }
     });
 
+    function showGithubPopup(){
+        $("#github_clone_popup_container").fadeIn();
+        $("#code_column .code_column, #code_column_tabs").addClass('dimmed', {duration:400});
+        $('.code_column_tab').attr('disabled', true);
+        $(".copyFileButton").hide();
+    }
+
+    function hideGithubPopup(){
+        $("#github_clone_popup_container").fadeOut();
+        $("#code_column .code_column, #code_column_tabs").removeClass('dimmed', {duration:400});
+        $('.code_column_tab').attr('disabled', false);
+        $(".copyFileButton").show();
+    }
+
     /*
        Handle showing/hiding the Github popup.
     */
@@ -490,22 +504,23 @@ $(document).ready(function() {
         var githubPopup = $("#github_clone_popup_container");
         if(githubPopup.length > 0){
             // Check if the first guide section that has code to show on the right has been scrolled past yet.
+            // If so, then the Github popup will be dismissed. If the first section hasn't been scrolled past yet but a hotspot is showing on the next section then also hide it. 
+            var navHeight = $('.navbar').height();
             var firstCodeSection = $('[data-has-code]').first();
             if(firstCodeSection.is('h3')){
                 firstCodeSection = firstCodeSection.parents('.sect1').find('h2').first();
             }
             var firstCodeSectionTop = Math.round(firstCodeSection[0].getBoundingClientRect().top);
-            var navHeight = $('.navbar').height();
-            var showGithubPopup = (firstCodeSectionTop - navHeight) > 1;
-            if(showGithubPopup){
-                githubPopup.fadeIn();
-                $("#code_column .code_column").addClass('dimmed_code_column', {duration:400});
-                $('.code_column_tab').attr('disabled', true);
+            var blurCodeOnRight = (firstCodeSectionTop - navHeight) > 1;
+
+            var firstHotspot = $("#guide_column .hotspot:visible")[0];
+            var firstHotspotRect = firstHotspot.getBoundingClientRect();
+            var firstHotspotInView = (firstHotspotRect.top > 0) && (firstHotspotRect.bottom <= window.innerHeight);
+            if(blurCodeOnRight && !firstHotspotInView){
+                showGithubPopup();
             }
             else{            
-                githubPopup.fadeOut();
-                $("#code_column .code_column").removeClass('dimmed_code_column', {duration:400});
-                $('.code_column_tab').attr('disabled', false);
+                hideGithubPopup();         
             }
         }                
     }

--- a/src/main/content/_layouts/guide-multipane.html
+++ b/src/main/content/_layouts/guide-multipane.html
@@ -97,8 +97,8 @@ js:
             <!-- Code section -->
             <div id="code_column" class="position_relative" tabindex="0">
                 <div id='code_column_title_container'>
-                    <ul id='code_column_tabs' class='nav' role='tablist'></ul>
-                    <div class='copyFileButton' tabindex=0>
+                    <ul id='code_column_tabs' class='nav dimmed' role='tablist'></ul>
+                    <div class='copyFileButton' tabindex=0 style="display: none;">
                         <img src='/img/guide_copy_button.svg' alt='Copy file contents' />
                     </div>
                 </div>


### PR DESCRIPTION
Blur out the code panel tabs and hide the copy button until the github popup is dismissed
Fixes #877 
Fixes #875 
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
