### PR TITLE
Fix code block padding in blogs

### DIFF
--- a/src/main/content/_assets/css/blog.scss
+++ b/src/main/content/_assets/css/blog.scss
@@ -18,15 +18,28 @@
 
 #blog_container {
     padding-top: 190px;
+
+    @media (max-width: 767px) {
+        padding-top: 60px;
+    }
 }
 
 #blog_row_1 {
     margin-bottom: 117px;
+
+    @media (max-width: 767px) {
+        margin-bottom: 40px;
+    }
 }
 
 #page_intro_paragraph {
     font-size: 20px;
     line-height: 35px;
+
+    @media (max-width: 767px) {
+        font-size: 16px;
+        line-height: inherit;
+    }
 }
 
 .blog_post_column {
@@ -39,10 +52,14 @@
     color: #24253A;
     border-left: solid 37px #EEEFF3;
     transition: border-color .2s;
-}
+    
+    &:hover {
+        border-color: #ECF1BA;
+    }
 
-.blog_post_column:hover {
-    border-color: #ECF1BA;
+    @media (max-width: 767px) {
+        border-width: 0;
+    }
 }
 
 .blog_post_content {
@@ -51,6 +68,20 @@
     padding-left: 72px;
     padding-right: 70px;
     padding-bottom: 64px;
+
+    @media (max-width: 991px) {
+        padding-top: 30px;
+        padding-left: 40px;
+        padding-right: 40px;
+        padding-bottom: 50px;
+    }
+
+    @media (max-width: 767px) {
+        padding-top: 20px;
+        padding-left: 30px;
+        padding-right: 30px;
+        padding-bottom: 40px;
+    }
 }
 
 .blog_post_title {
@@ -60,10 +91,10 @@
 .blog_post_title_link {
     color: #5E6B8D;
     transition: color .2s;
-}
 
-.blog_post_title_link:hover {
-    color: #3F4659;
+    &:hover {
+        color: #3F4659;
+    }
 }
 
 .blog_post_author_image {
@@ -108,47 +139,22 @@
     padding-left: 30px;
     padding-right: 30px;
     transition: all .2s;
+
+    &:hover {
+        color: white;
+        background-color: #5E6B8D;
+        border-color: #5E6B8D;
+    }
 }
 
-.read_more_link:hover {
-    color: white;
-    background-color: #5E6B8D;
-    border-color: #5E6B8D;
-}
-
-@media (max-width: 991.98px) {
-
-    .blog_post_content {
-        padding-top: 30px;
-        padding-left: 40px;
-        padding-right: 40px;
-        padding-bottom: 50px;
-    }
-
-}
-
-@media (max-width: 767.98px) {
-
-    #page_intro_paragraph {
-        font-size: 16px;
-        line-height: inherit;
-    }
-
-    #blog_container {
-        padding-top: 60px;
-    }
-
-    #blog_row_1 {
-        margin-bottom: 40px;
-    }
+@media (max-width: 767px) {
     
     #blog_title {
         margin-bottom: 40px;
     }
 
     #intro_logo {
-        display: block;
-        margin-left:auto;
+        margin-left: auto;
         margin-right: auto;
         margin-bottom: 40px;
     }
@@ -158,22 +164,10 @@
         -moz-box-shadow: none;
         box-shadow: none;
         margin-bottom: 40px;
-    }
-    
-    .blog_post_row:last-child {
-        margin-bottom: 0;
-        padding-bottom: 0;
-    }
 
-    .blog_post_content {
-        padding-top: 20px;
-        padding-left: 30px;
-        padding-right: 30px;
-        padding-bottom: 40px;
+        &:last-child {
+            margin-bottom: 0;
+            padding-bottom: 0;
+        }
     }
-
-    .blog_post_column {
-        border-width: 0;
-    }
-    
 }

--- a/src/main/content/_assets/css/post.scss
+++ b/src/main/content/_assets/css/post.scss
@@ -10,26 +10,36 @@
  *******************************************************************************/
 
 
-#background_container {
+ #background_container {
     padding-top: 100px;
     background-size: 100% calc(100% - 280px);
     background-repeat: no-repeat;
     margin-bottom: 67px;
+
+    @media (max-width: 767px) {
+        padding-top: 20px;
+        margin-bottom: 40px;
+    }
 }
 
 #intro_logo {
     margin-bottom: 70px;
+
+    @media (max-width: 767px) {
+        margin-left: 5px;
+        margin-bottom: 30px;
+    }
 }
 
 #post_column {
     padding: 0;
-}
 
-#post_column code,
-#post_column pre  {
-    /* Bootstrap override */
-    background-color: #F3F4F7;
-    color: #5e6b8d;
+    & code,
+    & pre {
+        /* Bootstrap override */
+        background-color: #F3F4F7;
+        color: #5e6b8d;
+    }
 }
 
 #article_container {
