### PR TITLE
Change the tab structure so the tabs don't touch the copy file button

### DIFF
--- a/src/main/content/_assets/css/guide-multipane.scss
+++ b/src/main/content/_assets/css/guide-multipane.scss
@@ -23,10 +23,62 @@ header {
     width: 100%;
 }
 
-.copyFileButton {
+#code_column_tabs_container {
     display: inline-block;
+
+    #code_column_tabs {
+        max-width: calc(100% - 50px);
+        & > li {
+            float: left;
+    
+            & > a {
+                text-overflow: ellipsis;
+                overflow: hidden;
+                white-space: nowrap;
+                text-align: center;  
+                letter-spacing: 0;
+                height: 32px;
+                padding: 2px 5px 4px 5px;
+                border: 1px solid #acb3c6;
+                border-bottom: transparent;
+                margin-right: 0;           /* Overlay bootstrap's margin so tabs are condensed   */
+                color: #5D6A8E !important;
+                line-height: 26px;
+    
+                &.active {
+                    background-color: #c7ccd9;
+                    color: #3f465a !important;
+                }
+    
+                &:hover {
+                    background-color: #D6DAE6;
+                    cursor: pointer;
+                }
+            }
+            
+            /* Keep below to override the normal styling */
+            &[disabled] {
+                pointer-events: none;
+                outline: none;
+    
+                & > a {
+                    background-color: inherit;
+                }
+            }
+        }        
+    }
+
+    @media (min-width: 1170px) {
+        width: 100%;
+        border-radius: 4px 4px 4px 4px;
+        border: 1px solid #c8d6fb;
+    }
+    
+}
+
+.copyFileButton {
     position: absolute;
-    right: 26px;
+    right: 15px;
     top: 6px;
     line-height: 5px;
     padding: 4px;
@@ -367,53 +419,6 @@ header {
     color: #3f465a;       
     display: table-cell;
     vertical-align: middle;
-}
-
-#code_column_tabs {
-    & > li {
-        max-width: 50%;
-        float: left;
-
-        & > a {
-            text-overflow: ellipsis;
-            overflow: hidden;
-            white-space: nowrap;
-            text-align: center;  
-            letter-spacing: 0;
-            height: 32px;
-            padding: 2px 5px 4px 5px;
-            border: 1px solid #acb3c6;
-            border-bottom: transparent;
-            margin-right: 0;           /* Overlay bootstrap's margin so tabs are condensed   */
-            color: #5D6A8E !important;
-            line-height: 26px;
-
-            &.active {
-                background-color: #c7ccd9;
-                color: #3f465a !important;
-            }
-
-            &:hover {
-                background-color: #D6DAE6;
-                cursor: pointer;
-            }
-        }
-        
-        /* Keep below to override the normal styling */
-        &[disabled] {
-            pointer-events: none;
-            outline: none;
-
-            & > a {
-                background-color: inherit;
-            }
-        }
-    }
-
-    @media (min-width: 1170px) {
-        border-radius: 4px 4px 4px 4px;
-        border: 1px solid #c8d6fb;
-     }
 }
 
 #github_clone_popup_container {

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -417,7 +417,7 @@ $(document).ready(function() {
         temp.css({
             'position':'absolute',
             'top':'-1000px',
-            'left':'-1000px'
+            'left':'-1000px'            
         });
         temp.html(target.html().trim());
         $('body').append(temp);
@@ -428,7 +428,7 @@ $(document).ready(function() {
             var position = current_target_object.position();	
             $('#code_section_copied_confirmation').css({	
                 top: position.top + 30,	
-                right: 5	
+                right: 5
             }).stop().fadeIn().delay(1000).fadeOut();
         } else {
             alert('Copy failed. Copy the code manually: ' + target.text());

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -580,8 +580,8 @@ $(document).ready(function() {
             $('#code_column_tabs').prepend(activeTab);
         }
         // Adjust the code content to take up the remaining height
-        var tabListHeight = $("#code_column_tabs").outerHeight();
-        $("code_column_content").css({
+        var tabListHeight = $("#code_column_title_container").outerHeight();
+        $("#code_column_content").css({
             "height": "calc(100% - " + tabListHeight + "px)"
         });
     }

--- a/src/main/content/_layouts/guide-multipane.html
+++ b/src/main/content/_layouts/guide-multipane.html
@@ -97,7 +97,9 @@ js:
             <!-- Code section -->
             <div id="code_column" class="position_relative" tabindex="0">
                 <div id='code_column_title_container'>
-                    <ul id='code_column_tabs' class='nav' role='tablist'></ul>
+                    <div id='code_column_tabs_container'>
+                        <ul id='code_column_tabs' class='nav' role='tablist'></ul>
+                    </div>                    
                     <div class='copyFileButton' tabindex=0>
                         <img src='/img/guide_copy_button.svg' alt='Copy file contents' />
                     </div>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Fixes the overlap of tabs with the copy file button.
Also fixed the code column content height due to the change in tab structure:
![image](https://user-images.githubusercontent.com/6392944/51209552-1b346f80-18d6-11e9-9aae-4ed622753dea.png)

#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [x] Dymanic Accessability Plugin (DAP)
