### PR TITLE
Do not change ordering of tabs when scrolling and keep order of tabs introduced in the guide

### DIFF
--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -60,7 +60,14 @@ $(document).ready(function() {
 
             // Remove old title from the DOM
             metadata_sect.detach();            
-            $('#code_column_tabs').append(tab);
+
+            // If the same tab exists already in the list, append it in the same order to persist the order it was introduced in the guide.
+            var tabAlreadyExists =  $('#code_column_tabs li').filter(":contains('" + fileName + "')");
+            if(tabAlreadyExists.length > 0){
+                tabAlreadyExists.last().after(tab);
+            } else {
+                $('#code_column_tabs').append(tab);
+            }            
 
             duplicate_code_block.addClass('dimmed'); // Dim the code at first while the github popup takes focus.
             duplicate_code_block.appendTo('#code_column_content'); // Move code to the right column
@@ -546,39 +553,38 @@ $(document).ready(function() {
             if(tabsWithSameName.length > 0){
                 // Compare to other tabs in this section to see if their content matches
                 tabsWithSameName.each(function(){
+                    if($(this).find('a').hasClass('active')){
+                        return;
+                    }
                     var fileIndex2 = $(this).data('file-index');
                     var data_id2 = $(this).attr('data-section-id');
                     var code_block2 = $($("#code_column .code_column[data-section-id='" + data_id2 + "']").get(fileIndex2));
 
                     if(substepIds.indexOf(data_id2) === -1){
-                        // Tab is not associated with this subsection so hide it.                        
+                        // Tab is not associated with this subsection so hide it.             
                         $(this).hide();
                     }
                     else {
                         // Other tab is from the same section, compare file contents to determine if it is a duplicate.
-                        if(code_block.text() === code_block2.text()){                            
+                        if(code_block.text() === code_block2.text()){          
                             $(this).hide();
                         }            
                     }
                 });
-            }            
+            }     
         });
     }
 
     // Sets the active tab in the code column and moves it to the front of the tab list.
     // activeTab: tab to set active
-    // setAsFirstTab: boolean whether to move this active tab to the front or not.
-    function setActiveTab(activeTab, setAsFirstTab){
+    function setActiveTab(activeTab){
         if(activeTab.children('a').hasClass('active')){
             return;
         }
         $('.code_column_tab > a').removeClass('active');
         activeTab.children('a').addClass('active');
         activeTab.show();
-        if(setAsFirstTab){
-            activeTab.detach();
-            $('#code_column_tabs').prepend(activeTab);
-        }
+
         // Adjust the code content to take up the remaining height
         var tabListHeight = $("#code_column_tabs").outerHeight();
         $("code_column_content").css({
@@ -610,10 +616,10 @@ $(document).ready(function() {
                     // Load all of the tabs for this section
                     var subsection_files = code_sections[id];
                     for(var i = subsection_files.length - 1; i >= 0; i--){
-                        setActiveTab(subsection_files[i].tab, true);
+                        setActiveTab(subsection_files[i].tab);
                     }
                     if(recent_sections[id]) {
-                        setActiveTab(tab, true);
+                        setActiveTab(tab);
                     }
                 }               
                 

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -575,6 +575,20 @@ $(document).ready(function() {
         });
     }
 
+    function loadPreviousStepsTabs(){
+        // Reveal the files from previous sections in case the user loaded a later step from a bookmarked hash.
+        var lastTab = $('#code_column_tabs li:visible').last();
+        var previousHiddenTabs = lastTab.prevAll().not(":visible");
+        for(var i = previousHiddenTabs.length - 1; i >= 0; --i){
+            let tab = previousHiddenTabs.get(i);
+            let fileName = tab.innerText.trim();
+            // Check that the most recent tab for this file is showing.
+            if($('#code_column_tabs li:visible').filter(":contains('" + fileName + "')").length == 0){
+                $(tab).show();
+            }
+        }
+    };
+
     // Sets the active tab in the code column and moves it to the front of the tab list.
     // activeTab: tab to set active
     function setActiveTab(activeTab){
@@ -621,8 +635,7 @@ $(document).ready(function() {
                     if(recent_sections[id]) {
                         setActiveTab(tab);
                     }
-                }               
-                
+                }
                 hideDuplicateTabs(id);
             }
         } catch(e) {
@@ -717,6 +730,7 @@ $(document).ready(function() {
             var hash = location.hash;
             accessContentsFromHash(hash);
             showCorrectCodeBlock(hash.substring(1), null, true);  // Remove the '#' in front of the id
+            loadPreviousStepsTabs();
         }
 
         if(window.location.hash === ""){


### PR DESCRIPTION
Do not switch order of tabs
Add new files introduced to the right of the tab list
Load all previous steps' tabs when visiting a later step via a bookmark hash

#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
