### PR TITLE
Avoid overwriting the img/guide images when copying over guides images

### DIFF
--- a/scripts/build_jekyll_maven.sh
+++ b/scripts/build_jekyll_maven.sh
@@ -63,12 +63,12 @@ mkdir -p src/main/content/img/guide
 # Check if any draft guide images exist.
 if ls src/main/content/guides/draft-guide*/assets/* 1> /dev/null 2>&1; then
     echo "Copying draft guide images to /img/guide"
-    cp src/main/content/guides/draft-guide*/assets/* src/main/content/img/guide/
+    cp -n src/main/content/guides/draft-guide*/assets/* src/main/content/img/guide/ || true
 fi
 # Check if any published guide images exist.
 if ls src/main/content/guides/guide*/assets/* 1> /dev/null 2>&1; then
     echo "Copying published guide images to /img/guide"
-    cp src/main/content/guides/guide*/assets/* src/main/content/img/guide/
+    cp -n src/main/content/guides/guide*/assets/* src/main/content/img/guide/ || true
 fi
 
 # Move any js/css files from guides to the _assets folder for jekyll-assets minification.

--- a/src/main/content/_includes/footer.html
+++ b/src/main/content/_includes/footer.html
@@ -32,8 +32,8 @@
 
 <!-- PRE-LOADED IMAGES FOR ON HOVER BEHAVIOR -->
 <div class="d-none hidden">
-    <img src="/img/Footer_GitCat_Hover.svg">
-    <img src="/img/Footer_TwitterBird_Hover.svg">
-    <img src="/img/Footer_StackO_Hover.svg">
-    <img src="/img/Footer_GroupsIO_Hover.svg">    
+    <img src="/img/Footer_GitCat_Hover.svg" alt="OpenLiberty Github link">
+    <img src="/img/Footer_TwitterBird_Hover.svg" alt="OpenLibertyIO Twitter link">
+    <img src="/img/Footer_StackO_Hover.svg" alt="Open-liberty Stack Overflow link">
+    <img src="/img/Footer_GroupsIO_Hover.svg" alt="Openliberty Groups IO link">
 </div>

--- a/src/main/content/blog.html
+++ b/src/main/content/blog.html
@@ -33,7 +33,7 @@ permalink: /blog/
             </div>
             <div id="right_column" class="col-md-12 col-lg-8 offset-lg-4">
                 <div id="filter">
-                    <img id="x_button" src="/img/blog_x_button.svg" onclick="removeFilter(); updateSearchUrl();">
+                    <img id="x_button" src="/img/blog_x_button.svg" onclick="removeFilter(); updateSearchUrl();" alt="Remove tag filter">
                     <span>Filtered by tag: </span>
                     <span id="filter_tag"></span>
                 </div>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Add the -n flag so the cp doesn't fail by trying to overwrite if it sees the same image already in img/guide from another guide.

The drafts site build was breaking due to the same image name in 2 guides.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
