### PR TITLE
Remove change to change all paragraphs text to 14px and just change t…

### DIFF
--- a/src/main/content/_assets/css/home.scss
+++ b/src/main/content/_assets/css/home.scss
@@ -396,8 +396,8 @@ body {
         border-radius: 30px;
         color: #ffffff;
         background-color: #3F4664;;
-        margin-left: 30px;
-        margin-right: 30px;
+        margin-left: 25px;
+        margin-right: 25px;
         margin-bottom: 0px;
     }
 }

--- a/src/main/content/_assets/css/openliberty.scss
+++ b/src/main/content/_assets/css/openliberty.scss
@@ -53,7 +53,7 @@ h4 {
 /* PARAGRAPHS */
 
 p {
-    font-size: 14px;
+    font-size: 16px;
 }
 
 

--- a/src/main/content/_assets/css/overview.scss
+++ b/src/main/content/_assets/css/overview.scss
@@ -12,6 +12,10 @@
 #overview_content {
     padding: 20px 20px 50px 20px;
 
+    & p{
+        font-size: 14px;
+    }
+
     #overview_title {
         font-family: BunueloLight, Arial Narrow, Helvetica, Arial;
         font-size: 35px;
@@ -50,7 +54,7 @@
     pre>code,
     code {
         font-family: Courier;
-        font-size: 16px;
+        font-size: 14px;
         letter-spacing: 0;
         line-height: 24px;
         border: none;


### PR DESCRIPTION
…he config text size

https://github.com/OpenLiberty/openliberty.io/pull/1296 accidentally changed all paragraph font size on the website to 14px when it should just change the config page.

#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
