### PR TITLE
Change hotspot scroll to consider different number of tab rows

### DIFF
--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -167,7 +167,8 @@ $(document).ready(function() {
         if(scroll){
             var scrollTop = $("#code_column_content")[0].scrollTop;
             var position = range.position().top;
-            $("#code_column_content").animate({scrollTop: scrollTop + position - 50});
+            var titleBarHeight = $("#code_column_title_container").outerHeight();
+            $("#code_column_content").animate({scrollTop: scrollTop + position - titleBarHeight});
         }        
     }
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Fix hotspot scrolling to the correct line when there are 2 lines of tabs / any lines of tabs instead of assuming it's just one line.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
