### PR TITLE
Fix white line between before and after pseudo elements

### DIFF
--- a/src/main/content/_assets/css/guide-multipane.scss
+++ b/src/main/content/_assets/css/guide-multipane.scss
@@ -291,7 +291,7 @@ header {
     position: absolute;
     left: 100%;
     width: 40px;
-    height: 50%;
+    height: 50.2%;
 }
 #guide_content .code_command > .content:before {
     top: 0px;


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
There was a white line in the code commands at a very specific browser zoom.
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
