### PR TITLE
Static guide single pane css fixes and fix the copy icons

### DIFF
--- a/src/main/content/_assets/css/guide.scss
+++ b/src/main/content/_assets/css/guide.scss
@@ -215,7 +215,7 @@ header {
 
 #guide_content .sect1 > .sectionbody {
     padding-top: 19px;
-    margin-bottom: 200px;
+    margin-bottom: 100px;
 }
 
 #guide_content div.sect1 {

--- a/src/main/content/_assets/js/guide-utils.js
+++ b/src/main/content/_assets/js/guide-utils.js
@@ -141,13 +141,15 @@ function isBackgroundBottomVisible() {
 function resizeGuideSections() {
         // Two column view or three column view.
     if (window.innerWidth > twoColumnBreakpoint) {
-        var viewportHeight = window.innerHeight;
-        var headerHeight = $('header').height();
-        var sectionTitleHeight = $("#guide_content h2").first().height();
-        var newSectionHeight = viewportHeight - headerHeight - sectionTitleHeight;
-        $('.sect1:not(#guide_meta):not(#related-guides)').css({
-                'min-height': newSectionHeight + 'px'
-        });
+        if(!onAppleDevice() && !onIE()){
+            var viewportHeight = window.innerHeight;
+            var headerHeight = $('header').height();
+            var sectionTitleHeight = $("#guide_content h2").first().height();
+            var newSectionHeight = viewportHeight - headerHeight - sectionTitleHeight;
+            $('.sect1:not(#guide_meta):not(#related-guides)').css({
+                    'min-height': newSectionHeight + 'px'
+            });
+        }        
         if(window.innerWidth >= threeColumnBreakpoint){
             // In three column view set the width of the #guide_column appropriately.
             if ($("#toc_column").hasClass('in') || $("#toc_column").hasClass('inline')) {

--- a/src/main/content/_layouts/guide.html
+++ b/src/main/content/_layouts/guide.html
@@ -82,7 +82,7 @@ js:
             
             </div>
             <div id="guide_section_copied_confirmation">Copied to clipboard</div>
-            <a id="copy_to_clipboard" href=""></a>
+            <img id="copy_to_clipboard" src='/img/guides_copy_button.svg' alt='Copy code block' title='Copy code block'>
         </div> 
         
     </div>    

--- a/src/main/content/_layouts/guide.html
+++ b/src/main/content/_layouts/guide.html
@@ -57,7 +57,7 @@ js:
                         <div id="mobile_github_clone_popup_repo">
                             <span>git clone https://github.com/OpenLiberty/guide-{{page.url | replace: '/guides/', ''}}.git</span>
                             <div id="mobile_github_clone_popup_copy" tabindex="0" aria-label="Copy the Github repository clone command">
-                                <img src="/img/guide_copy_button_black.svg" alt="Copy Github clone command">
+                                <img src="/img/guides_copy_button_black.svg" alt="Copy Github clone command" title="Copy Github clone command">
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Fixes the missing copy icon in https://draft-guides.mybluemix.net/guides/cloud-ibm.html in both the code snippets and mobile github copy.
Reduce the whitespace between sections.
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
