### PR TITLE
Fix whitespace in tag hotspot parsing code

### DIFF
--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -403,7 +403,7 @@ function parse_tags(code_block){
         var end_index = text.indexOf('[]');
         var tag_name = text.substring(start_index, end_index);
         var end = $(this).nextAll("span:contains('end::" + tag_name + "')").first();
-        var content = $(this).nextUntil(end);
+        var content = $(this).nextUntil(end.prev());
 
         // Check if the tag should be hidden
         var hide = false;
@@ -450,7 +450,8 @@ function parse_tags(code_block){
 
     start_tags.remove();
     end_tags.remove();
-    empty_start_space.add(empty_end_space).remove();
+    empty_start_space.remove();
+    empty_end_space.remove();
 
     // Trim extra whitespace
     var code = code_block.find('code');

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -371,8 +371,12 @@ function parse_tags(code_block){
     // Wrap the standalone text in spans so they can be selected between the range of start and end tags using jQuery's nextUntil()
     code_block.find('code').contents().each(function(){
         if (!$(this).is('span')) {
-            var newText = $(this).wrap('<span class="string"></span>');
-            $(this).replaceWith(newText);
+            var newText = $(this).wrap('<span class="string"></span>');     
+            if(newText.text().trim() === ""){
+                // Mark the span to know that it can be removed later when removing whitespace.
+                newText.parent().attr('data-empty-space', true);
+            }       
+            $(this).replaceWith(newText);           
         }
     });
 
@@ -434,19 +438,19 @@ function parse_tags(code_block){
     });
 
     // Hide the empty space before the start tags added before to select the range.
-    var empty_space = start_tags.prev('span').filter(function(){
-        return this.innerText.trim() == "";
+    var empty_start_space = start_tags.prev('span').add(start_tags.next('span')).filter(function(){
+        return this.innerText.trim() == "" && $(this).attr('data-empty-space');
     });
-    empty_space.remove();
-    start_tags.remove();
 
     // Hide the empty space after the end tags added before to select the range.
     var end_tags = code_block.find('span:contains(end::)');
-    empty_space = end_tags.next('span').filter(function(){
-        return this.innerText.trim() == "";
+    var empty_end_space = end_tags.next('span').filter(function(){
+        return this.innerText.trim() == "" && $(this).attr('data-empty-space');
     });
-    empty_space.remove();
+
+    start_tags.remove();
     end_tags.remove();
+    empty_start_space.add(empty_end_space).remove();
 
     // Trim extra whitespace
     var code = code_block.find('code');


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
When parsing the source code to mark tag lines that will be highlighted later and removing tags that the author wants hidden permanently, the parsing code was wrong and would leave a few whitespaces behind or remove necessary whitespace. This will fix the bugs.

Guides that are already using the tag hotspots:
https://github.com/OpenLiberty/guide-gradle-intro
https://github.com/OpenLiberty/guide-microprofile-jwt/pull/96
https://github.com/OpenLiberty/draft-guide-microprofile-rest-client-async/pull/4
https://github.com/OpenLiberty/guide-rest-intro

The bug was found in the draft-guide-microprofile-rest-client-async guides under branch `hotspot-conversion`.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
