### PR TITLE
Remove gray boxes behind html in Coderay

### DIFF
--- a/src/main/content/_assets/css/coderay-custom.css
+++ b/src/main/content/_assets/css/coderay-custom.css
@@ -81,7 +81,7 @@ table.CodeRay td { padding: 2px 4px; vertical-align: top; }
 .CodeRay .hex { color:#02b }
 .CodeRay .id  { color:#33D; font-weight:500 }
 .CodeRay .include { color:#554099; font-weight:500 }
-.CodeRay .inline { background-color: hsla(0,0%,0%,0.07); color: black }
+.CodeRay .inline { color: black }
 .CodeRay .inline-delimiter { font-weight: 500; color: #666 }
 .CodeRay .instance-variable { color:#33B }
 .CodeRay .integer  { color:#00D }


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Removed gray boxes that coderay put in html snippets. Confirmed that this is a new occurrence and the other guides don't have it like this one does: https://qa-guides-multipane.mybluemix.net/guides/rest-client-angularjs.html#creating-the-angularjs-template

![image](https://user-images.githubusercontent.com/31117513/51547198-65b07180-1e2b-11e9-9c9d-9ae7b938ba93.png)


#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
