### PR TITLE
1507 Another attempt to get the RFC822 format for dates on atom feed

### DIFF
--- a/src/main/content/jakartaee.xml
+++ b/src/main/content/jakartaee.xml
@@ -9,7 +9,7 @@ permalink: /jakartaee.xml
     <description>{{ site.description | xml_escape }}</description>
     <link>{{ site.url }}{{ site.baseurl }}/</link>
     <atom:link href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml"/>
-    {% assign date_format = site.minima.date_format | default: "%-d %b %y" %}
+    {% assign date_format = site.minima.date_format | default: date_to_rfc822 %}
     <pubDate>{{ site.time | date: date_format }}</pubDate>    
     <lastBuildDate>{{ site.time | date: date_format }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>


### PR DESCRIPTION
The template format has built in RFC822 date formatting. Attempting to
make use of that rather than define it ourselves

#### What was fixed?  (Issue # or description of fix)
#1507 

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
