### PR TITLE
Change trigger for removing github clone popup to match toc trigger

### DIFF
--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -235,6 +235,13 @@ function handleGithubPopup() {
         var navHeight = $('.navbar').height();
         var blurCodeOnRight = (firstCodeSectionTop - navHeight) > 1;
 
+        // get id of most visible section
+        // if most visible section is first code section, unblur code pane
+        var most_visible_section_id = getScrolledVisibleSectionID();
+        if (most_visible_section_id == firstCodeSection[0].id) {
+            blurCodeOnRight = false;
+        }
+
         var firstHotspot = $("#guide_column .hotspot:visible")[0];
         var firstHotspotRect = firstHotspot.getBoundingClientRect();
         var firstHotspotInView = (firstHotspotRect.top > 0) && (firstHotspotRect.bottom <= window.innerHeight);


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
