### PR TITLE
Target blank gem

### DIFF
--- a/gems/ol-target-blank/LICENSE.md
+++ b/gems/ol-target-blank/LICENSE.md
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 Keith Mifsud <mifsud.k@gmail.com> and approved contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/gems/ol-target-blank/lib/ol-target-blank.rb
+++ b/gems/ol-target-blank/lib/ol-target-blank.rb
@@ -1,0 +1,357 @@
+# frozen_string_literal: true
+
+require "jekyll"
+require "nokogiri"
+require "uri"
+
+module Jekyll
+  class TargetBlank
+    BODY_START_TAG         = "<body"
+    OPENING_BODY_TAG_REGEX = %r!<body([^<>]*)>\s*!
+
+    class << self
+      # Public: Processes the content and updated the external links
+      # by adding target="_blank" and rel="noopener noreferrer" attributes.
+      #
+      # content - the document or page to be processes.
+      def process(content)
+        @site_url                              = content.site.config["url"]
+        @config                                = content.site.config
+        @target_blank_config                   = class_config
+        @requires_specified_css_class          = false
+        @required_css_class_name               = nil
+        @should_add_css_classes                = false
+        @css_classes_to_add                    = nil
+        @should_add_noopener                   = true
+        @should_add_noreferrrer                = true
+        @should_add_extra_rel_attribute_values = false
+        @extra_rel_attribute_values            = nil
+
+        return unless content.output.include?("<a")
+
+        initialise
+
+        content.output = if content.output.include? BODY_START_TAG
+                           process_html(content)
+                         else
+                           process_anchor_tags(content.output)
+                         end
+      end
+
+      def print_exception(exception, explicit)
+        puts "[#{explicit ? 'EXPLICIT' : 'INEXPLICIT'}] #{exception.class}: #{exception.message}"
+        puts exception.backtrace.join("\n")
+      end
+
+      # Public: Determines if the document should be processed.
+      #
+      # doc - the document being processed.
+      def document_processable?(doc)
+        begin
+        (doc.is_a?(Jekyll::Page) || doc.write?) &&
+          doc.output_ext == ".html" || (doc.permalink&.end_with?("/"))
+        rescue
+        end
+      end
+
+      private
+
+      def initialise
+        requires_css_class_name
+        configure_adding_additional_css_classes
+        add_default_rel_attributes?
+        add_extra_rel_attributes?
+      end
+
+      # Private: Processes html content which has a body opening tag.
+      #
+      # content - html to be processes.
+      def process_html(content)
+        head, opener, tail  = content.output.partition(OPENING_BODY_TAG_REGEX)
+        body_content, *rest = tail.partition("</body>")
+
+        processed_markup = process_anchor_tags(body_content)
+
+        content.output = String.new(head) << opener << processed_markup << rest.join
+      end
+
+      # Private: Processes the anchor tags and adds the target
+      # attribute if the link is external and depending on the config settings.
+      #
+      # html = the html which includes the anchor tags.
+      def process_anchor_tags(html)
+        content = Nokogiri::HTML::DocumentFragment.parse(html)
+        anchors = content.css("a[href]")
+        anchors.each do |item|
+          if processable_link?(item)
+            add_target_blank_attribute(item)
+            add_rel_attributes(item)
+            add_css_classes_if_required(item)
+          end
+          next
+        end
+        content.to_html
+      end
+
+      # Private: Determines of the link should be processed.
+      #
+      # link = Nokogiri node.
+      def processable_link?(link)
+        if not_mailto_link?(link["href"]) && external?(link["href"])
+          if @requires_specified_css_class
+            return false unless includes_specified_css_class?(link)
+          end
+          true
+        end
+      end
+
+      # Private: Handles adding the target attribute of the config
+      # requires a specifies class.
+      def requires_css_class_name
+        if css_class_name_specified_in_config?
+          @requires_specified_css_class = true
+          @required_css_class_name      = specified_class_name_from_config
+        end
+      end
+
+      # Private: Configures any additional CSS classes
+      # if needed.
+      def configure_adding_additional_css_classes
+        if should_add_css_classes?
+          @should_add_css_classes = true
+          @css_classes_to_add     = css_classes_to_add_from_config.to_s
+        end
+      end
+
+      # Private: Handles the default rel attribute values
+      def add_default_rel_attributes?
+        if should_not_include_noopener?
+          @should_add_noopener = false
+        end
+
+        if should_not_include_noreferrer?
+          @should_add_noreferrrer = false
+        end
+      end
+
+      # Private: Sets any extra rel attribute values
+      # if required.
+      def add_extra_rel_attributes?
+        if should_add_extra_rel_attribute_values?
+          @should_add_extra_rel_attribute_values = true
+          @extra_rel_attribute_values            = extra_rel_attribute_values_to_add
+        end
+      end
+
+      # Private: Checks if the link contains localhost
+      #
+      # link = Nokogiri node.
+      def link_is_internal(link)
+        if link.to_s.include?("localhost")          
+          return true
+        else
+          return false
+        end
+      end
+
+      # Private: adds the cs classes if set in config.
+      #
+      # link = Nokogiri node.
+      def add_css_classes_if_required(link)
+        if @should_add_css_classes and link_is_internal(link)
+          existing_classes = get_existing_css_classes(link)
+          existing_classes = " " + existing_classes unless existing_classes.to_s.empty?
+          link["class"]    = @css_classes_to_add + existing_classes
+        end
+      end
+
+      # Private: Adds a target="_blank" to the link.
+      #
+      # link = Nokogiri node.
+      def add_target_blank_attribute(link)
+        link["target"] = "_blank"
+      end
+
+      # Private: Adds the rel attribute and values to the link.
+      #
+      # link = Nokogiri node.
+      def add_rel_attributes(link)
+        rel = ""
+        if @should_add_noopener
+          rel = "noopener"
+        end
+
+        if @should_add_noreferrrer
+          unless rel.empty?
+            rel += " "
+          end
+          rel += "noreferrer"
+        end
+
+        if @should_add_extra_rel_attribute_values
+          unless rel.empty?
+            rel += " "
+          end
+          rel += @extra_rel_attribute_values
+        end
+
+        unless rel.empty?
+          link["rel"] = rel
+        end
+      end
+
+      # Private: Checks if the link is a mailto url.
+      #
+      # link - a url.
+      def not_mailto_link?(link)
+        true unless link.to_s.start_with?("mailto:")
+      end
+
+      # Private: Checks if the links points to a host
+      # other than that set in Jekyll's configuration.
+      #
+      # link - a url.
+      def external?(link)
+          if link =~ URI.regexp(%w(http https))
+            URI.parse(CGI.escape(link)).host != URI.parse(@site_url).host
+          end        
+      end
+
+      # Private: Checks if a css class name is specified in config
+      def css_class_name_specified_in_config?
+        target_blank_config = @target_blank_config
+        case target_blank_config
+        when nil, NilClass
+          false
+        else
+          target_blank_config.fetch("css_class", false)
+        end
+      end
+
+      # Private: Checks if the link contains the same css class name
+      # as specified in config.
+      #
+      # link - the url under test.
+      def includes_specified_css_class?(link)
+        link_classes = get_existing_css_classes(link)
+        if link_classes
+          link_classes = link_classes.split(" ")
+          contained    = false
+          link_classes.each do |name|
+            contained = true unless name != @required_css_class_name
+          end
+          return contained
+        end
+        false
+      end
+
+      # Private: Gets the the css classes of the link.
+      #
+      # link - an anchor tag.
+      def get_existing_css_classes(link)
+        link["class"].to_s
+      end
+
+      # Private: Checks if the link contains the class attribute.
+      #
+      # link - an anchor tag.
+      def link_has_class_attribute?(link)
+        link.include?("class=")
+      end
+
+      # Private: Fetches the specified css class name
+      # from config.
+      def specified_class_name_from_config
+        target_blank_config = @target_blank_config
+        target_blank_config.fetch("css_class")
+      end
+
+      # Private: Checks if it should add additional CSS classes.
+      def should_add_css_classes?
+        config = @target_blank_config
+        case config
+        when nil, NilClass
+          false
+        else
+          config.fetch("add_css_classes", false)
+        end
+      end
+
+      # Private: Checks if any addional rel attribute values
+      # should be added.
+      def should_add_extra_rel_attribute_values?
+        config = @target_blank_config
+        case config
+        when nil, NilClass
+          false
+        else
+          config.fetch("rel", false)
+        end
+      end
+
+      # Private: Gets any additional rel attribute values
+      # values to add from config.
+      def extra_rel_attribute_values_to_add
+        config = @target_blank_config
+        config.fetch("rel")
+      end
+
+      # Private: Gets the CSS classes to be added to the link from
+      # config.
+      def css_classes_to_add_from_config
+        config = @target_blank_config
+        config.fetch("add_css_classes")
+      end
+
+      # Private: Determines if the noopener rel attribute value should be added
+      # based on the specified config values.
+      #
+      # Returns true if noopener is false in config.
+      def should_not_include_noopener?
+        config = @target_blank_config
+        case config
+        when nil, NilClass
+          false
+        else
+          noopener = config.fetch("noopener", true)
+          if noopener == false
+            return true
+          else
+            return false
+          end
+        end
+      end
+
+      # Private: Determines if the noreferrer rel attribute value should be added
+      # based on the specified config values.
+      #
+      # Returns true if noreferrer is false in config.
+      def should_not_include_noreferrer?
+        config = @target_blank_config
+        case config
+        when nil, NilClass
+          false
+        else
+          noreferrer = config.fetch("noreferrer", true)
+          if noreferrer == false
+            return true
+          else
+            return false
+          end
+        end
+      end
+
+      # Private: Gets the relative config values
+      # if they exist.
+      def class_config
+        @target_blank_config = @config.fetch("target-blank", nil)
+      end
+    end
+  end
+end
+
+# Hooks into Jekyll's post_render event.
+Jekyll::Hooks.register %i[pages documents], :post_render do |doc|
+  puts "In the post render"
+  Jekyll::TargetBlank.process(doc) if Jekyll::TargetBlank.document_processable?(doc)
+end

