### PR TITLE
Keep github popup visible when a hotspot is near the top except for w…

### DIFF
--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -317,6 +317,8 @@ $(document).ready(function() {
         if(hotspot.data('hovering') == false){
             return;
         }
+        $("#github_clone_popup_container").data('hotspot-hovered', true); // Track if a hotspot was hovered over to hide the github popup
+        hideGithubPopup();
         var header = get_header_from_element(hotspot);
         var fileIndex = hotspot.data('file-index');
         if(!fileIndex){
@@ -529,7 +531,11 @@ $(document).ready(function() {
             var firstHotspot = $("#guide_column .hotspot:visible")[0];
             var firstHotspotRect = firstHotspot.getBoundingClientRect();
             var firstHotspotInView = (firstHotspotRect.top > 0) && (firstHotspotRect.bottom <= window.innerHeight);
-            if(blurCodeOnRight && !firstHotspotInView){
+
+            // Only show the Github popup if above the first section with code
+            // and if hotspots weren't hovered over to reveal the code behind the popup.
+            var hotspotHovered = $("#github_clone_popup_container").data('hotspot-hovered');
+            if(blurCodeOnRight && !(firstHotspotInView && hotspotHovered)){
                 showGithubPopup();
             }
             else{            


### PR DESCRIPTION
…hen the user hovers over a hotspot

#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
