### PR TITLE
Remove hotspots extra padding

### DIFF
--- a/src/main/content/_assets/css/guide-multipane.scss
+++ b/src/main/content/_assets/css/guide-multipane.scss
@@ -549,12 +549,12 @@ header {
 
 .code_column .CodeRay code {
     display: block;
+    padding-bottom: 34px;
 }
 
 .code_column .CodeRay code, .code_column .CodeRay .highlightSection {
     padding-left: 23px;
-    padding-right: 31px;
-    padding-bottom: 34px;
+    padding-right: 31px;   
 }
 
 .codeTitle {


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Css selector for the code pane on the right was also adding padding to the bottom of a hotspot, making it look like an extra line was inserted.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
