### PR TITLE
Restore function call that scrolls to subsection

### DIFF
--- a/src/main/content/_assets/js/configs.js
+++ b/src/main/content/_assets/js/configs.js
@@ -213,6 +213,9 @@ function scrollToPos(pos) {
         $('html, body').animate({
             scrollTop: pos
         }, 400);
+    } else {	
+        // scroll to the position that will show the target anchor below the fixed content breadcrumb	
+        iframeContents.scrollTop(pos);	
     }
 }
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
