### PR TITLE
Fix mvn commands that were not getting the command styling

### DIFF
--- a/src/main/content/_assets/css/guide-multipane.scss
+++ b/src/main/content/_assets/css/guide-multipane.scss
@@ -219,7 +219,8 @@ header {
 }
 
 #guide_content .listingblock.command .content pre,
-#guide_content .command .listingblock:not(.no_copy):not(.code_command) .content pre {
+#guide_content .command .listingblock:not(.no_copy):not(.code_command) .content pre,
+#guide_content .paragraph.command ~ .listingblock:not(.no_copy):not(.code_command) .content pre{
     background-color: #FFFFFF;
     border: 1px solid #96bc32;
     border-left: 8px solid #96bc32;


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Fixed some included mvn adoc that weren't turning green since they are commands:
https://qa-guides-multipane.mybluemix.net/guides/microprofile-opentracing.html#running-the-services
https://qa-guides-multipane.mybluemix.net/guides/rest-client-java.html#starting-the-service
https://qa-guides-multipane.mybluemix.net/guides/microprofile-health.html#testing-health-checks

Checked all of the guides on qa-guides-multipane, and none of them besides these have that selector.

## Fixed the grey box to match the green and white box.
![image](https://user-images.githubusercontent.com/31117513/51775813-9d821800-20bc-11e9-8988-4474410a6313.png)

#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
