### PR TITLE
Move the jekyll gem before the other gems in the install order

### DIFF
--- a/scripts/build_gem_dependencies.sh
+++ b/scripts/build_gem_dependencies.sh
@@ -1,4 +1,4 @@
 echo "Installing ruby packages..."
-gem install bundler jekyll-feed jekyll-asciidoc coderay uglifier octopress-minify-html octokit
 gem install jekyll -v 3.8.6
+gem install bundler jekyll-feed jekyll-asciidoc coderay uglifier octopress-minify-html octokit
 gem install jekyll-assets -v 2.4.0


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
