### PR TITLE
DAP accessibility updates for the Guides page.

### DIFF
--- a/src/main/content/_assets/css/guide-card.css
+++ b/src/main/content/_assets/css/guide-card.css
@@ -65,7 +65,7 @@
 }
 
 .guide_interactive_container, .new_guide_container {
-    border: 1px solid #F69144;
+    border: 1px solid #CC4D19;
     border-radius: 100px;
     float: right;
     padding: 0px 5px;
@@ -87,7 +87,7 @@
 .guide_interactive{
     font-family: BunueloBold, Arial Narrow, Helvetica, Arial;
     font-size: 13px;
-    color: #DC6B00;
+    color: #CC4D19;
     letter-spacing: 0;
     text-transform: uppercase;
 }

--- a/src/main/content/docs.html
+++ b/src/main/content/docs.html
@@ -48,23 +48,23 @@ permalink: /docs/
 
                 <div class="row">
                     <div class="col-sm-6">
-                        <a href="/docs/ref/config/" class="reference_item" aria-label="Open Liberty configuration documentation">
-                            <h3 class="reference_title">Server config</h3>
+                        <a href="/docs/ref/config/" class="reference_item" aria-label="Open Liberty server configuration documentation">
+                            <h3 class="reference_title">Server configuration</h3>
                         </a> 
                     </div>
                     <div class="col-sm-6">
-                        <a href="/docs/ref/feature/" class="reference_item" aria-label="Open Liberty feature documentation">
+                        <a href="/docs/ref/feature/" class="reference_item" aria-label="Open Liberty server features documentation">
                             <h3 class="reference_title">Server features</h3>
                         </a>
                     </div>
                     <div class="w-100"></div>
                     <div class="col-sm-6">
-                        <a href="/docs/ref/command/" class="reference_item" aria-label="Open Liberty command documentation">
+                        <a href="/docs/ref/command/" class="reference_item" aria-label="Open Liberty server commands documentation">
                             <h3 class="reference_title">Server commands</h3>
                         </a>   
                     </div>
                     <div class="col-sm-6">
-                        <a href="/docs/ref/javaee/" class="reference_item" aria-label="Java Enterprise Edition API documentation">
+                        <a href="/docs/ref/javaee/" class="reference_item" aria-label="Java EE API documentation">
                             <h3 class="reference_title">Java EE API</h3>
                         </a>
                     </div>
@@ -75,7 +75,7 @@ permalink: /docs/
                         </a>  
                     </div>
                     <div class="col-sm-6">
-                        <a href="/docs/ref/general/" class="reference_item" aria-label="General documentation">
+                        <a href="/docs/ref/general/" class="reference_item" aria-label="General reference documentation">
                             <h3 class="reference_title">General Reference</h3>
                         </a>
                     </div>

--- a/src/main/content/img/guide_lightning_bolt.svg
+++ b/src/main/content/img/guide_lightning_bolt.svg
@@ -1,1 +1,1 @@
-<svg width="8" height="15" xmlns="http://www.w3.org/2000/svg"><path d="M6.125 0L0 8.949h3.828L2.038 15l5.959-8.411H4.491z" fill="#DC6B00" fill-rule="evenodd"/></svg>
+<svg width="8" height="15" xmlns="http://www.w3.org/2000/svg"><path d="M6.125 0L0 8.949h3.828L2.038 15l5.959-8.411H4.491z" fill="#CC4D19" fill-rule="evenodd"/></svg>


### PR DESCRIPTION
#### What was fixed?  Accessibility updates for the Guides Page.  See #1521.

The color of the Interactive guide indicator/link needed to be made darker.  

![image](https://user-images.githubusercontent.com/29490139/72940910-5f521f80-3d35-11ea-910c-018f83ed4164.png)

I changed it to the darker color used in the link 
![image](https://user-images.githubusercontent.com/29490139/72940940-70029580-3d35-11ea-907d-60457c25cbca.png)

![image](https://user-images.githubusercontent.com/29490139/72940977-7e50b180-3d35-11ea-91bd-f55f492f8bce.png)


#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [x] Dymanic Accessability Plugin (DAP)
