### PR TITLE
Add table alignment classes that are generated from asciidoc

### DIFF
--- a/src/main/content/_assets/css/openliberty.scss
+++ b/src/main/content/_assets/css/openliberty.scss
@@ -600,3 +600,24 @@ footer {
 .position_relative {
     position: relative;
 }
+
+/* TABLE CLASSES */
+.valign-top {
+    vertical-align: top;
+}
+.valign-middle {
+    vertical-align: middle;
+}
+.valign-bottom {
+    vertical-align: bottom;
+}
+
+.halign-left {
+    text-align: left;
+}
+.halign-center {
+    text-align: center;
+}
+.halign-right {
+    text-align: right;
+}


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Asciidoctor generates halign/valign for table cells and our css did not do anything to actually support those alignments so we need to add it.
For example: https://draft-openlibertyio.mybluemix.net/docs/ref/general/#metrics_catalog.html
The check marks are not centered even though there is classes specified by asciidoc syntax to do so.
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
