### PR TITLE
Edit action styling

### DIFF
--- a/src/main/content/_assets/css/guide-multipane.scss
+++ b/src/main/content/_assets/css/guide-multipane.scss
@@ -583,20 +583,8 @@ header {
         width: 100%;
     }
 }
-
-@media (min-width: 1171px) {
-    #guide_content code.hotspot {
-        background-color: #F1F4FE;
-        color:#5e6b8d;
-    }
-
-    #guide_content code.hotspot:not(.code_command):hover {
-        color: #24253A;
-        background-color: #C7CCD9;
-    }
-}
     
-@media (max-width: 1170px) {
+@media (max-width: 1169.98px) {
     header {
         position: static; /* Make the header non sticky in mobile view */
     }
@@ -716,10 +704,30 @@ header {
     }
 }
 
-@media (min-width: 1171px) {
+@media (min-width: 1170px) {
     #background_container {
         background-image: inherit;
         margin-bottom: 0;
+    }
+
+    /* Styling for the paragraphs following the edit commands */
+    #guide_content .edit_command_text {
+        position: relative;
+        margin-top: -2px; // Overlap the blue border of the command action.
+        border-left: 8px solid #96bc32;
+        & > p {
+            padding-left: 30px;
+        }
+    }
+
+    #guide_content code.hotspot {
+        background-color: #F1F4FE;
+        color:#5e6b8d;
+    }
+
+    #guide_content code.hotspot:not(.code_command):hover {
+        color: #24253A;
+        background-color: #C7CCD9;
     }
 }
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Added styling for the text below edit commands to the new design.
![image](https://user-images.githubusercontent.com/6392944/52285452-f6a74280-292b-11e9-8424-be9800217ef8.png)

The author will specify the styling as follows:
[role="edit_command_text"]
Change the `io_openliberty_guides_system_inMaintenance` property from `false` to `true` and save the file. 

#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
