### PR TITLE
override the default code styling in end of guide section

### DIFF
--- a/src/main/content/_assets/css/end-of-guide.css
+++ b/src/main/content/_assets/css/end-of-guide.css
@@ -101,6 +101,11 @@
     padding-left: 0;
 }
 
+#end_of_guide_left_section code {
+    background-color: #f4f4f4;
+    color: #5e6b8d;
+}
+
 @media (min-width: 1440px) {
     #end_of_guide_left_section {
         width: calc(100% - 780px);


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