--- a/gems/ol-target-blank/lib/ol-target-blank.rb
+++ b/gems/ol-target-blank/lib/ol-target-blank.rb
@@ -146,7 +146,7 @@ module Jekyll
       # Private: Checks if the link contains localhost
       #
       # link = Nokogiri node.
-      def link_is_internal(link)
+      def link_is_localhost(link)
         if link.to_s.include?("localhost")          
           return true
         else
@@ -158,7 +158,7 @@ module Jekyll
       #
       # link = Nokogiri node.
       def add_css_classes_if_required(link)
-        if @should_add_css_classes and link_is_internal(link)
+        if @should_add_css_classes and link_is_localhost(link)
           existing_classes = get_existing_css_classes(link)
           existing_classes = " " + existing_classes unless existing_classes.to_s.empty?
           link["class"]    = @css_classes_to_add + existing_classes

--- a/gems/ol-target-blank/lib/ol-target-blank.rb
+++ b/gems/ol-target-blank/lib/ol-target-blank.rb
@@ -352,6 +352,5 @@ end
 
 # Hooks into Jekyll's post_render event.
 Jekyll::Hooks.register %i[pages documents], :post_render do |doc|
-  puts "In the post render"
   Jekyll::TargetBlank.process(doc) if Jekyll::TargetBlank.document_processable?(doc)
 end

