### PR TITLE
Fix the way we look for existing guide images in the build before c…

### DIFF
--- a/scripts/build_jekyll_maven.sh
+++ b/scripts/build_jekyll_maven.sh
@@ -59,13 +59,16 @@ popd
 
 echo "Copying guide images to /img/guide"
 mkdir -p src/main/content/img/guide
-# Check if any draft guide images exist first
-if [ -e src/main/content/guides/draft-guide*/assets/* ]
- then cp src/main/content/guides/draft-guide*/assets/* src/main/content/img/guide/
+
+# Check if any draft guide images exist.
+if ls src/main/content/guides/draft-guide*/assets/* 1> /dev/null 2>&1; then
+    echo "Copying draft guide images to /img/guide"
+    cp src/main/content/guides/draft-guide*/assets/* src/main/content/img/guide/
 fi
-# Check if any published guide images exist first
-if [ -e src/main/content/guides/guide*/assets/* ]
- then cp src/main/content/guides/guide*/assets/* src/main/content/img/guide/
+# Check if any published guide images exist.
+if ls src/main/content/guides/guide*/assets/* 1> /dev/null 2>&1; then
+    echo "Copying published guide images to /img/guide"
+    cp src/main/content/guides/guide*/assets/* src/main/content/img/guide/
 fi
 
 # Move any js/css files from guides to the _assets folder for jekyll-assets minification.


### PR DESCRIPTION
…opying

them to the img directory

#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
