### PR TITLE
Remove direct link to latest runtime package

### DIFF
--- a/src/main/content/_assets/js/download.js
+++ b/src/main/content/_assets/js/download.js
@@ -12,16 +12,6 @@
 var latest_release_url = '/api/builds/latest';
 
 $(document).ready(function() {
-
-    $.ajax({
-        url: latest_release_url
-    }).done(function(data) {
-
-        $('#download_link').attr('href', data.runtime.driver_location);
-        $('#download_link_size_label').text('(' + Math.floor(data.runtime.size_in_bytes / 1048576) + ' MB)');
-
-    });
-
     // add custom css to twitter iframe
     $('#twitter_iframe_div').on('DOMSubtreeModified propertychange',"#twitter-widget-0", function() {
         $(".twitter-timeline").contents().find(".timeline-Tweet-media").css("display", "none");


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
