### PR TITLE
Clone guide images during the build process

### DIFF
--- a/scripts/build_clone_guides.rb
+++ b/scripts/build_clone_guides.rb
@@ -69,7 +69,7 @@ repos.each do |element|
             # Clone the default branch if the guide_branch does not exist for this guide repo.
             if !(directory_exists?(repo_name))
                 `git clone https://github.com/OpenLiberty/#{repo_name}.git src/main/content/guides/#{repo_name}`
-            end            
+            end
         end
     end
 end

--- a/scripts/build_jekyll_maven.sh
+++ b/scripts/build_jekyll_maven.sh
@@ -49,6 +49,11 @@ else
     ./scripts/build_clone_docs.sh "master" # Argument is branch name of OpenLiberty/docs
 fi
 
+# Copy guide images to /img/guide
+echo "Copying any guide images to /img/guide"
+cp src/main/content/guides/guide*/assets/* src/main/content/img/guide
+cp src/main/content/guides/draft-guide*/assets/* src/main/content/img/guide
+
 # Move any js/css files from guides to the _assets folder for jekyll-assets minification.
 echo "Moving any js and css files published interactive guides..."
 # Assumption: There is _always_ iguide* folders

--- a/scripts/build_jekyll_maven.sh
+++ b/scripts/build_jekyll_maven.sh
@@ -49,10 +49,16 @@ else
     ./scripts/build_clone_docs.sh "master" # Argument is branch name of OpenLiberty/docs
 fi
 
-# Copy guide images to /img/guide
-echo "Copying any guide images to /img/guide"
-cp src/main/content/guides/guide*/assets/* src/main/content/img/guide
-cp src/main/content/guides/draft-guide*/assets/* src/main/content/img/guide
+
+echo "Copying guide images to /img/guide"
+# Check if any draft guide images exist first
+if [ -e src/main/content/guides/draft-guide*/assets/* ]
+ then cp src/main/content/guides/draft-guide*/assets/* src/main/content/img/guide
+fi
+# Check if any published guide images exist first
+if [ -e src/main/content/guides/guide*/assets/* ]
+ then cp src/main/content/guides/guide*/assets/* src/main/content/img/guide
+fi
 
 # Move any js/css files from guides to the _assets folder for jekyll-assets minification.
 echo "Moving any js and css files published interactive guides..."

--- a/src/main/content/_assets/css/guide-multipane.scss
+++ b/src/main/content/_assets/css/guide-multipane.scss
@@ -38,6 +38,10 @@
     max-width: 100%;
 }
 
+#guide_content img {
+    max-width: 100%;
+}
+
 #guide_content code.hotspot {
     background-color: #F1F4FE;
     color:#5e6b8d;


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Guides needed a way to reference images in the asciidoc files without having to put the whole path to the image e.g. image::/guides/draft-guide-sessions/assets/sessionCache.png[Session Cache] when including an image. When we copy the image to a central location, then the guides can just put :imagesdir: /img/guide in their front matter and use image::sessionCache.png[Session Cache] without having to put the full path. to the image in the guide's directory.

Max-width: 100% is so the images don't overflow the guide.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
