### PR TITLE
Add ol-target-blank gem to the Dockerfile and remove extra git command in the gem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,11 @@ RUN pushd gems/ol-asciidoc \
     && gem build ol-asciidoc.gemspec \
     && gem install ol-asciidoc-0.0.1.gem \
     && popd
+    
+RUN pushd gems/ol-target-blank \
+    && gem build ol-target-blank.gemspec \
+    && gem install ol-target-blank-0.0.1.gem \
+    && popd
 
 # Serve the site
 ENTRYPOINT ["bash", "./scripts/jekyll_serve_dev.sh"]

--- a/gems/ol-target-blank/ol-target-blank.gemspec
+++ b/gems/ol-target-blank/ol-target-blank.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |s|
   s.files              = ["lib/ol-target-blank.rb"]
   s.homepage           = 'https://github.com/OpenLiberty/openliberty.io'
   s.license = "MIT"
-  s.files = `git ls-files -z`.split("\x0")
   s.require_paths = ["lib"]
   s.required_ruby_version = ">= 2.3.0"
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
