### PR TITLE
Fix the hotspotted text from removing styling when leaving the hotspot

### DIFF
--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -66,7 +66,7 @@ function highlight_code_range(code_section, fromLine, toLine, scroll){
 function remove_highlighting(){
     var highlightedSections = $('.highlightSection');
     highlightedSections.each(function(){
-        var children = $(this).find('span');
+        var children = $(this).children('span');
         children.unwrap(); // Remove the wrapped highlighted div from these children.
     });
     


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
When leaving the hotspot with your mouse, the code would remove the parent hotspot div but also remove one of the nested spans which was applying styling to the code to color it purple. See #991 for images.
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
