### PR TITLE
Change check for duplicate tabs to a full name match instead of contains

### DIFF
--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -254,7 +254,9 @@ function hideDuplicateTabs(id){
             continue;
         }
         var fileName = tab.text();
-        var tabsWithSameName = $('#code_column_tabs li:visible').not(tab).filter(":contains('" + fileName + "')");
+        var tabsWithSameName = $('#code_column_tabs li:visible').not(tab).filter(function(){
+            return this.innerText === fileName;
+        });
         
         if(tabsWithSameName.length > 0){
             // Find duplicates and hide them.


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Fixes issue #1053
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
