### PR TITLE
Support other OS tabs in guides

### DIFF
--- a/src/main/content/_assets/css/guide.scss
+++ b/src/main/content/_assets/css/guide.scss
@@ -327,7 +327,7 @@ header {
     }
 }
 
-#guide_content .windows_link > p, #guide_content .mac_link > p, #guide_content .linux_link > p {
+#guide_content .tab_link > p {
     padding-top: 0px;
     padding-bottom: 0px;
 

--- a/src/main/content/_assets/js/guide.js
+++ b/src/main/content/_assets/js/guide.js
@@ -157,25 +157,30 @@
         var sections = $('.sectionbody:has(.tab_content)');
         for(var i = 0; i < sections.length; i++){
             var section = $(sections.get(i));
-            if(!OSName){
-                // Show the first tab's contents for every set of tabs in this section.
-                var first_tab = section.find('.tab_link').first();
-                // Find OS name to show all of its tab contents in this section.
-                var class_list = first_tab[0].classList;
-                for (var j = 0; j < class_list.length; j++) {
-                    var class_name = class_list[j];
-                    if (class_name !== "tab_link" && class_name.indexOf("_link") > -1) {
-                        var tab_class = "." + class_name;
-                        var tab_content_class = "." + class_name.replace("link", "section");
-                        section.find(tab_class).addClass("active");
-                        section.find(tab_content_class).show();
-                        break;
-                    }
-                }
+            // Check if the current OS tab exists in the section
+            if(OSName){
+                var content = section.find("." + OSName + "_section");
+                var tab = section.find("." + OSName + "_link");
+                if(content.length > 0 && (content.length === tab.length)){
+                    content.show();                
+                    tab.addClass("active");
+                    continue;
+                }                
             }
-            else {
-                section.find("." + OSName + "_section").show();
-                section.find("." + OSName + "_link").addClass("active");
+            // If the current Operating System's tab has not been found
+            // show the first tab's contents for every set of tabs in this section.
+            var first_tab = section.find('.tab_link').first();
+            // Find OS name to show all of its tab contents in this section.
+            var class_list = first_tab[0].classList;
+            for (var j = 0; j < class_list.length; j++) {
+                var class_name = class_list[j];
+                if (class_name !== "tab_link" && class_name.indexOf("_link") > -1) {
+                    var tab_class = "." + class_name;
+                    var tab_content_class = "." + class_name.replace("link", "section");
+                    section.find(tab_class).addClass("active");
+                    section.find(tab_content_class).show();
+                    break;
+                }
             }
         }
     }

--- a/src/main/content/_assets/js/guide.js
+++ b/src/main/content/_assets/js/guide.js
@@ -145,7 +145,7 @@
             OSName = "windows";
         }
         if (ua.indexOf("mac") != -1) {
-            // OSName = "mac";
+            OSName = "mac";
         }
         if (ua.indexOf("linux") != -1) {
             OSName = "linux";
@@ -158,11 +158,20 @@
         for(var i = 0; i < sections.length; i++){
             var section = $(sections.get(i));
             if(!OSName){
-                // Show the first tab's contents
-                var first_tab = section.find('.tab_content').first();
-                first_tab.show();
-                var first_link = section.find('.tab_link').first();
-                first_link.addClass("active");
+                // Show the first tab's contents for every set of tabs in this section.
+                var first_tab = section.find('.tab_link').first();
+                // Find OS name to show all of its tab contents in this section.
+                var class_list = first_tab[0].classList;
+                for (var j = 0; j < class_list.length; j++) {
+                    var class_name = class_list[j];
+                    if (class_name !== "tab_link" && class_name.indexOf("_link") > -1) {
+                        var tab_class = "." + class_name;
+                        var tab_content_class = "." + class_name.replace("link", "section");
+                        section.find(tab_class).addClass("active");
+                        section.find(tab_content_class).show();
+                        break;
+                    }
+                }
             }
             else {
                 section.find("." + OSName + "_section").show();

--- a/src/main/content/_assets/js/guide.js
+++ b/src/main/content/_assets/js/guide.js
@@ -161,7 +161,7 @@
             if(OSName){
                 var content = section.find("." + OSName + "_section");
                 var tab = section.find("." + OSName + "_link");
-                if(content.length > 0 && (content.length === tab.length)){
+                if(content.length > 0 && tab.length > 0){
                     content.show();                
                     tab.addClass("active");
                     continue;

--- a/src/main/content/_assets/js/guide.js
+++ b/src/main/content/_assets/js/guide.js
@@ -138,25 +138,37 @@
 
     // determine user's operating system and show prerequisite instructions for that OS
     function setDefaultTab() {
-        // set default OS to windows
-        var OSName = "windows";
-        // get user's operating system
+        var OSName = "";
+        // Detect user's operating system
         var ua = navigator.userAgent.toLowerCase();
         if (ua.indexOf("win") != -1) {
             OSName = "windows";
         }
         if (ua.indexOf("mac") != -1) {
-            OSName = "mac";
+            // OSName = "mac";
         }
         if (ua.indexOf("linux") != -1) {
             OSName = "linux";
         }
         // hide tab content except for selected tab and add active class to selected tab
-        var os_section = "." + OSName + "_section";
-        var os_class = "." + OSName + "_link";
         $(".tab_content").hide();
-        $(os_section).show();
-        $(os_class).addClass("active");
+
+        // For each of the groups of tab contents, show the first one unless an OS is detected
+        var sections = $('.sectionbody:has(.tab_content)');
+        for(var i = 0; i < sections.length; i++){
+            var section = $(sections.get(i));
+            if(!OSName){
+                // Show the first tab's contents
+                var first_tab = section.find('.tab_content').first();
+                first_tab.show();
+                var first_link = section.find('.tab_link').first();
+                first_link.addClass("active");
+            }
+            else {
+                section.find("." + OSName + "_section").show();
+                section.find("." + OSName + "_link").addClass("active");
+            }
+        }
     }
 
     $(window).on('scroll', function(event) {


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
The code will show the tabs if it detects a user is on Windows, Mac, or Linux. The default is moving from showing Windows to showing the FIRST tab in each section. 
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
