### PR TITLE
Guide mobile hotspots update

### DIFF
--- a/src/main/content/_assets/css/coderay-custom.scss
+++ b/src/main/content/_assets/css/coderay-custom.scss
@@ -64,7 +64,7 @@ table.CodeRay td { padding: 2px 4px; vertical-align: top; }
 .CodeRay .class { color:#995613; font-weight:500 }
 .CodeRay .class-variable { color:#369 }
 .CodeRay .color { color:#0A0 }
-.CodeRay .comment { color:#777 }
+.CodeRay .comment { color: darken(#777, 5%) } // Darken to pass DAP
 .CodeRay .comment .char { color:#444 }
 .CodeRay .comment .delimiter { color:#444 }
 .CodeRay .constant { color:#036; font-weight:500 }
@@ -107,7 +107,7 @@ table.CodeRay td { padding: 2px 4px; vertical-align: top; }
 .CodeRay .predefined { color:#369; font-weight:500 }
 .CodeRay .predefined-constant { color:#069 }
 .CodeRay .predefined-type { color:#566D17; font-weight:500 }
-.CodeRay .preprocessor { color:#579 }
+.CodeRay .preprocessor { color:darken(#579, 5%) } // Darken to pass DAP
 .CodeRay .pseudo-class { color:#00C; font-weight:500 }
 .CodeRay .regexp { background-color:hsla(300,100%,50%,0.06); }
 .CodeRay .regexp .content { color:#808 }

--- a/src/main/content/_assets/css/guide-multipane.scss
+++ b/src/main/content/_assets/css/guide-multipane.scss
@@ -100,10 +100,11 @@
 .mobile_code_column {
     display: none;
     background-color: #f1f4fe;
+    overflow: hidden;  
 
     @media screen and (max-width: 1169.98px){
         &.open {
-            display: block;           
+            display: block;                     
 
             .CodeRay, code {
                 background-color: inherit !important;
@@ -112,6 +113,13 @@
     
             #github_clone_popup {
                 display: none;
+            }
+
+            .code_column_title_container { 
+                @media (max-width: 1169.98px) {
+                    width: 100%;
+                    padding-left: 0;
+                }
             }
     
             // Remove blur
@@ -126,28 +134,31 @@
     
             .code_column_tabs {
                 max-width: calc(100% - 60px);
-                height: 44px;
-                overflow-x: auto;
-                overflow-y: hidden;
-    
-                & > li {
-                    float: none;
-                    display: table-cell !important;
-                }
+                overflow: auto;
+            }
+
+            .code_colummn_content {
+                overflow: auto;
             }
     
-            .mobile_code_expand {
-                display: block;
+            .mobile_code_caret {
                 position: absolute;
                 z-index: 2; // Appear over the dimmed mobile snippet.
                 right: 30px;
                 bottom: 30px;
                 width: 30px;
                 height: 25px; 
-                border: none;
-                background-image: url(/img/down_arrow_blue.svg);
+                border: none;                
                 background-color: transparent;
-                background-repeat: no-repeat;                               
+                background-repeat: no-repeat;
+                background-image: url(/img/down_arrow_blue.svg);
+            }
+            .mobile_code_expand {
+                display: block;
+            }
+            .mobile_code_collapse {
+                display: none;
+                transform: rotate(180deg);
             }
         } 
         &:after {
@@ -184,18 +195,6 @@
 .dimmed {
     opacity: .19;
     filter: blur(1px);
-}
-
-.code_column_title_container {
-    height: 43px;
-    padding-left: 23px; 
-    border-bottom: solid 1px #d4d7e3;
-    display: table;
-    width: 100%;
-
-    @media (max-width: 1169.98px) {
-        padding-left: 0;
-    }
 }
 
 .code_column_title {

--- a/src/main/content/_assets/css/guide-multipane.scss
+++ b/src/main/content/_assets/css/guide-multipane.scss
@@ -101,7 +101,9 @@
 
     @media screen and (max-width: 1169.98px){
         &.open {
-            display: block;                     
+            display: block;       
+            margin-left: -23px;
+            margin-right: -31px;
 
             .CodeRay, code {
                 background-color: inherit !important;
@@ -136,6 +138,13 @@
 
             .code_colummn_content {
                 overflow: auto;
+            }
+
+            .CodeRay .highlightSection {
+                padding-left: 44px;
+                padding-right: 34px;
+                margin-left: -44px;
+                margin-right: -34px;
             }
     
             .mobile_code_caret {
@@ -413,6 +422,12 @@
 }
 
 @media (max-width: 1169.98px) {
+    #guide_content pre code {
+        white-space: pre-wrap;
+    }
+    #guide_content .code_column .CodeRay {
+        padding: 9.5px 16px; // Override guide.css
+    }
     #guide_content code.hotspot:hover,
     #guide_content .code_command:hover {
         cursor: pointer;

--- a/src/main/content/_assets/css/guide-multipane.scss
+++ b/src/main/content/_assets/css/guide-multipane.scss
@@ -84,10 +84,6 @@
     bottom: 0; /* Initially extend the code column the full height */
     overflow: hidden;
 
-    .mobile_code_expand {
-        display: none;
-    }
-
     @media screen and (max-width: 1169.98px) {
         position: absolute;
         display: none;
@@ -100,6 +96,7 @@
 .mobile_code_column {
     display: none;
     background-color: #f1f4fe;
+    margin-bottom: 18px;
     overflow: hidden;  
 
     @media screen and (max-width: 1169.98px){
@@ -154,31 +151,27 @@
                 background-image: url(/img/down_arrow_blue.svg);
             }
             .mobile_code_expand {
-                display: block;
+                display: none;
             }
             .mobile_code_collapse {
-                display: none;
+                display: block;
                 transform: rotate(180deg);
             }
-        } 
-        &:after {
-            content  : "";
-            position : absolute;
-            z-index  : 1;
-            bottom   : 0;
-            left     : 0;
-            pointer-events   : none;
-            background-image : linear-gradient(to bottom, 
-                                rgba(255,255,255, 0), 
-                                rgba(255,255,255, 1) 90%);
-            width    : 100%;
-            height   : 50%;
         }       
-        &.removeGradient {
+        &.gradient {
             &:after {
-                content: none;
-                background-image: none;
-            }
+                content  : "";
+                position : absolute;
+                z-index  : 1;
+                bottom   : 0;
+                left     : 0;
+                pointer-events   : none;
+                background-image : linear-gradient(to bottom, 
+                                    rgba(255,255,255, 0), 
+                                    rgba(255,255,255, 1) 90%);
+                width    : 100%;
+                height   : 50%;
+            }            
         }
     }
 }

--- a/src/main/content/_assets/css/guide-multipane.scss
+++ b/src/main/content/_assets/css/guide-multipane.scss
@@ -45,6 +45,8 @@
 #guide_content code.hotspot {
     background-color: #F1F4FE;
     color:#5e6b8d;
+    border: 1px solid #C8D6FB;
+    border-radius: 5px;
 }
 
 #guide_content .hotspot:not(.code_command) pre {
@@ -61,6 +63,7 @@
 
 #guide_content .code_command pre,  #guide_content .code_command code {
     background-color: #F1F4FE;
+    color: #5e6b8d;
     margin-bottom: 0;
     overflow: hidden;
     white-space: pre-wrap;       /* css-3 */
@@ -81,7 +84,7 @@
     bottom: 0; /* Initially extend the code column the full height */
     overflow: hidden;
 
-    #dismiss_button {
+    .mobile_code_expand {
         display: none;
     }
 
@@ -91,40 +94,79 @@
         left: 0;
         width: 100%;
         height: 100%;
+    }
+}
 
-        &.modal {
-            display: block;
-            overflow: auto;
+.mobile_code_column {
+    display: none;
+    background-color: #f1f4fe;
 
+    @media screen and (max-width: 1169.98px){
+        &.open {
+            display: block;           
+
+            .CodeRay, code {
+                background-color: inherit !important;
+                color: inherit !important;
+            }
+    
             #github_clone_popup {
                 display: none;
             }
-
+    
             // Remove blur
-            #code_column_tabs_container, .code_column {
+            .code_column_tabs_container, .code_column {
                 opacity: 1;
                 filter: none;
             }
-
-            #code_column_tabs_container {
-                width: 100%;
+    
+            .code_column_tabs_container {
+                width: 100%;                
             }
-
-            #code_column_tabs {
-                // Give more room for the 'Back to text' button so the tabs don't overlap.
-                max-width: calc(100% - 135px);
+    
+            .code_column_tabs {
+                max-width: calc(100% - 60px);
+                height: 44px;
+                overflow-x: auto;
+                overflow-y: hidden;
+    
+                & > li {
+                    float: none;
+                    display: table-cell !important;
+                }
             }
-
-            #dismiss_button {
+    
+            .mobile_code_expand {
+                display: block;
                 position: absolute;
-                display: inline-block;
-                top: 0;
-                right: 50px;
-                background:#ffffff;
-                border:1px solid #96bc32;
-                border-radius:3px;
-                width:92px;
-                height:38px;
+                z-index: 2; // Appear over the dimmed mobile snippet.
+                right: 30px;
+                bottom: 30px;
+                width: 30px;
+                height: 25px; 
+                border: none;
+                background-image: url(/img/down_arrow_blue.svg);
+                background-color: transparent;
+                background-repeat: no-repeat;                               
+            }
+        } 
+        &:after {
+            content  : "";
+            position : absolute;
+            z-index  : 1;
+            bottom   : 0;
+            left     : 0;
+            pointer-events   : none;
+            background-image : linear-gradient(to bottom, 
+                                rgba(255,255,255, 0), 
+                                rgba(255,255,255, 1) 90%);
+            width    : 100%;
+            height   : 50%;
+        }       
+        &.removeGradient {
+            &:after {
+                content: none;
+                background-image: none;
             }
         }
     }
@@ -134,7 +176,7 @@
     outline-offset: -1px;
 }
 
-#code_column_content {
+.code_column_content {
     height: calc(100% - 34px); /* Take up the remaining height from the tabs container */
     overflow-y: scroll;
 }
@@ -150,6 +192,10 @@
     border-bottom: solid 1px #d4d7e3;
     display: table;
     width: 100%;
+
+    @media (max-width: 1169.98px) {
+        padding-left: 0;
+    }
 }
 
 .code_column_title {
@@ -219,21 +265,21 @@
     height: 16px;
 }
 
-#code_column_tabs_container {
+.code_column_tabs_container {
     display: inline-block;
 
-    #code_column_tabs {
+    .code_column_tabs {
         max-width: calc(100% - 50px);
         & > li {
             float: left;
+            height: 44px;
     
             & > a {
                 text-overflow: ellipsis;
                 overflow: hidden;
                 white-space: nowrap;
                 text-align: center;  
-                letter-spacing: 0;
-                height: 44px;
+                letter-spacing: 0;                
                 padding: 8px 5px;
                 border: 1px solid #acb3c6;
                 border-bottom: transparent;

--- a/src/main/content/_assets/css/guide.scss
+++ b/src/main/content/_assets/css/guide.scss
@@ -118,11 +118,16 @@ header {
     background:#f1f4fe;
 }
 
-#guide_content code,
-#guide_content pre  {
+#guide_content code  {
     /* Bootstrap override */
     background-color: #ffffff;
-    color: #7B7B7B;
+    color: darken(#7B7B7B, 5%); // Darken to pass DAP test
+}
+
+#guide_content pre,
+#guide_content pre code {
+    background-color: #f4f4f4;
+    color: #5e6b8d;
 }
 
 #guide_content code {

--- a/src/main/content/_assets/css/guide.scss
+++ b/src/main/content/_assets/css/guide.scss
@@ -121,8 +121,8 @@ header {
 #guide_content code,
 #guide_content pre  {
     /* Bootstrap override */
-    background-color:#f4f4f4;
-    color: #5e6b8d;
+    background-color: #ffffff;
+    color: #7B7B7B;
 }
 
 #guide_content code {

--- a/src/main/content/_assets/css/guide.scss
+++ b/src/main/content/_assets/css/guide.scss
@@ -141,8 +141,7 @@ header {
     }
 }
 
-#guide_content .listingblock.command .content pre,
-#guide_content .command .listingblock:not(.no_copy):not(.code_command) .content pre {
+#guide_content .command .listingblock:not(.no_copy):not(.code_command):not(.code_column) .content pre {
     background-color: #FFFFFF;
     border: 1px solid #96bc32;
     border-left: 8px solid #96bc32;
@@ -156,8 +155,8 @@ header {
 }
 
 #guide_content .listingblock.command .content pre,
-#guide_content .command .listingblock:not(.no_copy):not(.code_command) .content pre,
-#guide_content .paragraph.command ~ .listingblock:not(.no_copy):not(.code_command) .content pre{
+#guide_content .command .listingblock:not(.no_copy):not(.code_command):not(.code_column) .content pre,
+#guide_content .paragraph.command ~ .listingblock:not(.no_copy):not(.code_command):not(.code_column) .content pre{
     background-color: #FFFFFF;
     border: 1px solid #96bc32;
     border-left: 8px solid #96bc32;

--- a/src/main/content/_assets/css/openliberty.scss
+++ b/src/main/content/_assets/css/openliberty.scss
@@ -406,7 +406,7 @@ footer {
     #footer_project {
         font-weight: 500;
         font-size: 11px;
-        color: #6F7878;
+        color: darken(#6F7878, 5%); // Darken to pass DAP
         letter-spacing: 0;
         float: left;
         clear: left;

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -503,6 +503,10 @@ function showMobileCodeBlock(hotspot){
         // Clone the code column including its events and display it below the hotspot
         var code_clone = $("#code_column").clone(true);
         code_clone.removeAttr('id');
+        code_clone.css({ // Remove top/bottom that could have been set on the desktop code column.
+            'top': '',
+            'botom': ''
+        });
         code_clone.addClass('mobile_code_column');
         code_clone.addClass("open");
 

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -443,10 +443,6 @@ function parse_tags(code_block){
 }
 
 $(document).ready(function() { 
-
-    $(window).on('resize', function(){
-        restoreCodeColumn();
-    });
      
      /* Copy button for the github clone command  that pops up initially when opening a guide. */
     $("#github_clone_popup_copy").click(function(event){
@@ -666,7 +662,7 @@ $(document).ready(function() {
             var code_clone = $("#code_column").clone(true); // Clone the code column including its events.
             code_clone.removeAttr('id');
             code_clone.addClass('mobile_code_column');
-            code_clone.addClass("open");  
+            code_clone.addClass("open");
 
             // Scroll the hotspot to the top of the page, with the paragraph encompassing the hotspot shown.
             var top = $(this).offset().top;
@@ -681,7 +677,6 @@ $(document).ready(function() {
             var bottom = scrollTo + window.innerHeight - hotspot_height - 5;
             var height = (bottom - scrollTo) / 2;
             code_clone.css({
-                // "top" : scrollTo + mobile_toc_height + hotspot_height + 5 + "px",
                 "height" : height
             });
 
@@ -692,10 +687,24 @@ $(document).ready(function() {
 
     $('.mobile_code_expand').on('click', function(){
         // Expand the code column to its full height (auto)
-        $(this).parents('.mobile_code_column').css({
+        var code_column = $(this).parents('.mobile_code_column');
+        var height = code_column.css('height');
+        code_column.data('old_height', height);
+        code_column.css({
             'height': 'auto'
         }).addClass('removeGradient');
         $(this).hide();
+        $(this).siblings('.mobile_code_collapse').show();
+    });
+
+    $('.mobile_code_collapse').on('click', function(){
+        var code_column = $(this).parents('.mobile_code_column');
+        var old_height = code_column.data('old_height');
+        code_column.css('height', old_height);
+
+        // Hide the collapse button and show the expand button.
+        $(this).hide();
+        $(this).siblings('.mobile_code_expand').show();
     });
 
     // When hovering over a code hotspot, highlight the correct lines of code in the corresponding code section.

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -72,10 +72,11 @@ function highlightCodeRange(code_section, fromLine, toLine, scroll){
 
     if(scroll){
         var container = code_section.parents(".code_column_container");
-        var scrollTop = code_section.parent()[0].scrollTop;
-        var position = range.position().top;
+        var containerPosition = code_section.parent()[0].scrollTop;
+        var highlightPosition = range.position().top;
         var titleBarHeight = container.find(".code_column_title_container").outerHeight();
-        container.find(".code_column_content").animate({scrollTop: scrollTop + position - titleBarHeight});
+        var scrollPosition = containerPosition + highlightPosition - titleBarHeight;
+        container.find(".code_column_content").animate({scrollTop: scrollPosition});
     }        
 }
 
@@ -360,23 +361,6 @@ function hideDuplicateTabs(id, code_block){
     activeDuplicates.hide();
 }
 
-// function loadMobileTabs(section){
-//     // Reveal the files from previous sections in case the user loaded a later step from a bookmarked hash.
-//     var code_column = section ? section : $("#code_column");
-//     var hiddenTabs = code_column.find(".code_column_tabs li:hidden");
-//     for(var i = hiddenTabs.length - 1; i >= 0; --i){
-//         var tab = hiddenTabs.get(i);
-//         var fileName = tab.innerText.trim();
-//         // Check that only the most recent tab for this file is showing.
-//         var visibleTabsWithSameName = code_column.find(".code_column_tabs li:visible").filter(function(){
-//             return this.innerText.trim() === fileName;
-//         });
-//         if(visibleTabsWithSameName.length === 0){
-//             $(tab).show();
-//         }
-//     }
-// }
-
 function loadPreviousStepsTabs(section){
     // Reveal the files from previous sections in case the user loaded a later step from a bookmarked hash.
     var code_column = section ? section : $("#code_column");
@@ -539,7 +523,7 @@ function showMobileCodeBlock(hotspot){
         // If the hotspot is within a table, insert the code in a row below it.
         var table_row = hotspot.parents('tr');
         if(table_row.length === 1){
-            var new_tr = $("<tr></tr>");
+            var new_tr = $("<tr style='background:none'></tr>");
             var new_td = $("<td colspan='2'></td>");
             new_td.css('padding', '0'); // Make the code full width
             new_tr.append(new_td);
@@ -565,6 +549,9 @@ function expandMobileCodeFile(code_column){
     code_column.css({
         'height': 'auto'
     });
+    code_column.find('.code_column_content').css({
+        'overflow-y': 'scroll'
+    });
     code_column.removeClass('gradient');
     expand_button.hide();
     expand_button.siblings('.mobile_code_collapse').show();
@@ -575,7 +562,12 @@ function expandMobileCodeFile(code_column){
 function collapseMobileCodeFile(code_column){
     var collapsed_height = code_column.data('collapsed_height');
     var collapse_button = code_column.find('.mobile_code_collapse');
-    code_column.css('height', collapsed_height);
+    code_column.css({
+        'height': collapsed_height
+    });
+    code_column.find('.code_column_content').css({
+        'overflow-y': 'hidden'
+    });
     code_column.addClass('gradient');
 
     // Hide the collapse button and show the expand button.
@@ -906,7 +898,7 @@ $(document).ready(function() {
     }
 
     $(".copyFileButton").click(function(event){
-        event.preventDefault();        
+        event.preventDefault();
         var code_column = $(this).parents('.code_column_container');
         var target_copy = code_column.find(".code_column:visible .content code").clone();
         target_copy.find('.line-numbers').remove(); // Remove the line numbers from being copied.

--- a/src/main/content/_assets/js/guide-multipane.js
+++ b/src/main/content/_assets/js/guide-multipane.js
@@ -144,14 +144,24 @@ function showCorrectCodeBlock(id, index, switchTabs, code_block) {
             code_section.find('.code_column').not(code_block).hide();
             code_block.show();
             if(switchTabs){
-                // Load all of the tabs for this section
-                var subsection_files = code_sections[id];
-                for(var i = subsection_files.length - 1; i >= 0; i--){
-                    setActiveTab(subsection_files[i].tab);
-                }
-                if(recent_sections[id]) {
-                    setActiveTab(tab);
-                }
+                if(inSingleColumnView()){
+                    // Find the tab in mobile view to set active.
+                    tab = code_sections[id][index].tab;
+                    var tab_name = $(tab).text();
+                    var mobile_tab = code_section.find('.code_column_tab:visible').filter(function(){
+                        return $(this).text().trim() == tab_name;
+                    });
+                    setActiveTab(mobile_tab);
+                } else {
+                    // Load all of the tabs for this section
+                    var subsection_files = code_sections[id];
+                    for(var i = subsection_files.length - 1; i >= 0; i--){
+                        setActiveTab(subsection_files[i].tab);
+                    }
+                    if(recent_sections[id]) {
+                        setActiveTab(tab);
+                    }
+                }                
             }
             hideDuplicateTabs(id, code_block);
         }
@@ -203,8 +213,9 @@ var handleHotspotHover = debounce(function(hotspot){
             // Switch to the correct tab
             var tab = code_sections[header.id][fileIndex].tab;
             setActiveTab(tab);
-        }        
-        showCorrectCodeBlock(header.id, fileIndex, false, code_block);
+        }
+        var switchTabs = inSingleColumnView() ? true : false;
+        showCorrectCodeBlock(header.id, fileIndex, switchTabs, code_block);
 
         // Highlight the code
         var ranges = hotspot.data('highlight-ranges');

--- a/src/main/content/_layouts/guide-multipane.html
+++ b/src/main/content/_layouts/guide-multipane.html
@@ -106,7 +106,8 @@ js:
                 </div>
             </div>
             <div class="code_column_content"></div>
-            <button class="mobile_code_expand"></button>
+            <button class="mobile_code_caret mobile_code_expand" aria-label="Expand the code"></button>
+            <button class="mobile_code_caret mobile_code_collapse" aria-label="Collapse the code"></button>
 
             <div id="github_clone_popup_container">
                 <div id="github_clone_popup" tabindex="0">

--- a/src/main/content/_layouts/guide-multipane.html
+++ b/src/main/content/_layouts/guide-multipane.html
@@ -96,16 +96,17 @@ js:
         </div>
 
         <!-- Code section -->
-        <div id="code_column" class="position_relative" tabindex="0">
-            <div id='code_column_title_container'>
-                <div id='code_column_tabs_container' class='dimmed'>
-                    <ul id='code_column_tabs' class='nav' role='tablist'></ul>
-                </div>                    
+        <div id="code_column" class="code_column_container position_relative" tabindex="0">
+            <div class='code_column_title_container'>
+                <div class='code_column_tabs_container dimmed'>
+                    <ul class='code_column_tabs nav' role='tablist'></ul>
+                </div>
                 <div class='copyFileButton' tabindex="0">
                     <img src='/img/guides_copy_button.svg' alt='Copy file contents' title='Copy file contents'>
                 </div>
             </div>
-            <div id="code_column_content"></div>
+            <div class="code_column_content"></div>
+            <button class="mobile_code_expand"></button>
 
             <div id="github_clone_popup_container">
                 <div id="github_clone_popup" tabindex="0">
@@ -119,7 +120,6 @@ js:
                 </div>
             </div>
             <div id="code_section_copied_confirmation">Copied to clipboard</div>
-            <button id="dismiss_button" aria-label="Back to text" tabindex="0">Back to text</button>
         </div>
 </div>
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Change the mobile view to allow for hotspots to open code and remain open. The user can collapse or expand the code pane. The code css was altered to make most things classes to allow more than one code pane to exist on the page at once so the user can keep them open.
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [x] iOS (Mobile)
- [x] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
