### PR TITLE
Update qa-guides-dev to use master branch of each guide

### DIFF
--- a/scripts/build_clone_guides.rb
+++ b/scripts/build_clone_guides.rb
@@ -26,12 +26,6 @@ repos = client.org_repos('OpenLiberty')
 # --------------------------------------------
 # For the interactive guides, only build the dev branch for the TravisCI environments
 guide_branch = 'master'
-if ENV['TRAVIS']
-    if ENV['TRAVIS_BRANCH'] == "development"
-        guide_branch = 'dev'
-    end
-end
-
 puts "Looking for draft interactive guides with branch: #{guide_branch}..."
 
 # Function to check if the guide directory exists after a git clone command


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
The static guide team needs an environment to check draft guides on their master branch so this will enable them to use qa-guides-dev.mybluemix.net to test their guides.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
