### PR TITLE
Fix dismiss button showing up in desktop view

### DIFF
--- a/src/main/content/_assets/css/guide-multipane.scss
+++ b/src/main/content/_assets/css/guide-multipane.scss
@@ -81,6 +81,10 @@
     bottom: 0; /* Initially extend the code column the full height */
     overflow: hidden;
 
+    #dismiss_button {
+        display: none;
+    }
+
     @media screen and (max-width: 1169.98px) {
         position: absolute;
         display: none;
@@ -113,6 +117,7 @@
 
             #dismiss_button {
                 position: absolute;
+                display: inline-block;
                 top: 0;
                 right: 50px;
                 background:#ffffff;


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Added css to not show the dismiss button in desktop mode.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
