### PR TITLE
Add rss feed for jakartaee

### DIFF
--- a/src/main/content/jakartaee.xml
+++ b/src/main/content/jakartaee.xml
@@ -13,7 +13,7 @@ permalink: /jakartaee.xml
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>
 
-    {% for post in site.tags["jakartaee"] %}
+    {% for post in site.tags["Jakarta EE"] %}
       <item>
         <title>{{ post.title | xml_escape }}</title>
         <description>{{ post.content | xml_escape }}</description>

--- a/src/main/content/jakartaee.xml
+++ b/src/main/content/jakartaee.xml
@@ -9,15 +9,16 @@ permalink: /jakartaee.xml
     <description>{{ site.description | xml_escape }}</description>
     <link>{{ site.url }}{{ site.baseurl }}/</link>
     <atom:link href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml"/>
-    <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
-    <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
+    {% assign date_format = site.minima.date_format | default: "%b %-d, %Y" %}
+    <pubDate>{{ site.time | date: date_format }}</pubDate>    
+    <lastBuildDate>{{ site.time | date: date_format }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>
 
     {% for post in site.tags["Jakarta EE"] %}
       <item>
         <title>{{ post.title | xml_escape }}</title>
-        <description>{{ post.content | xml_escape }}</description>
-        <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
+        <description>{{ post.content | xml_escape }}</description>        
+        <pubDate>{{ post.date | date: date_format }}</pubDate>
         <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
         <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>
         {% for tag in post.tags %}

--- a/src/main/content/jakartaee.xml
+++ b/src/main/content/jakartaee.xml
@@ -1,0 +1,33 @@
+---
+layout: null
+permalink: /jakartaee.xml
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ site.title | xml_escape }}</title>
+    <description>{{ site.description | xml_escape }}</description>
+    <link>{{ site.url }}{{ site.baseurl }}/</link>
+    <atom:link href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml"/>
+    <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
+    <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
+    <generator>Jekyll v{{ jekyll.version }}</generator>
+
+    {% for post in site.tags["jakartaee"] %}
+      <item>
+        <title>{{ post.title | xml_escape }}</title>
+        <description>{{ post.content | xml_escape }}</description>
+        <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
+        <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
+        <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>
+        {% for tag in post.tags %}
+        <category>{{ tag | xml_escape }}</category>
+        {% endfor %}
+        {% for cat in post.categories %}
+        <category>{{ cat | xml_escape }}</category>
+        {% endfor %}
+      </item>
+    {% endfor %}
+
+  </channel>
+</rss>

--- a/src/main/content/jakartaee.xml
+++ b/src/main/content/jakartaee.xml
@@ -14,7 +14,7 @@ permalink: /jakartaee.xml
     <lastBuildDate>{{ site.time | date: date_format }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>
 
-    {% for post in site.tags["Jakarta EE"] %}
+    {% for post in site.tags["JakartaEE"] %}
       <item>
         <title>{{ post.title | xml_escape }}</title>
         <description>{{ post.content | xml_escape }}</description>        


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Until we get response from jekyll-feed for auto generation of rss feeds based on category/tags, we created this rss feed file which will load at /jakartaee.xml

To add the blog to this feed, the blog author needs to add `tags: [jakartaee]` to their blog in the front matter.
#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