@@ -43,6 +53,23 @@
     -moz-box-shadow: 0px 5px 11px -3px rgba(0,0,0,0.27);
     box-shadow: 0px 5px 11px -3px rgba(0,0,0,0.27);
     overflow: hidden;
+
+    @media (max-width: 991px) {
+        padding-top: 40px;
+        padding-bottom: 40px;
+        padding-left: 60px;
+        padding-right: 60px;
+    }
+
+    @media (max-width: 767px) {
+        padding-top: 30px;
+        padding-bottom: 30px;
+        padding-left: 15px;
+        padding-right: 15px;
+        -webkit-box-shadow: none;
+        -moz-box-shadow: none;
+        box-shadow: none;
+    }
 }
 
 /* Keep images from overflowing */
@@ -83,10 +110,10 @@
     font-weight: 500;
     color: #E3700D;
     transition: color .2s;
-}
 
-#article_body a:hover {
-    color: #F4914D;
+    &:hover {
+        color: #F4914D;
+    }
 }
 
 #author_image {
@@ -119,6 +146,10 @@
     color: #3F4659;
     font-size: 20px;
     padding-top: 50px;
+
+    @media (max-width: 767px) {
+        padding-top: 20px;
+    }
 }
 
 #twitter_link {
@@ -130,10 +161,10 @@
     margin-left: 20px;
     vertical-align: middle;
     transition: all .2s;
-}
 
-#twitter_link:hover {
-    background-image: url('/img/twitter_link_hover.svg');
+    &:hover {
+        background-image: url('/img/twitter_link_hover.svg');
+    }
 }
 
 #reddit_link {
@@ -145,51 +176,12 @@
     margin-left: 20px;
     vertical-align: middle;
     transition: background-image .2s;
-}
 
-#reddit_link:hover {
-    background-image: url('/img/reddit_link_hover.svg');
+    &:hover {
+        background-image: url('/img/reddit_link_hover.svg');
+    }
 }
 
 .download-ol-button {
     margin-bottom: 10px;
-}
-
-@media (max-width: 991.98px) {
-
-    #article_container {
-        padding-top: 40px;
-        padding-bottom: 40px;
-        padding-left: 60px;
-        padding-right: 60px;
-    }
-
-}
-
-@media (max-width: 767.98px) {
-
-    #background_container {
-        padding-top: 20px;
-        margin-bottom: 40px;
-    }
-
-    #intro_logo {
-        margin-left: 5px;
-        margin-bottom: 30px;
-    }
-
-    #article_container {
-        padding-top: 30px;
-        padding-bottom: 30px;
-        padding-left: 15px;
-        padding-right: 15px;
-        -webkit-box-shadow: none;
-        -moz-box-shadow: none;
-        box-shadow: none;
-    }
-
-    #share_post_container {
-        padding-top: 20px;
-    }
-
 }

--- a/src/main/content/_assets/css/post.scss
+++ b/src/main/content/_assets/css/post.scss
@@ -16,7 +16,7 @@
     background-repeat: no-repeat;
     margin-bottom: 67px;
 
-    @media (max-width: 767px) {
+    @media (max-width: 767.98px) {
         padding-top: 20px;
         margin-bottom: 40px;
     }
@@ -25,7 +25,7 @@
 #intro_logo {
     margin-bottom: 70px;
 
-    @media (max-width: 767px) {
+    @media (max-width: 767.98px) {
         margin-left: 5px;
         margin-bottom: 30px;
     }
@@ -59,14 +59,14 @@
     box-shadow: 0px 5px 11px -3px rgba(0,0,0,0.27);
     overflow: hidden;
 
-    @media (max-width: 991px) {
+    @media (max-width: 991.98px) {
         padding-top: 40px;
         padding-bottom: 40px;
         padding-left: 60px;
         padding-right: 60px;
     }
 
-    @media (max-width: 767px) {
+    @media (max-width: 767.98px) {
         padding-top: 30px;
         padding-bottom: 30px;
         padding-left: 15px;
@@ -152,7 +152,7 @@
     font-size: 20px;
     padding-top: 50px;
 
-    @media (max-width: 767px) {
+    @media (max-width: 767.98px) {
         padding-top: 20px;
     }
 }

--- a/src/main/content/_assets/css/post.scss
+++ b/src/main/content/_assets/css/post.scss
@@ -34,6 +34,11 @@
 #post_column {
     padding: 0;
 
+    & pre {
+        /* Bootstrap 4 override */
+        padding: 9.5px;
+    }
+
     & code,
     & pre {
         /* Bootstrap override */


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

When the blogs were upgraded to bootstrap4, the code blocks post their padding.  The padding came from the bootstrap3 source code.  Add the padding back to the code blocks in the blog posts.

I also took the time to convert two CSS to Sass

#### Before
![image](https://user-images.githubusercontent.com/31117513/52322074-3b1ef680-299d-11e9-990c-897f5aab9aaf.png)

#### After
![image](https://user-images.githubusercontent.com/31117513/52322057-2cd0da80-299d-11e9-95c5-d96f13711544.png)

#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
