### PR TITLE
Fix bootstrap popover issue in guides search bar

### DIFF
--- a/src/main/content/_assets/js/guides.js
+++ b/src/main/content/_assets/js/guides.js
@@ -254,6 +254,7 @@ $(document).ready(function() {
 
     // Create popover when search bar is focused
     $('#guide_search_input').popover({
+        sanitize: false,
         container: '#guides_search_container',
         delay: {
             show: '520'


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
