### PR TITLE
Sort general references documentation

### DIFF
--- a/src/main/content/general-references.html
+++ b/src/main/content/general-references.html
@@ -11,7 +11,7 @@ permalink: /docs/ref/general/
 
 <!-- Build list of general reference pages -->
 
-{% assign generalDocs = site.pages | where: 'layout', 'general-reference' | where: 'type', 'general' %}
+{% assign generalDocs = site.pages | where: 'layout', 'general-reference' | where: 'type', 'general' | sort: 'title' %}
 
 <div id="background_container">
     <!-- table of contents section -->


### PR DESCRIPTION
Without Liquid's "sort: title", Jekyll will sort the general references based on the filename.  The problem is that the filename is every different from the title used for each general reference documentation.

The other documentation types have similar title and filename.  This is the reason why this was the first time we had to handle this scenario of sorting by title rather than filename.

#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
