### PR TITLE
Fix wrapping of command blocks

### DIFF
--- a/src/main/content/_assets/css/guide.scss
+++ b/src/main/content/_assets/css/guide.scss
@@ -172,7 +172,7 @@ header {
     & code {
         background-color: inherit;
         color: inherit;
-        white-space: normal;
+        white-space: pre-wrap;
     }
 }
 


### PR DESCRIPTION
Pre wrap the white-space so that the content preserves the newlines from the .adoc files

#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
