### PR TITLE
Fix copy function to work with html snippets

### DIFF
--- a/src/main/content/_assets/js/guide-utils.js
+++ b/src/main/content/_assets/js/guide-utils.js
@@ -50,6 +50,40 @@ function debounce(func, wait, immediate) {
     };
 }
 
+/* Copy the target element to the clipboard
+   target: element to copy
+   callback: function to run if the copy is successful
+*/
+function copy_element_to_clipboard(target, callback){
+    // IE
+    if(window.clipboardData){
+        window.clipboardData.setData("Text", target.innerText);
+    } 
+    else{
+        var temp = $('<textarea>');
+        temp.css({
+            position: "absolute",
+            left:     "-1000px",
+            top:      "-1000px",
+        });       
+        
+        // Create a temporary element for copying the text.
+        // Prepend <br> with newlines because jQuery .text() strips the <br>'s and we use .text() because we don't want all of the html tags copied to the clipboard.
+        var text = $(target).clone().find('br').prepend('\r\n').end().text().trim();
+        temp.text(text);
+        $("body").append(temp);
+        temp.select();
+        
+        // Try to copy the selection and if it fails display a popup to copy manually.
+        if(document.execCommand('copy')) { 
+            callback();
+        } else {
+            alert('Copy failed. Copy the command manually: ' + target.innerText);
+        }
+        temp.remove(); // Remove temporary element.
+    }
+}
+
 // Handle sticky header in IE, because IE doesn't support position: sticky
 function handleStickyHeader() {
     if (!inSingleColumnView()) {

--- a/src/main/content/_assets/js/guide.js
+++ b/src/main/content/_assets/js/guide.js
@@ -9,40 +9,6 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-/* Copy the target element to the clipboard
-   target: element to copy
-   callback: function to run if the copy is successful
-*/
-function copy_element_to_clipboard(target, callback){
-    // IE
-    if(window.clipboardData){
-        window.clipboardData.setData("Text", target.innerText);
-    } 
-    else{
-        var temp = $('<textarea>');
-        temp.css({
-            position: "absolute",
-            left:     "-1000px",
-            top:      "-1000px",
-        });       
-        
-        // Create a temporary element for copying the text.
-        // Prepend <br> with newlines because jQuery .text() strips the <br>'s and we use .text() because we don't want all of the html tags copied to the clipboard.
-        var text = $(target).clone().find('br').prepend('\r\n').end().text().trim();
-        temp.text(text);
-        $("body").append(temp);
-        temp.select();
-        
-        // Try to copy the selection and if it fails display a popup to copy manually.
-        if(document.execCommand('copy')) { 
-            callback();
-        } else {
-            alert('Copy failed. Copy the command manually: ' + target.innerText);
-        }
-        temp.remove(); // Remove temporary element.
-    }
-}
-
  $(document).ready(function() {
     
     var offset;	

--- a/src/main/content/_assets/js/guide.js
+++ b/src/main/content/_assets/js/guide.js
@@ -8,6 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
+
 /* Copy the target element to the clipboard
    target: element to copy
    callback: function to run if the copy is successful
@@ -28,12 +29,12 @@ function copy_element_to_clipboard(target, callback){
         // Create a temporary element for copying the text.
         // Prepend <br> with newlines because jQuery .text() strips the <br>'s and we use .text() because we don't want all of the html tags copied to the clipboard.
         var text = $(target).clone().find('br').prepend('\r\n').end().text().trim();
-        temp.html(text);
+        temp.text(text);
         $("body").append(temp);
         temp.select();
         
         // Try to copy the selection and if it fails display a popup to copy manually.
-        if(document.execCommand('copy')) {            
+        if(document.execCommand('copy')) { 
             callback();
         } else {
             alert('Copy failed. Copy the command manually: ' + target.innerText);


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Append the text as just text to the temporary textarea instead of html so it doesn't run scripts. 
Move the copy function to guide-utils so the interactive guides team can use it.
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
