### PR TITLE
Fix a hotspot bug where it switches to the wrong file

### DIFF
--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -30,7 +30,9 @@ function link_hotspots_to_file(code_block, header, index){
         hotspots = hotspots.add(code_block.prevUntil('.code_column', '.paragraph').find('code[class*=hotspot], span[class*=hotspot], div[class*=hotspot]'));
     }
     hotspots.each(function(){
-        $(this).data('file-index', index);
+        if($(this).data('file-index') === undefined){
+            $(this).data('file-index', index);
+        }        
     });
 }
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
In https://hotspots-openlibertyio.mybluemix.net/guides/getting-started.html#updating-the-source-code-without-restarting-the-server, some hotspots were broken because the second file was overriding the hotspots from the previous file. This will only set the fileindex for hotspots that haven't been set by a previous iteration.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
