### PR TITLE
Change Travis config to only start builds required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,16 @@ before_install:
   - sudo apt-get install python3-bs4 -y
 
 # Trigger a build for each environment
-env:
-  - ROUTE=$SITE_QA_DOMAIN GUIDE_CLONE_BRANCH=$GUIDE_QA_BRANCH JEKYLL_ENV=production
-  - ROUTE=$SITE_DRAFT_GUIDES_DOMAIN GUIDE_CLONE_BRANCH=$GUIDE_DEV_BRANCH
-  - ROUTE=$SITE_DEV_DOMAIN GUIDE_CLONE_BRANCH=$GUIDE_DEV_BRANCH
+jobs:
+  include:
+    - env: ROUTE=$SITE_QA_DOMAIN GUIDE_CLONE_BRANCH=$GUIDE_QA_BRANCH JEKYLL_ENV=production
+      if: branch = master
+    - env: ROUTE=$SITE_DRAFT_GUIDES_DOMAIN GUIDE_CLONE_BRANCH=$GUIDE_DEV_BRANCH
+      if: branch = master
+    - env: ROUTE=$SITE_DEV_DOMAIN GUIDE_CLONE_BRANCH=$GUIDE_DEV_BRANCH
+      if: branch = development
+    # Build other branches besides master and development
+    - if: branch != master  AND branch != development 
 
 script: >
     if [ $TRAVIS_BRANCH = "master" && $ROUTE = $SITE_QA_DOMAIN ]; then
@@ -38,16 +44,16 @@ deploy:
     on:
       branch: master
       condition: $ROUTE = $SITE_QA_DOMAIN
-    script: env ROUTE=$SITE_QA_DOMAIN ./.travis/cf-push.sh
+    script: ./.travis/cf-push.sh
   - provider: script
     skip_cleanup: true
     on:
       branch: master
       condition: $ROUTE = $SITE_DRAFT_GUIDES_DOMAIN
-    script: env ROUTE=$SITE_DRAFT_GUIDES_DOMAIN ./.travis/cf-push.sh
+    script: ./.travis/cf-push.sh
   - provider: script
     skip_cleanup: true
     on:
       branch: development
       condition: $ROUTE = $SITE_DEV_DOMAIN
-    script: env ROUTE=$SITE_DEV_DOMAIN ./.travis/cf-push.sh
+    script: ./.travis/cf-push.sh

--- a/scripts/build_clone_guides.rb
+++ b/scripts/build_clone_guides.rb
@@ -26,7 +26,7 @@ repos = client.org_repos('OpenLiberty')
 # --------------------------------------------
 # For the interactive guides, only build the dev branch for the TravisCI environments
 guide_branch = 'master'
-if ENV['TRAVIS']
+if ENV['TRAVIS'] && ENV['GUIDE_CLONE_BRANCH']
     guide_branch = ENV['GUIDE_CLONE_BRANCH']
 end
 

--- a/scripts/build_jekyll_maven.sh
+++ b/scripts/build_jekyll_maven.sh
@@ -30,7 +30,6 @@ if [ "$JEKYLL_ENV" != "production" ]; then
     cp robots.txt src/main/content/robots.txt
     
     echo "Clone draft guides for test environments..."
-    echo "The GUIDE_CLONE_BRANCH is $GUIDE_CLONE_BRANCH"
     ruby ./scripts/build_clone_guides.rb "draft-guide"
     ./scripts/build_clone_docs.sh "develop" # Argument is branch name of OpenLiberty/docs
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Problem:
The last Travis changes had a matrix of environment variables that ran 3 builds for every branch pushed to, even if they weren't environments meant for the given branch. This would waste resources and later just cancel the build before deploying the zombie builds.
Fixes:
Change the Travis configuration to only run builds that should be ran for each branch using Travis 'jobs'. 
Remove redundant $ROUTE in the deploy stage for master and development already set in the env step.
Added a fallback Travis job to run when not on development or master so it will still build on new branches, and they will deploy to the ROUTE specified in the added deploy step when adding a new environment such as: 
```
- provider: script
    skip_cleanup: true
    on:
      branch: <new_branch>
    script: env ROUTE<new_route_domain> =./.travis/cf-push.sh
```
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
