### PR TITLE
Add feature exclude back to dev_config.yml that was mistakingly removed

### DIFF
--- a/src/main/content/_dev_config.yml
+++ b/src/main/content/_dev_config.yml
@@ -17,4 +17,5 @@ assets:
 minify_html: false
 
 exclude:
+  - feature
   - docs/templates


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Accidentally removed feature from _dev_config.yml
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