--- a/gems/ol-target-blank/lib/ol-target-blank.rb
+++ b/gems/ol-target-blank/lib/ol-target-blank.rb
@@ -50,7 +50,7 @@ module Jekyll
         begin
         (doc.is_a?(Jekyll::Page) || doc.write?) &&
           doc.output_ext == ".html" || (doc.permalink&.end_with?("/"))
-        rescue
+        rescue => error
         end
       end
 
@@ -212,9 +212,12 @@ module Jekyll
       #
       # link - a url.
       def external?(link)
+        begin
           if link =~ URI.regexp(%w(http https))
-            URI.parse(CGI.escape(link)).host != URI.parse(@site_url).host
+            URI.parse(link).host != URI.parse(@site_url).host
           end        
+        rescue => error
+        end
       end
 
       # Private: Checks if a css class name is specified in config

--- a/gems/ol-target-blank/ol-target-blank.gemspec
+++ b/gems/ol-target-blank/ol-target-blank.gemspec
@@ -1,0 +1,23 @@
+Gem::Specification.new do |s|
+  s.name               = 'ol-target-blank'
+  s.version            = '0.0.1'
+  s.date               = '2019-09-24'
+  s.summary            = 'OpenLiberty Asciidoc extensions'
+  s.description        = 'A set of extensions to Asciidoc for OpenLiberty project'
+  s.authors            = ["Steven Zvonek"]
+  s.email              = 'szvonek@us.ibm.com'
+  s.files              = ["lib/ol-target-blank.rb"]
+  s.homepage           = 'https://github.com/OpenLiberty/openliberty.io'
+  s.license = "MIT"
+  s.files = `git ls-files -z`.split("\x0")
+  s.require_paths = ["lib"]
+  s.required_ruby_version = ">= 2.3.0"
+
+  s.add_dependency "jekyll", ">= 3.0", "<5.0"
+  s.add_dependency "nokogiri", "~> 1.10"
+
+  s.add_development_dependency "bundler", "~> 2.0"
+  s.add_development_dependency "rake", "~> 12.0"
+  s.add_development_dependency "rs", "~> 3.0"
+  s.add_development_dependency "rubocop", "0.55" 
+end

