### PR TITLE
Add a redirect for moved 19.0.0.9 blog post

### DIFF
--- a/src/main/webapp/WEB-INF/redirects.properties
+++ b/src/main/webapp/WEB-INF/redirects.properties
@@ -18,3 +18,4 @@
 /config/*=/docs/ref/config/#
 /javadocs/*=/docs/ref/javadocs/
 /blog/2019/03/01/microprofile-concurrency.html=/blog/2019/08/16/microprofile-context-propagation.html
+/blog/2019/09/13/microprofile-reactive-messsaging-19009.html=/blog/2019/09/13/microprofile-reactive-messaging-19009.html


### PR DESCRIPTION
## What was fixed?  (Issue # or description of fix)
The 19.0.0.9 blog post had a typo in the URL OpenLiberty/blogs#131

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
