### PR TITLE
Update openliberty.io: Fix missing tabs in some of the guides

### DIFF
--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -254,7 +254,9 @@ function hideDuplicateTabs(id){
             continue;
         }
         var fileName = tab.text();
-        var tabsWithSameName = $('#code_column_tabs li:visible').not(tab).filter(":contains('" + fileName + "')");
+        var tabsWithSameName = $('#code_column_tabs li:visible').not(tab).filter(function(){
+            return this.innerText === fileName;
+        });
         
         if(tabsWithSameName.length > 0){
             // Find duplicates and hide them.

--- a/src/main/content/_includes/end-of-guide.html
+++ b/src/main/content/_includes/end-of-guide.html
@@ -16,10 +16,10 @@
 
             <h3 id="feedback_rating_question">What did you think of this guide?</h3>
             <div id="feedback_ratings">
-                <img src="/img/1_Extreme_Dislike.png" alt="Extreme Dislike" data-guide-rating="1" tabindex="0" aria-label="Rate this guide as extreme dislike">
-                <img src="/img/2_Dislike.png" alt="Dislike" data-guide-rating="2" tabindex="0" aria-label="Rate this guide as dislike">
-                <img src="/img/3_Like.png" alt="Like" data-guide-rating="3" tabindex="0" aria-label="Rate this guide as like">
-                <img src="/img/4_Extreme_Like.png" alt="Extreme Like" data-guide-rating="4" tabindex="0" aria-label="Rate this guide as extreme like">
+                <img class="guide_rating" id="extreme_dislike" src="/img/1_Extreme_Dislike.png" alt="Extreme Dislike" data-guide-rating="1" tabindex="0" aria-label="Rate this guide as extreme dislike">
+                <img class="guide_rating" id="dislike" src="/img/2_Dislike.png" alt="Dislike" data-guide-rating="2" tabindex="0" aria-label="Rate this guide as dislike">
+                <img class="guide_rating" id="like" src="/img/3_Like.png" alt="Like" data-guide-rating="3" tabindex="0" aria-label="Rate this guide as like">
+                <img class="guide_rating" id="extreme_like" src="/img/4_Extreme_Like.png" alt="Extreme Like" data-guide-rating="4" tabindex="0" aria-label="Rate this guide as extreme like">
             </div>
 
         </div>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