--- a/gems/ol-target-blank/ol-target-blank.gemspec
+++ b/gems/ol-target-blank/ol-target-blank.gemspec
@@ -2,8 +2,8 @@ Gem::Specification.new do |s|
   s.name               = 'ol-target-blank'
   s.version            = '0.0.1'
   s.date               = '2019-09-24'
-  s.summary            = 'OpenLiberty Asciidoc extensions'
-  s.description        = 'A set of extensions to Asciidoc for OpenLiberty project'
+  s.summary            = 'OpenLiberty External Link processing'
+  s.description        = 'OpenLiberty Target Blank automatically modifies external links to open in a new browser for the OpenLiberty project and adds a notranslate class to localhost links.'
   s.authors            = ["Steven Zvonek"]
   s.email              = 'szvonek@us.ibm.com'
   s.files              = ["lib/ol-target-blank.rb"]

--- a/scripts/build_jekyll_maven.sh
+++ b/scripts/build_jekyll_maven.sh
@@ -61,6 +61,12 @@ gem build ol-asciidoc.gemspec
 gem install ol-asciidoc-0.0.1.gem
 popd
 
+# Special external link handling
+pushd gems/ol-target-blank
+gem build ol-target-blank.gemspec
+gem install ol-target-blank-0.0.1.gem
+popd
+
 echo "Copying guide images to /img/guide"
 mkdir -p src/main/content/img/guide
 

--- a/src/main/content/_config.yml
+++ b/src/main/content/_config.yml
@@ -20,6 +20,10 @@ asciidoctor:
 
 markdown: kramdown  
 
+# Adds target=_blank, noopener, and noreferrer to all external links
+target-blank: 
+  add_css_classes: "notranslate" # Add notranslate class to localhost links
+
 assets:
   compress:
     css: true
@@ -33,6 +37,8 @@ plugins:
   - jekyll-asciidoc
   - jekyll-assets
   - ol-asciidoc
+  - ol-target-blank
+  # - jekyll-target-blank
   - octopress-minify-html
 exclude:
   - vendor # TravisCI bundles all gems in the vendor directory on its build servers, which Jekyll will mistakenly read and explode on.

--- a/src/main/content/_config.yml
+++ b/src/main/content/_config.yml
@@ -38,7 +38,6 @@ plugins:
   - jekyll-assets
   - ol-asciidoc
   - ol-target-blank
-  # - jekyll-target-blank
   - octopress-minify-html
 exclude:
   - vendor # TravisCI bundles all gems in the vendor directory on its build servers, which Jekyll will mistakenly read and explode on.

--- a/src/main/content/_includes/doc_header.html
+++ b/src/main/content/_includes/doc_header.html
@@ -10,7 +10,7 @@
                     <span class="icon-bar"></span>
                 </button>
                 <a href="/" aria-label="Open Liberty Home Page">
-                    <img id="doc_logo" src="{{ " /img/docs_openliberty_logo.png " | relative }}" class="img-responsive" alt="Home" />
+                    <img id="doc_logo" src="/img/docs_openliberty_logo.png" class="img-responsive" alt="Home" />
                 </a>
                 <div id="doc_title">
                     <img src="{{ "/img/doc_header_title.svg" | relative }}" alt="Docs">
