### PR TITLE
Change checks for tabs with the same name from contains to exact match

### DIFF
--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -296,7 +296,9 @@ function hideDuplicateTabs(id){
     }
     // Hide duplicates of the active tab
     var activeTab = $('.code_column_tab > .active').parent();
-    var activeDuplicates = $('#code_column_tabs li:visible').not(activeTab).filter(":contains('" + activeTab.text() + "')");
+    var activeDuplicates = $('#code_column_tabs li:visible').not(activeTab).filter(function(){
+        return this.innerText === activeTab.text();
+    });
     activeDuplicates.hide();
 }
 
@@ -307,26 +309,15 @@ function loadPreviousStepsTabs(){
     for(var i = previousHiddenTabs.length - 1; i >= 0; --i){
         var tab = previousHiddenTabs.get(i);
         var fileName = tab.innerText.trim();
-        // Check that the most recent tab for this file is showing.
-        if($('#code_column_tabs li:visible').filter(":contains('" + fileName + "')").length == 0){
+        // Check that only the most recent tab for this file is showing.
+        var visibleTabsWithSameName = $('#code_column_tabs li:visible').filter(function(){
+            return this.innerText === fileName;
+        });
+        if(visibleTabsWithSameName.length === 0){
             $(tab).show();
         }
     }
-};
-
-function loadPreviousStepsTabs(){
-    // Reveal the files from previous sections in case the user loaded a later step from a bookmarked hash.
-    var lastTab = $('#code_column_tabs li:visible').last();
-    var previousHiddenTabs = lastTab.prevAll().not(":visible");
-    for(var i = previousHiddenTabs.length - 1; i >= 0; --i){
-        var tab = previousHiddenTabs.get(i);
-        var fileName = tab.innerText.trim();
-        // Check that the most recent tab for this file is showing.
-        if($('#code_column_tabs li:visible').filter(":contains('" + fileName + "')").length == 0){
-            $(tab).show();
-        }
-    }
-};
+}
 
 // Sets the active tab in the code column and moves it to the front of the tab list.
 // activeTab: tab to set active

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -413,7 +413,9 @@ function restoreCodeColumn(){
             metadata_sect.detach();            
 
             // If the same tab exists already in the list, append it in the same order to persist the order it was introduced in the guide.
-            var tabAlreadyExists =  $('#code_column_tabs li').filter(":contains('" + fileName + "')");
+            var tabAlreadyExists = $('#code_column_tabs li').filter(function(){
+                return this.innerText === fileName;
+            });
             if(tabAlreadyExists.length > 0){
                 tabAlreadyExists.last().after(tab);
             } 

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -255,7 +255,7 @@ function hideDuplicateTabs(id){
         }
         var fileName = tab.text();
         var tabsWithSameName = $('#code_column_tabs li:visible').not(tab).filter(function(){
-            return this.innerText === fileName;
+            return this.innerText.trim() === fileName;
         });
         
         if(tabsWithSameName.length > 0){
@@ -297,7 +297,7 @@ function hideDuplicateTabs(id){
     // Hide duplicates of the active tab
     var activeTab = $('.code_column_tab > .active').parent();
     var activeDuplicates = $('#code_column_tabs li:visible').not(activeTab).filter(function(){
-        return this.innerText === activeTab.text();
+        return this.innerText.trim() === activeTab.text();
     });
     activeDuplicates.hide();
 }
@@ -311,7 +311,7 @@ function loadPreviousStepsTabs(){
         var fileName = tab.innerText.trim();
         // Check that only the most recent tab for this file is showing.
         var visibleTabsWithSameName = $('#code_column_tabs li:visible').filter(function(){
-            return this.innerText === fileName;
+            return this.innerText.trim() === fileName;
         });
         if(visibleTabsWithSameName.length === 0){
             $(tab).show();
@@ -414,7 +414,7 @@ function restoreCodeColumn(){
 
             // If the same tab exists already in the list, append it in the same order to persist the order it was introduced in the guide.
             var tabAlreadyExists = $('#code_column_tabs li').filter(function(){
-                return this.innerText === fileName;
+                return this.innerText.trim() === fileName;
             });
             if(tabAlreadyExists.length > 0){
                 tabAlreadyExists.last().after(tab);


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
