### PR TITLE
Full file hotspot

### DIFF
--- a/src/main/content/_assets/css/guide-multipane.scss
+++ b/src/main/content/_assets/css/guide-multipane.scss
@@ -582,21 +582,11 @@ header {
         background-color: #F1F4FE;
         color:#5e6b8d;
     }
-    
-    #guide_content code.hotspot:hover, #guide_content .hotspot pre:hover, #guide_content .code_command.hotspot:hover pre {
+
+    #guide_content code.hotspot:not(.code_command):hover {
         color: #24253A;
         background-color: #C7CCD9;
         cursor: pointer;
-    }
-    
-    #guide_content .code_command.hotspot:hover > .content:before {
-        cursor: pointer;
-        background: linear-gradient(to top right, #C7CCD9 48%, #c8d6fb calc(48% + 1px), transparent calc(48% + 2px));
-    }
-    
-    #guide_content .code_command.hotspot:hover > .content:after{
-        cursor: pointer;
-        background: linear-gradient(to bottom right, #C7CCD9 48%, #c8d6fb calc(48% + 1px), transparent calc(48% + 2px));
     }
 }
     

--- a/src/main/content/_assets/css/guide-multipane.scss
+++ b/src/main/content/_assets/css/guide-multipane.scss
@@ -586,7 +586,6 @@ header {
     #guide_content code.hotspot:not(.code_command):hover {
         color: #24253A;
         background-color: #C7CCD9;
-        cursor: pointer;
     }
 }
     

--- a/src/main/content/_assets/css/guide-multipane.scss
+++ b/src/main/content/_assets/css/guide-multipane.scss
@@ -549,12 +549,12 @@ header {
 
 .code_column .CodeRay code {
     display: block;
+    padding-bottom: 34px;
 }
 
 .code_column .CodeRay code, .code_column .CodeRay .highlightSection {
     padding-left: 23px;
-    padding-right: 31px;
-    padding-bottom: 34px;
+    padding-right: 31px;   
 }
 
 .codeTitle {


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
If a hotspot refers to a whole file, then it will just switch to that file and not highlight it.
Removed the hover state for code commands (arrows) that say to create/action/etc. something in the code and it has a similar behavior to switch to the file its talking about but not highlight.
Built off of https://github.com/OpenLiberty/openliberty.io/pull/891
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
