### PR TITLE
Fix mobile related guide spacing and update copyright year

### DIFF
--- a/src/main/content/_assets/css/end-of-guide.css
+++ b/src/main/content/_assets/css/end-of-guide.css
@@ -119,10 +119,12 @@
 
     #end_of_guide_right_section {
         width: auto;
+        float: none;
         padding: 0 37px;
     }
 
-    #end_of_guide_right_section h3 {
+    /* Override margin-top */
+    #end_of_guide #where_to_next {
         margin-top: 41px;
     }
 }

--- a/src/main/content/_includes/footer.html
+++ b/src/main/content/_includes/footer.html
@@ -16,7 +16,7 @@
 
     <div id="footer_bottom_container" class="footer_container container">
         <div id="footer_bottom_left_section">
-            <p id="footer_copyright">&copy; Copyright IBM Corp. 2017, 2018</p>
+            <p id="footer_copyright">&copy; Copyright IBM Corp. 2017, 2019</p>
             <p class="vertical_bar">|</p>
             <a id="footer_privacy_policy_link" href="https://www.ibm.com/privacy/" target="_blank" class="left_footer_link">Privacy policy</a>
             <p class="vertical_bar">|</p>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Very minor updates to the spacing in the end of guide section and copyright year.
Before:
![image](https://user-images.githubusercontent.com/6392944/53764695-973d4380-3e93-11e9-8588-b0915d0f887a.png)


After:
![image](https://user-images.githubusercontent.com/6392944/53764683-8ee50880-3e93-11e9-9743-bd52a0239a6e.png)

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
