### PR TITLE
Fix newlines from being stripped by the copy to clipboard function;

### DIFF
--- a/src/main/content/_assets/css/guide.scss
+++ b/src/main/content/_assets/css/guide.scss
@@ -335,7 +335,7 @@ header {
     color: #5e6b8d;
 }
 
-.copy_to_clipboard {	
+#copy_to_clipboard {	
     position: absolute;	
     display: none;	
     background-color: #eeeff3;	
@@ -344,13 +344,15 @@ header {
     background-position: center center;	
     height: 63px;	
     width: 58px;	
+
+    &:hover {	
+        border: solid 1px #b2bbd1;	
+    }	
+    &:active {	
+        border: solid 1px #5e6b8d;	
+    }
 }	
-.copy_to_clipboard:hover {	
-    border: solid 1px #b2bbd1;	
-}	
-.copy_to_clipboard:active {	
-    border: solid 1px #5e6b8d;	
-}
+
 
 @media (max-width: 1199.98px) {
     .guide_item {

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -9,7 +9,6 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-var target;
 var code_sections = {}; // Map guide sections to code blocks to show on the right column. Each guide section maps to its tab and code block.
 var recent_sections = {}; // Store the most recently viewed code_section for each guide section
 
@@ -621,7 +620,10 @@ function setActiveTab(activeTab){
 
     $(".copyFileButton").click(function(event){
         event.preventDefault();
-        target = $("#code_column .code_column:visible .content")[0];
+        // Remove the line numbers from being copied.
+        var target_copy = $("#code_column .code_column:visible .content code").clone();
+        target_copy.find('.line-numbers').remove();
+        target = target_copy[0];
         copy_element_to_clipboard(target, function(){
             var current_target_object = $(event.currentTarget);
             var position = current_target_object.position();	

--- a/src/main/content/_assets/js/guide.js
+++ b/src/main/content/_assets/js/guide.js
@@ -18,24 +18,22 @@ function copy_element_to_clipboard(target, callback){
         window.clipboardData.setData("Text", target.innerText);
     } 
     else{
-        var temp = $('<div>');
+        var temp = $('<textarea>');
         temp.css({
             position: "absolute",
             left:     "-1000px",
             top:      "-1000px",
-        });
+        });       
+        
         // Create a temporary element for copying the text.
-        // temp.text(target.innerText);
-        temp.html(target.innerHTML.trim());
+        // Prepend <br> with newlines because jQuery .text() strips the <br>'s and we use .text() because we don't want all of the html tags copied to the clipboard.
+        var text = $(target).clone().find('br').prepend('\r\n').end().text().trim();
+        temp.html(text);
         $("body").append(temp);
-        var range = document.createRange();
-        range.selectNodeContents(temp.get(0));
-        selection = window.getSelection();
-        selection.removeAllRanges(); // Remove previous selections
-        selection.addRange(range);
+        temp.select();
         
         // Try to copy the selection and if it fails display a popup to copy manually.
-        if(document.execCommand('copy')) {
+        if(document.execCommand('copy')) {            
             callback();
         } else {
             alert('Copy failed. Copy the command manually: ' + target.innerText);
@@ -46,7 +44,12 @@ function copy_element_to_clipboard(target, callback){
 
  $(document).ready(function() {
     
-    var target;
+    var offset;	
+    var target;	
+    var target_position;	
+    var target_width;	
+    var target_height;
+
     $('#preamble').detach().insertAfter('#duration_container');  
 
     $("#mobile_github_clone_popup_copy").click(function(event){
@@ -104,11 +107,11 @@ function copy_element_to_clipboard(target, callback){
         target_position = current_target_object.position();	
         target_width = current_target_object.outerWidth();	
         target_height = current_target_object.outerHeight();	
-         $('.copy_to_clipboard').css({	
+         $('#copy_to_clipboard').css({	
             top: target_position.top + 8,	
             right: parseInt($('#guide_column').css('padding-right')) + 55	
         });	
-        $('.copy_to_clipboard').stop().fadeIn();	
+        $('#copy_to_clipboard').stop().fadeIn();	
      }, function(event) {	
         if(offset){
             var x = event.clientX - offset.left;	
@@ -117,13 +120,13 @@ function copy_element_to_clipboard(target, callback){
             && x < target_position.left + target_width	
             && y > target_position.top	
             && y < target_position.top + target_height)) {	
-                $('.copy_to_clipboard').stop().fadeOut();	
+                $('#copy_to_clipboard').stop().fadeOut();	
                 $('#guide_section_copied_confirmation').stop().fadeOut();	
             }
         }          	
      });	
 
-     $('.copy_to_clipboard').click(function(event) {
+     $('#copy_to_clipboard').click(function(event) {
         event.preventDefault();
         // Target was assigned while hovering over the element to copy.
         copy_element_to_clipboard(target, function(){

--- a/src/main/content/_layouts/guide-multipane.html
+++ b/src/main/content/_layouts/guide-multipane.html
@@ -92,7 +92,7 @@ js:
             
             </div>
             <div id="guide_section_copied_confirmation">Copied to clipboard</div>
-            <a class="copy_to_clipboard" href=""></a>
+            <a id="copy_to_clipboard" href=""></a>
         </div>
 
         <!-- Code section -->

--- a/src/main/content/_layouts/guide.html
+++ b/src/main/content/_layouts/guide.html
@@ -82,7 +82,7 @@ js:
             
             </div>
             <div id="guide_section_copied_confirmation">Copied to clipboard</div>
-            <a class="copy_to_clipboard" href=""></a>
+            <a id="copy_to_clipboard" href=""></a>
         </div> 
         
     </div>    


### PR DESCRIPTION
Change copy_to_clipboard to an id since there's only one;

#### What was fixed?  (Issue # or description of fix)
Guide snippets with more than one line of text to copy was being copied to the clipboard on one line. This will fix preserving those new lines.
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
