### PR TITLE
Update width of "Interactive guide" text border

### DIFF
--- a/src/main/content/_assets/css/guide-card.css
+++ b/src/main/content/_assets/css/guide-card.css
@@ -65,7 +65,7 @@
 }
 
 .guide_interactive_container{
-    border: 0.5px solid #F69144;
+    border: 1px solid #F69144;
     border-radius: 100px;
     float: right;
     padding: 0px 5px;


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
The orange border surrounding the text indicating that a guide is an "Interactive guide" was barely showing on my newly installed MAC when I was within one of the interactive guides.
<img width="330" alt="image" src="https://user-images.githubusercontent.com/29490139/53965831-840abd80-40b7-11e9-8f31-4e6eb7a4d613.png">

Increased the border width from .5px to 1px to fix.

#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
