### PR TITLE
Fix the color/background color of imported commands from guides common

### DIFF
--- a/src/main/content/_assets/css/guide-multipane.scss
+++ b/src/main/content/_assets/css/guide-multipane.scss
@@ -231,6 +231,11 @@ header {
     white-space: -pre-wrap;      /* Opera 4-6 */
     white-space: -o-pre-wrap;    /* Opera 7 */
     word-wrap: break-word;  
+
+    & code {
+        background-color: inherit;
+        color: inherit;
+    }
 }
 
 #guide_content .command .CodeRay code {


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Before:
![image](https://user-images.githubusercontent.com/6392944/52595853-84939980-2e14-11e9-8dd6-6ee0b0ffe581.png)
After:
![image](https://user-images.githubusercontent.com/6392944/52595883-9412e280-2e14-11e9-99cf-a0e4cd997d92.png)

#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
