### PR TITLE
Set bundler version to 2.0.2 after an implicit upgrade broke the build

### DIFF
--- a/scripts/build_gem_dependencies.sh
+++ b/scripts/build_gem_dependencies.sh
@@ -1,4 +1,5 @@
 echo "Installing ruby packages..."
 gem install jekyll -v 3.8.6
-gem install bundler jekyll-feed jekyll-asciidoc coderay uglifier octopress-minify-html octokit
+gem install bundler -v 2.0.2 # Upgrading to 2.1.0 breaks the build
+gem install jekyll-feed jekyll-asciidoc coderay uglifier octopress-minify-html octokit
 gem install jekyll-assets -v 2.4.0


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
We installed the latest bundler version. Yesterday we used 2.0.2 and a new version was released of 2.1.0 which broke our website build.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
