### PR TITLE
Use jekyll gem version 3.8.6 until we can get the latest version to work

### DIFF
--- a/scripts/build_gem_dependencies.sh
+++ b/scripts/build_gem_dependencies.sh
@@ -1,3 +1,4 @@
 echo "Installing ruby packages..."
-gem install jekyll bundler jekyll-feed jekyll-asciidoc coderay uglifier octopress-minify-html octokit
+gem install jekyll -v 3.8.6
+gem install bundler jekyll-feed jekyll-asciidoc coderay uglifier octopress-minify-html octokit
 gem install jekyll-assets -v 2.4.0


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Since we normally pull in the latest `jekyll` gem version, our build breaks since it doesn't work with the `jekyll-assets` version we use. This will temporarily fix the issue and allow development until we can update `jekyll-assets` and turn off the manual version of `jekyll`.

https://github.com/OpenLiberty/openliberty.io/pull/742 will deliver the change to remove the hardcoded `jekyll-assets` version as well as turn off the hardcoded `jekyll` gem version once the entire app works on that branch due to some css issues and license.

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
