### PR TITLE
Add a class to guides to wrap tables that overflow

### DIFF
--- a/src/main/content/_assets/css/guide.scss
+++ b/src/main/content/_assets/css/guide.scss
@@ -266,7 +266,18 @@ header {
     padding-bottom: 23px;
 }
 
-#guide_content table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
+#guide_content table {
+    background:#fff;
+    margin-bottom:1.25em;
+    border:solid 1px #dedede;       
+      
+    &.wrap_table {
+        /* Prevent overflow of table contents */
+        display: block;
+        overflow-x: auto;
+        overflow-y: hidden;
+    }
+}
 #guide_content table thead, #guide_content table tfoot{background:#f7f8f7;font-weight:bold}
 #guide_content table thead tr th,#guide_content table thead tr td,#guide_content table tfoot tr th,#guide_content table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
 #guide_content table tr th,#guide_content table tr td{padding: 0em 1.625em;font-size:inherit;color:rgba(0,0,0,.8)}


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
To fix the table overflowing on /guides/microprofile-rest-client-async.html#building-and-running-the-application
We can't just add a generic table css because it breaks other guides' tables so this css will be specifically for tables that have too many columns to present in the skinny width of the guide column.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
