### PR TITLE
Update redirect for MP javadoc to 3.0

### DIFF
--- a/src/main/webapp/WEB-INF/redirects.properties
+++ b/src/main/webapp/WEB-INF/redirects.properties
@@ -8,7 +8,7 @@
 
 /index.html/=/index.html
 /docs/ref/javaee/=/docs/ref/javaee/8/
-/docs/ref/microprofile/=/docs/ref/microprofile/2.2/
+/docs/ref/microprofile/=/docs/ref/microprofile/3.0/
 /docs/ref/=/docs/
 /docs/intro/=/docs/
 /guides/microprofile-intro.html=/guides/cdi-intro.html


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
MicroProfile javadoc redirect was updated from 2.2 to the shiny new 3.0

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
