### PR TITLE
Change the tab structure so the tabs don't touch the copy file button (redeliver)

### DIFF
--- a/src/main/content/_assets/css/guide-multipane.scss
+++ b/src/main/content/_assets/css/guide-multipane.scss
@@ -395,6 +395,7 @@ header {
     left: calc(100% - 780px); /* Adjust for the width and padding */
     top: 100px;
     bottom: 0; /* Initially extend the code column the full height */
+    overflow: hidden;
 }
 
 #code_column_content {

--- a/src/main/content/_assets/css/guide-multipane.scss
+++ b/src/main/content/_assets/css/guide-multipane.scss
@@ -23,10 +23,62 @@ header {
     width: 100%;
 }
 
-.copyFileButton {
+#code_column_tabs_container {
     display: inline-block;
+
+    #code_column_tabs {
+        max-width: calc(100% - 50px);
+        & > li {
+            float: left;
+    
+            & > a {
+                text-overflow: ellipsis;
+                overflow: hidden;
+                white-space: nowrap;
+                text-align: center;  
+                letter-spacing: 0;
+                height: 32px;
+                padding: 2px 5px 4px 5px;
+                border: 1px solid #acb3c6;
+                border-bottom: transparent;
+                margin-right: 0;           /* Overlay bootstrap's margin so tabs are condensed   */
+                color: #5D6A8E !important;
+                line-height: 26px;
+    
+                &.active {
+                    background-color: #c7ccd9;
+                    color: #3f465a !important;
+                }
+    
+                &:hover {
+                    background-color: #D6DAE6;
+                    cursor: pointer;
+                }
+            }
+            
+            /* Keep below to override the normal styling */
+            &[disabled] {
+                pointer-events: none;
+                outline: none;
+    
+                & > a {
+                    background-color: inherit;
+                }
+            }
+        }        
+    }
+
+    @media (min-width: 1170px) {
+        width: 100%;
+        border-radius: 4px 4px 4px 4px;
+        border: 1px solid #c8d6fb;
+    }
+    
+}
+
+.copyFileButton {
     position: absolute;
-    right: 26px;
+    right: 15px;
     top: 6px;
     line-height: 5px;
     padding: 4px;
@@ -371,53 +423,6 @@ header {
     color: #3f465a;       
     display: table-cell;
     vertical-align: middle;
-}
-
-#code_column_tabs {
-    & > li {
-        max-width: 50%;
-        float: left;
-
-        & > a {
-            text-overflow: ellipsis;
-            overflow: hidden;
-            white-space: nowrap;
-            text-align: center;  
-            letter-spacing: 0;
-            height: 32px;
-            padding: 2px 5px 4px 5px;
-            border: 1px solid #acb3c6;
-            border-bottom: transparent;
-            margin-right: 0;           /* Overlay bootstrap's margin so tabs are condensed   */
-            color: #5D6A8E !important;
-            line-height: 26px;
-
-            &.active {
-                background-color: #c7ccd9;
-                color: #3f465a !important;
-            }
-
-            &:hover {
-                background-color: #D6DAE6;
-                cursor: pointer;
-            }
-        }
-        
-        /* Keep below to override the normal styling */
-        &[disabled] {
-            pointer-events: none;
-            outline: none;
-
-            & > a {
-                background-color: inherit;
-            }
-        }
-    }
-
-    @media (min-width: 1170px) {
-        border-radius: 4px 4px 4px 4px;
-        border: 1px solid #c8d6fb;
-     }
 }
 
 #github_clone_popup_container {

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -421,7 +421,7 @@ $(document).ready(function() {
         temp.css({
             'position':'absolute',
             'top':'-1000px',
-            'left':'-1000px'
+            'left':'-1000px'            
         });
         temp.html(target.html().trim());
         $('body').append(temp);
@@ -489,14 +489,14 @@ $(document).ready(function() {
 
     function showGithubPopup(){
         $("#github_clone_popup_container").fadeIn();
-        $("#code_column .code_column, #code_column_tabs").addClass('dimmed', {duration:400});
+        $("#code_column .code_column, #code_column_tabs_container").addClass('dimmed', {duration:400});
         $('.code_column_tab').attr('disabled', true);
         $(".copyFileButton").hide();
     }
 
     function hideGithubPopup(){
         $("#github_clone_popup_container").fadeOut();
-        $("#code_column .code_column, #code_column_tabs").removeClass('dimmed', {duration:400});
+        $("#code_column .code_column, #code_column_tabs_container").removeClass('dimmed', {duration:400});
         $('.code_column_tab').attr('disabled', false);
         $(".copyFileButton").show();
     }
@@ -600,8 +600,8 @@ $(document).ready(function() {
         activeTab.show();
 
         // Adjust the code content to take up the remaining height
-        var tabListHeight = $("#code_column_tabs").outerHeight();
-        $("code_column_content").css({
+        var tabListHeight = $("#code_column_title_container").outerHeight();
+        $("#code_column_content").css({
             "height": "calc(100% - " + tabListHeight + "px)"
         });
     }

--- a/src/main/content/_layouts/guide-multipane.html
+++ b/src/main/content/_layouts/guide-multipane.html
@@ -97,7 +97,9 @@ js:
             <!-- Code section -->
             <div id="code_column" class="position_relative" tabindex="0">
                 <div id='code_column_title_container'>
-                    <ul id='code_column_tabs' class='nav dimmed' role='tablist'></ul>
+                    <div id='code_column_tabs_container' class='dimmed'>
+                        <ul id='code_column_tabs' class='nav' role='tablist'></ul>
+                    </div>                    
                     <div class='copyFileButton' tabindex=0 style="display: none;">
                         <img src='/img/guide_copy_button.svg' alt='Copy file contents' />
                     </div>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Fixes the overlap of tabs with the copy file button.
Also fixed the code column content height due to the change in tab structure:
![image](https://user-images.githubusercontent.com/6392944/51209552-1b346f80-18d6-11e9-9aae-4ed622753dea.png)
Fixed overflow of the code column into the end of guide (for the static guides, interactive guides already had the same fix).

Redeliver of https://github.com/OpenLiberty/openliberty.io/pull/886 but with an extra fix for the tabs overflowing into the end of the guide part.
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [x] Dymanic Accessability Plugin (DAP)
