### PR TITLE
Change whitespace wrapping back to normal for command blocks

### DIFF
--- a/src/main/content/_assets/css/guide.scss
+++ b/src/main/content/_assets/css/guide.scss
@@ -172,6 +172,7 @@ header {
     & code {
         background-color: inherit;
         color: inherit;
+        white-space: normal;
     }
 }
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