@@ -52,7 +52,7 @@
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
-                        <img src="{{ " /img/toc_close_green.svg " | relative }}" id="header_close_toc_svg" class="hidden img-responsive" alt="Table of contents close button"/>
+                        <img src="/img/toc_close_green.svg" id="header_close_toc_svg" class="hidden img-responsive" alt="Table of contents close button"/>
                     </button>
                 {% endif %}  
 

--- a/src/main/content/_layouts/guide-multipane.html
+++ b/src/main/content/_layouts/guide-multipane.html
@@ -24,10 +24,10 @@ js:
                 {% assign toc = page.document | tocify_asciidoc %}
                 {% if toc %}
                 <div id="close_container">
-                    <img id="toc_close_white" src="{{ " /img/toc_close_white.svg " | relative }}" alt="Close the table of contents" tabindex="0"/>
+                    <img id="toc_close_white" src="/img/toc_close_white.svg" alt="Close the table of contents" tabindex="0"/>
                 </div>
                 <div id="mobile_close_container" data-toggle="collapse" data-target="#toc_column" aria-expanded="false" aria-controls="toc_column">
-                    <img src="{{ " /img/toc_close_green.svg " | relative }}" alt="Table of contents close button" tabindex="0"/>                        
+                    <img src="/img/toc_close_green.svg" alt="Table of contents close button" tabindex="0"/>                        
                 </div>
                 <h3 id="toc_title">Contents</h3>
                 <div id="toc_container">
@@ -77,7 +77,7 @@ js:
                                 <span class="icon-bar"></span>
                                 <span class="icon-bar"></span>
                                 <span class="icon-bar"></span>
-                                <img src="{{ " /img/toc_close_green.svg " | relative }}" class="TOC_Close_SVG hidden img-responsive" alt="Table of contents close button"/>
+                                <img src="/img/toc_close_green.svg" class="TOC_Close_SVG hidden img-responsive" alt="Table of contents close button"/>
                         </button>
                         <span>Table of contents</span>
                     </div>

--- a/src/main/content/_layouts/guide.html
+++ b/src/main/content/_layouts/guide.html
@@ -22,10 +22,10 @@ js:
                 {% assign toc = page.document | tocify_asciidoc %}
                 {% if toc %}
                 <div id="close_container">
-                    <img id="toc_close_white" src="{{ " /img/toc_close_white.svg " | relative }}" alt="Close the table of contents" tabindex="0"/>
+                    <img id="toc_close_white" src="/img/toc_close_white.svg" alt="Close the table of contents" tabindex="0"/>
                 </div>
                 <div id="mobile_close_container" data-toggle="collapse" data-target="#toc_column" aria-expanded="false" aria-controls="toc_column">
-                    <img src="{{ " /img/toc_close_green.svg " | relative }}" alt="Table of contents close button" tabindex="0"/>                        
+                    <img src="/img/toc_close_green.svg" alt="Table of contents close button" tabindex="0"/>                        
                 </div>
                 <h3 id="toc_title">Contents</h3>
                 <div id="toc_container">
@@ -73,7 +73,7 @@ js:
                                 <span class="icon-bar"></span>
                                 <span class="icon-bar"></span>
                                 <span class="icon-bar"></span>
-                                <img src="{{ " /img/toc_close_green.svg " | relative }}" class="hidden img-responsive" alt="Table of contents close button"/>
+                                <img src="/img/toc_close_green.svg" class="hidden img-responsive" alt="Table of contents close button"/>
                         </button>
                         <span>Table of contents</span>
                     </div>

--- a/src/main/content/_layouts/iguide-multipane.html
+++ b/src/main/content/_layouts/iguide-multipane.html
@@ -21,10 +21,10 @@ js:
     <div id="toc_column" class="collapse inline open">
         <div id="toc_inner">
             <div id="close_container">
-                <img id="toc_close_white" src="{{ " /img/toc_close_white.svg " | relative }}" alt="Close the table of contents" tabindex="0"/>
+                <img id="toc_close_white" src="/img/toc_close_white.svg" alt="Close the table of contents" tabindex="0"/>
             </div>
             <div id="mobile_close_container" data-toggle="collapse" data-target="#toc_column" aria-expanded="false" aria-controls="toc_column">
