### PR TITLE
Remove single branch clone flag; change staging to use master guide branches

### DIFF
--- a/scripts/build_clone_guides.rb
+++ b/scripts/build_clone_guides.rb
@@ -32,9 +32,6 @@ if ENV['TRAVIS']
         iguide_branch = 'multiPane'
         guide_branch = 'multipane'
         guide_camelcase_branch = 'multiPane'
-    elsif ENV['TRAVIS_BRANCH'] == "development"
-        guide_branch = 'dev'
-        iguide_branch = 'dev'
     end
 end
 

--- a/scripts/build_clone_guides.rb
+++ b/scripts/build_clone_guides.rb
@@ -57,11 +57,11 @@ repos.each do |element|
         # Clone guides that are still being drafted and are only for the staging website
         if repo_name.start_with?('draft-iguide') || repo_name.start_with?('draft-guide')
             # Clone the draft guides, using the multipane/multiPane branch for travis and master for all other environments.
-            `git clone https://github.com/OpenLiberty/#{repo_name}.git --branch #{guide_branch} --single-branch src/main/content/guides/#{repo_name}`
+            `git clone https://github.com/OpenLiberty/#{repo_name}.git -b #{guide_branch} src/main/content/guides/#{repo_name}`
 
             # Clone the draft guide using multiPane because git clone is case sensitive
             if !(directory_exists?(repo_name))
-                `git clone https://github.com/OpenLiberty/#{repo_name}.git --branch #{guide_camelcase_branch} --single-branch src/main/content/guides/#{repo_name}`
+                `git clone https://github.com/OpenLiberty/#{repo_name}.git -b #{guide_camelcase_branch} src/main/content/guides/#{repo_name}`
             end
 
             # Clone the default branch if the guide_branch or guide_camelcase_branch does not exist for this guide repo.
@@ -75,11 +75,11 @@ repos.each do |element|
         # Clone interactive guides that are ready to be published to openliberty.io
         if repo_name.start_with?('iguide') || repo_name.start_with?('guide')
             # Clone the  guides, using the multipane/multiPane branch for travis and master for all other environments.
-            `git clone https://github.com/OpenLiberty/#{repo_name}.git --branch #{guide_branch} --single-branch src/main/content/guides/#{repo_name}`
+            `git clone https://github.com/OpenLiberty/#{repo_name}.git -b #{guide_branch} src/main/content/guides/#{repo_name}`
 
              # Clone the draft guide using multiPane because git clone is case sensitive
              if !(directory_exists?(repo_name))
-                `git clone https://github.com/OpenLiberty/#{repo_name}.git --branch #{guide_camelcase_branch} --single-branch src/main/content/guides/#{repo_name}`
+                `git clone https://github.com/OpenLiberty/#{repo_name}.git -b #{guide_camelcase_branch} src/main/content/guides/#{repo_name}`
              end
 
             # Clone the default branch if the guide_branch or guide_camelcase_branch does not exist for this guide repo.


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Removed the --single-branch flag. When people use the script they will also be able to check out other branches than the one cloned.
Also delete the flag for the development site to change the branch to dev so that they will clone master.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
