### PR TITLE
Cleanup unused IBM analytics code

### DIFF
--- a/src/main/content/_layouts/default.html
+++ b/src/main/content/_layouts/default.html
@@ -24,9 +24,6 @@ js:
 
     {% include footer.html %}
 
-    <!-- Cookie preference button -->
-    <div id="teconsent" style="display: none"></div>
-
     {% include javascript.html %}
 
   </body>

--- a/src/main/content/_layouts/doc.html
+++ b/src/main/content/_layouts/doc.html
@@ -17,9 +17,6 @@
 
     {% include footer.html %}
 
-    <!-- Cookie preference button -->
-    <div id="teconsent" style="display: none"></div>
-
     {% include javascript.html %}
 
   </body>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

The `teconsent` element belongs to the IBM analytics suite.  We currently do not use the IBM analytics suite.

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
