### PR TITLE
Allow command line args to be passed in dev mode

### DIFF
--- a/scripts/jekyll_serve_dev.sh
+++ b/scripts/jekyll_serve_dev.sh
@@ -1,1 +1,1 @@
-jekyll s --host 0.0.0.0 --source src/main/content --config src/main/content/_config.yml,src/main/content/_dev_config.yml
+jekyll s --host 0.0.0.0 --source src/main/content --config src/main/content/_config.yml,src/main/content/_dev_config.yml "$@"


### PR DESCRIPTION
Allow additional arguments like --drafts to be passed when running
jekyll_serve_dev.sh

#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
