### PR TITLE
Fix resize code column

### DIFF
--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -565,6 +565,9 @@ function restoreCodeColumn(){
             "pointer-events" : "auto"
         });
         $("#code_column").removeClass("modal");
+        $("#code_column").css({
+            "height" : 'auto'
+        });
         remove_highlighting();
     });
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Undo the mobile hotspot code popup height so that if the user resizes the screen to desktop view it isn't broken.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
