### PR TITLE
Support [hotspot] to switch to a file but not highlight it

### DIFF
--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -239,10 +239,20 @@ $(document).ready(function() {
     // Parse the hotspot lines to highlight and store them as a data attribute.
     $('code[class*=hotspot], span[class*=hotspot], div[class*=hotspot]').each(function(){
         var snippet = $(this);
-        var code_block = get_code_block_from_hotspot(snippet);
         var classList = this.classList;
         var line_nums, ranges;
+
+        // Find if the hotspot has a file index set to override the default behavior.
         for(var i = 0; i < classList.length; i++){
+            if(classList[i].indexOf('file=') === 0){
+                var fileIndex = classList[i].substring(5);
+                snippet.data('file-index', parseInt(fileIndex));
+            }
+        }
+
+        var code_block = get_code_block_from_hotspot(snippet);
+
+        for(i = 0; i < classList.length; i++){
             var className = classList[i];
             if(className.indexOf('hotspot') === 0){
                 var fromLine, toLine;
@@ -270,22 +280,12 @@ $(document).ready(function() {
                         snippet.data('highlight-ranges', ranges);
                     }
                 } else {
-                    // Hotspot does not highlight lines, it just switches to the file.
+                    // Hotspot does not highlight lines, it just switches to the file. 
                     var num_lines = parseInt(code_block.find('.line-numbers').last().text());  
                     fromLine = 1;
                     toLine = num_lines;
-                }
-                                    
+                }                                    
                 snippet.addClass('hotspot');
-
-                // Find if the hotspot has a file index set to override the default behavior.
-                for(var j = 0; j < classList.length; j++){
-                    if(classList[j].indexOf('file=') === 0){
-                        var fileIndex = classList[j].substring(5);
-                        $(this).data('file-index', parseInt(fileIndex));
-                    }
-                }
-                
                 create_mobile_code_snippet(snippet, code_block, fromLine, toLine);
             }              
         }

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -167,7 +167,8 @@ $(document).ready(function() {
         if(scroll){
             var scrollTop = $("#code_column_content")[0].scrollTop;
             var position = range.position().top;
-            $("#code_column_content").animate({scrollTop: scrollTop + position - 50});
+            var titleBarHeight = $("#code_column_title_container").outerHeight();
+            $("#code_column_content").animate({scrollTop: scrollTop + position - titleBarHeight});
         }        
     }
 

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -65,7 +65,8 @@ $(document).ready(function() {
             var tabAlreadyExists =  $('#code_column_tabs li').filter(":contains('" + fileName + "')");
             if(tabAlreadyExists.length > 0){
                 tabAlreadyExists.last().after(tab);
-            } else {
+            } 
+            else {
                 $('#code_column_tabs').append(tab);
             }            
 
@@ -267,7 +268,8 @@ $(document).ready(function() {
                         fromLine = parseInt(lines[0]);
                         toLine = parseInt(lines[1]);
                         ranges = line_nums;
-                    } else {
+                    } 
+                    else {
                         // Only one line to highlight.
                         fromLine = parseInt(line_nums);
                         toLine = parseInt(line_nums);
@@ -280,10 +282,11 @@ $(document).ready(function() {
                         old_ranges += "," + ranges;
                         snippet.data('highlight-ranges', old_ranges);                    
                     }
-                    else{
+                    else {
                         snippet.data('highlight-ranges', ranges);
                     }
-                } else {
+                } 
+                else {
                     // Hotspot does not highlight lines, it just switches to the file. 
                     var num_lines = parseInt(code_block.find('.line-numbers').last().text());  
                     fromLine = 1;

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -239,20 +239,25 @@ $(document).ready(function() {
     // Parse the hotspot lines to highlight and store them as a data attribute.
     $('code[class*=hotspot], span[class*=hotspot], div[class*=hotspot]').each(function(){
         var snippet = $(this);
+        var code_block = get_code_block_from_hotspot(snippet);
         var classList = this.classList;
         var line_nums, ranges;
         for(var i = 0; i < classList.length; i++){
             var className = classList[i];
             if(className.indexOf('hotspot=') === 0){
-                line_nums = className.substring(8);
+                line_nums = className.substring(8);                
                 var fromLine, toLine;
-                if(line_nums.indexOf('-') > -1){
+                if(line_nums === "*"){
+                    var num_lines = parseInt(code_block.find('.line-numbers').last().text());    
+                    fromLine = 1;
+                    toLine = num_lines;                
+                    ranges = fromLine + "-" + toLine;
+                } else if(line_nums.indexOf('-') > -1){
                     var lines = line_nums.split('-');
                     fromLine = parseInt(lines[0]);
                     toLine = parseInt(lines[1]);
                     ranges = line_nums;
-                }
-                else {
+                } else {
                     // Only one line to highlight.
                     fromLine = parseInt(line_nums);
                     toLine = parseInt(line_nums);
@@ -277,8 +282,7 @@ $(document).ready(function() {
                         $(this).data('file-index', parseInt(fileIndex));
                     }
                 }
-
-                var code_block = get_code_block_from_hotspot(snippet);
+                
                 create_mobile_code_snippet(snippet, code_block, fromLine, toLine);
             }  
         }

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -285,12 +285,6 @@ $(document).ready(function() {
                     else {
                         snippet.data('highlight-ranges', ranges);
                     }
-                } 
-                else {
-                    // Hotspot does not highlight lines, it just switches to the file. 
-                    var num_lines = parseInt(code_block.find('.line-numbers').last().text());  
-                    fromLine = 1;
-                    toLine = num_lines;
                 }                                    
                 snippet.addClass('hotspot');
                 create_mobile_code_snippet(snippet, code_block, fromLine, toLine);
@@ -357,13 +351,10 @@ $(document).ready(function() {
                         var fromLine = parseInt(lines[0]);
                         var toLine = parseInt(lines[1]);
                         var num_Lines = parseInt(code_block.find('.line-numbers').last().text());
-                        if(fromLine && toLine){
-                            // If a hotspot refers to a whole file, do not highlight it.    
-                            if(!(fromLine === 1 && toLine >= num_Lines)){               
-                                // When multiple ranges are going to be highlighted, only scroll to the first one.                 
-                                var shouldScroll = (i === 0);
-                                highlight_code_range(code_block, fromLine, toLine, shouldScroll);
-                            }                            
+                        if(fromLine && toLine){   
+                            // When multiple ranges are going to be highlighted, only scroll to the first one.                 
+                            var shouldScroll = (i === 0);
+                            highlight_code_range(code_block, fromLine, toLine, shouldScroll);               
                         }
                     }                
                 }


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
This is to support [hotspot] for hotspots to switch to a file but not highlight it.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
