### PR TITLE
Restore centering of Blog title in narrow windows

### DIFF
--- a/src/main/content/_assets/css/blog.scss
+++ b/src/main/content/_assets/css/blog.scss
@@ -154,6 +154,7 @@
     }
 
     #intro_logo {
+        display: block;
         margin-left: auto;
         margin-right: auto;
         margin-bottom: 40px;


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

I did a bad job of converting the CSS to SCSS.  I left out the `display: block` that is required for centering the `Blog` title in tablet/mobile views.

### Before
![image](https://user-images.githubusercontent.com/31117513/52362176-94bb0b80-2a05-11e9-834e-a11659c0b7f5.png)

### After
![image](https://user-images.githubusercontent.com/31117513/52362183-9ab0ec80-2a05-11e9-8015-a37611882507.png)

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
