### PR TITLE
Change guide hash changes to replaceState;

### DIFF
--- a/src/main/content/_assets/js/guide-utils.js
+++ b/src/main/content/_assets/js/guide-utils.js
@@ -472,9 +472,9 @@ function defaultToFirstPage() {
     // Reset the hash in the URL
     var currentPath = window.location.pathname;
     var newPath = currentPath.substring(currentPath.lastIndexOf('/')+1);
-    // We already scrolled to the top of the guide.  history.pushState allows
+    // We already scrolled to the top of the guide.  history.replaceState allows
     // us to set the URL without invoking immediate scrolling.
-    history.pushState(null, null, newPath);
+    history.replaceState(null, null, newPath);
 }
 
 

--- a/src/main/content/_assets/js/guide.js
+++ b/src/main/content/_assets/js/guide.js
@@ -50,9 +50,9 @@
                 var newPath = currentPath.substring(currentPath.lastIndexOf('/')+1) + scrolledToHash;
                 // Not setting window.location.hash here because that causes an
                 // onHashChange event to fire which will scroll to the top of the
-                // section.  pushState updates the URL without causing an
+                // section.  replaceState updates the URL without causing an
                 // onHashChange event.
-                history.pushState(null, null, newPath);
+                history.replaceState(null, null, newPath);
 
                 // Update the selected TOC entry
                 updateTOCHighlighting(id);                    

--- a/src/main/content/_assets/js/toc.js
+++ b/src/main/content/_assets/js/toc.js
@@ -158,7 +158,7 @@ function TOCEntryClick(liElement, event) {
         // Not setting window.location.hash here because that causes the
         // window to scroll immediately to the section.  We want to implement
         // smooth scrolling that is adjusted to account for the sticky header.
-        // So, this history.pushState will allow us to set the URL without
+        // So, this history.replaceState will allow us to set the URL without
         // invoking immediate scrolling.  Then we call accessContentsFromHash
         // to perform the smooth scrolling to the requested section.
         history.replaceState(null, null, newPath);

--- a/src/main/content/_assets/js/toc.js
+++ b/src/main/content/_assets/js/toc.js
@@ -161,7 +161,7 @@ function TOCEntryClick(liElement, event) {
         // So, this history.pushState will allow us to set the URL without
         // invoking immediate scrolling.  Then we call accessContentsFromHash
         // to perform the smooth scrolling to the requested section.
-        history.pushState(null, null, newPath);
+        history.replaceState(null, null, newPath);
     }
     accessContentsFromHash(hash);
 }


### PR DESCRIPTION
so it doesn't consume the browser history stack with every step selected

#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
