### PR TITLE
Change keygen server in the build pipeline to get Ruby

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,7 +4,7 @@
 sudo apt-get update
 sudo apt-get install libgdbm-dev libncurses5-dev automake libtool bison libffi-dev -y
 sudo apt-get install python3-bs4 -y
-gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 curl -sSL https://get.rvm.io | bash -s stable
 source /home/pipeline/.rvm/scripts/rvm
 rvm requirements

--- a/src/main/webapp/WEB-INF/redirects.properties
+++ b/src/main/webapp/WEB-INF/redirects.properties
@@ -8,7 +8,7 @@
 
 /index.html/=/index.html
 /docs/ref/javaee/=/docs/ref/javaee/8/
-/docs/ref/microprofile/=/docs/ref/microprofile/2.1/
+/docs/ref/microprofile/=/docs/ref/microprofile/2.2/
 /docs/ref/=/docs/
 /docs/intro/=/docs/
 /guides/microprofile-intro.html=/guides/cdi-intro.html


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [x] https://validator.w3.org/checklink
- [x] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
