### PR TITLE
Remove the coupling between TRAVIS_ENV and cloning draft content

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ jobs:
       if: branch = master
     - env: ROUTE=$SITE_DEV_DOMAIN GUIDE_CLONE_BRANCH=$GUIDE_DEV_BRANCH JEKYLL_DRAFTS=true
       if: branch = development
+    - env: ROUTE=$SITE_DEMO1_DOMAIN
+      if: branch = demo1
     # Build other branches besides master and development
     - if: branch != master AND branch != development 
 
@@ -58,5 +60,5 @@ deploy:
     skip_cleanup: true
     on:
       branch: demo1
-    script: env ROUTE=$SITE_DEMO1_DOMAIN ./.travis/cf-push.sh
+    script: ./.travis/cf-push.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,12 @@ jobs:
   include:
     - env: ROUTE=$SITE_QA_DOMAIN GUIDE_CLONE_BRANCH=$GUIDE_QA_BRANCH JEKYLL_ENV=production
       if: branch = master
-    - env: ROUTE=$SITE_DRAFT_GUIDES_DOMAIN GUIDE_CLONE_BRANCH=$GUIDE_DEV_BRANCH
+    - env: ROUTE=$SITE_DRAFT_GUIDES_DOMAIN GUIDE_CLONE_BRANCH=$GUIDE_DEV_BRANCH JEKYLL_DRAFTS=true
       if: branch = master
-    - env: ROUTE=$SITE_DEV_DOMAIN GUIDE_CLONE_BRANCH=$GUIDE_DEV_BRANCH
+    - env: ROUTE=$SITE_DEV_DOMAIN GUIDE_CLONE_BRANCH=$GUIDE_DEV_BRANCH JEKYLL_DRAFTS=true
       if: branch = development
     # Build other branches besides master and development
-    - if: branch != master  AND branch != development 
+    - if: branch != master AND branch != development 
 
 script: >
     if [ $TRAVIS_BRANCH = "master" && $ROUTE = $SITE_QA_DOMAIN ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ jobs:
       if: branch = development
     - env: ROUTE=$SITE_DEMO1_DOMAIN
       if: branch = demo1
-    # Build other branches besides master and development
-    - if: branch != master AND branch != development 
 
 script: >
     if [ $JEKYLL_ENV == "production" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,9 @@ jobs:
     - if: branch != master AND branch != development 
 
 script: >
-    if [ $TRAVIS_BRANCH = "master" && $ROUTE = $SITE_QA_DOMAIN ]; then
+    if [ $JEKYLL_ENV == "production" ]; then
       cp robots.txt src/main/content/robots.txt      
       ./scripts/build_jekyll_maven.sh
-    elif [ $TRAVIS_BRANCH = "master" && $ROUTE = $SITE_DRAFT_GUIDES_DOMAIN ]; then
-      ./scripts/build_jekyll_maven.sh
-    elif [ $TRAVIS_BRANCH = "development" && $ROUTE = $SITE_DEV_DOMAIN ]; then
-      env GUIDE_CLONE_BRANCH=$GUIDE_DEV_BRANCH ./scripts/build_jekyll_maven.sh
     else
       ./scripts/build_jekyll_maven.sh
     fi

--- a/scripts/build_jekyll_maven.sh
+++ b/scripts/build_jekyll_maven.sh
@@ -17,14 +17,22 @@ echo "Cloning repositories with name starting with guide or iguide..."
 ruby ./scripts/build_clone_guides.rb
 
 # Development environment only actions
-if [ "$JEKYLL_ENV" != "production" ]; then
+if [ "$JEKYLL_ENV" != "production" ]; then 
     echo "Not in production environment..."
     echo "Adding robots.txt"
     cp robots.txt src/main/content/robots.txt
-    
-    echo "Clone draft guides for test environments..."
-    ruby ./scripts/build_clone_guides.rb "draft-guide"
+
     ./scripts/build_clone_docs.sh "develop" # Argument is branch name of OpenLiberty/docs
+else
+    # Production!
+    echo "Clone published docs!"
+    ./scripts/build_clone_docs.sh "master" # Argument is branch name of OpenLiberty/docs
+fi
+
+# Development environments with draft docs/guides
+if [ "$JEKYLL_DRAFTS" == "true" ]; then
+    echo "Clone draft guides for test environments..."
+    ruby ./scripts/build_clone_guides.rb "draft-guide"    
 
     # Need to make sure there are draft-iguide* folders before using the find command
     # If we don't, the find command will fail because the path does not exist
@@ -36,10 +44,6 @@ if [ "$JEKYLL_ENV" != "production" ]; then
 
     # Include draft blog posts for non production environments
     JEKYLL_BUILD_FLAGS="--drafts"
-else
-    # Production!
-    echo "Clone published docs!"
-    ./scripts/build_clone_docs.sh "master" # Argument is branch name of OpenLiberty/docs
 fi
 
 # Special handling for javadocs


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Now every test/dev site that doesn't have the TRAVIS_ENV==production flag will not clone draft guides/docs unless a TRAVIS_DRAFTS=true flag is set. This is so some of the test environments which should mimic the real website such as qa and demo will not have drafts.
Openlibertydev.mybluemix.net will still have the draft flag set because the doc team uses it to test draft docs/blogs.

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