-                <img src="{{ " /img/toc_close_green.svg " | relative }}" alt="Table of contents close button" tabindex="0"/>
+                <img src="/img/toc_close_green.svg" alt="Table of contents close button" tabindex="0"/>
             </div>
             <h3 id="toc_title">Contents</h3>
             <div id="toc_container">
@@ -74,7 +74,7 @@ js:
                             <span class="icon-bar"></span>
                             <span class="icon-bar"></span>
                             <span class="icon-bar"></span>
-                            <img src="{{ " /img/toc_close_green.svg " | relative }}" class="TOC_Close_SVG hidden img-responsive" alt="Table of contents close button"/>
+                            <img src="/img/toc_close_green.svg" class="TOC_Close_SVG hidden img-responsive" alt="Table of contents close button"/>
                     </button>
                     <span>Table of contents</span>
                 </div>

--- a/src/main/content/about.html
+++ b/src/main/content/about.html
@@ -11,7 +11,7 @@ permalink: /about/
     <div id="intro_container_1" class="container">
         <div class="row">
             <div class="col-md-4">
-                <img id="intro_logo" src="{{ "/img/about_page_title.svg" | relative }}" class="img-fluid" alt="About">
+                <img id="intro_logo" src="/img/about_page_title.svg" class="img-fluid" alt="About">
             </div>
             <div class="col-md-8">
                 <h3 id="intro_subtitle_1">The most flexible server runtime in the cosmos is open to Earth's Java<sup>TM</sup> developers.</h3>
@@ -48,7 +48,7 @@ permalink: /about/
     <div id="intro-container_2" class="container">
         <div class="row">
             <div class="col-md-4">
-                <img id="ibm_logo" src="{{ "/img/IBM_logo.svg" | relative }}" class="img-fluid" alt="IBM">
+                <img id="ibm_logo" src="/img/IBM_logo.svg" class="img-fluid" alt="IBM">
             </div>
             <div class="col-md-8">
                 <h2 id="intro_subitle_3">Open Liberty Support</h2>
@@ -92,7 +92,7 @@ permalink: /about/
         <div id="lightspeed_column_1" class="col-lg-6 clearfix">
             <div class="row">
                 <div class="col-4">
-                    <img src="{{ " /img/about1.png " | relative }}" class="img-fluid" alt="chronometer">
+                    <img src="/img/about1.png" class="img-fluid" alt="chronometer">
                 </div>
                 <div class="col-8">
                     <h3 class="lightspeed_fast_title">Fast to start</h3>
@@ -105,7 +105,7 @@ permalink: /about/
         <div class="col-lg-6 clearfix">
             <div class="row">
                 <div class="col-4">
-                    <img src="{{ " /img/about2.png " | relative }}" class="img-fluid" alt="Update">
+                    <img src="/img/about2.png" class="img-fluid" alt="Update">
                 </div>
                 <div class="col-8">
                     <h3 class="lightspeed_fast_title">Dynamic update capabilities</h3>
@@ -152,7 +152,7 @@ permalink: /about/
             </p>
         </div>
         <div class="col-md-6">
-            <img src="{{ " /img/about3.jpg " | relative }}" class="img-fluid d-block mx-auto" alt="Tools">
+            <img src="/img/about3.jpg" class="img-fluid d-block mx-auto" alt="Tools">
         </div>
     </div>
 </div>

--- a/src/main/content/community.html
+++ b/src/main/content/community.html
@@ -10,7 +10,7 @@ permalink: /community/
     <div class="container">
         <div class="row">
             <div class="col-md-5">
-                <img id="intro_logo" src="{{ " /img/community_page_title.svg " | relative }}" class="img-fluid" alt="Commmunity">
+                <img id="intro_logo" src="/img/community_page_title.svg" class="img-fluid" alt="Commmunity">
             </div>
             <div class="col-md-7">
                 <p id="commmunity_intro_paragraph_1">


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
This adds a gem that will add target="_blank" as well as the noreferrer and noopener attributes to external links automatically during build time for us.
The gem is extended to also add class "notranslate" to localhost links so that they don't get translated when users use the built in browser translation feature.

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
