### PR TITLE
Fix to allow tags on 3rd party blog posts

### DIFF
--- a/src/main/content/_assets/js/blog.js
+++ b/src/main/content/_assets/js/blog.js
@@ -9,12 +9,16 @@ function getTags(callback) {
                 $('#featured_tags_list').append(featured_tags_html);
             }
             $(".blog_post_title_link").each(function(i, link) {
-                var href = this.getAttribute('href');
-                post_name = href.substring(17).replace('.html', '');
+                if (this.hasAttribute('data-path')) {
+                    var post_name = this.getAttribute('data-path').substring(19).replace(".adoc", "");
+                }
+                else {
+                    var post_name = this.getAttribute('href').substring(17).replace('.html', '');
+                }
                 var tags_html = "";
                 if (tag.posts.indexOf(post_name) > -1) {
                     tags_html = '<p class="blog_tag" onclick="filterPosts(' + "'" + tag_class + "'" + '); updateSearchUrl(' + "'" + tag_class + "'" + ');">' + tag.name + '</p>' + '<span>, </span>';
-
+                    
                     $(".blog_post_content:eq(" + i + ")").addClass(tag_class.toLowerCase());
                     $(".blog_tags_container:eq(" + i + ")").append(tags_html);
                 }

--- a/src/main/content/blog.html
+++ b/src/main/content/blog.html
@@ -74,7 +74,7 @@ permalink: /blog/
                             {% if count <= latest_posts_count %}
                                     <div class="blog_post_content">
                                     {% if post.redirect_link %}
-                                        <h2 class="blog_post_title"><a href="{{ post.redirect_link }}" target="_blank" rel="noopener" class="blog_post_title_link">{{ post.title | escape }}</a>
+                                        <h2 class="blog_post_title"><a href="{{ post.redirect_link }}" data-path="{{ post.path | relative_url }}" target="_blank" rel="noopener" class="blog_post_title_link">{{ post.title | escape }}</a>
                                             <span class="continued_text">
                                                 {% assign continue_text = ' [Continued on ' %}
                                                 {% assign domain_name = post.redirect_link | remove: "https://" | remove: "http://" | remove: "www." | append: "]" %}
@@ -131,7 +131,7 @@ permalink: /blog/
                             {% else %}
                                 <div class="blog_post_content">
                                     {% if post.redirect_link %}
-                                        <h2 class="blog_post_title_condensed"><a href="{{ post.redirect_link }}" target="_blank" rel="noopener" class="blog_post_title_link blog_post_title_link_condensed">{{ post.title | escape }}</a>
+                                        <h2 class="blog_post_title_condensed"><a href="{{ post.redirect_link }}" data-path="{{ post.path | relative_url }}" target="_blank" rel="noopener" class="blog_post_title_link blog_post_title_link_condensed">{{ post.title | escape }}</a>
                                             <span class="continued_text">
                                                 {% assign continue_text = ' [Continued on ' %}
                                                 {% assign domain_name = post.redirect_link | remove: "https://" | remove: "http://" | remove: "www." | append: "]" %}


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
