### PR TITLE
Remove asciidoctor icons setting

### DIFF
--- a/src/main/content/_assets/css/openliberty.scss
+++ b/src/main/content/_assets/css/openliberty.scss
@@ -92,6 +92,13 @@ div.sectionbody > div.enableByList > ul > li > p {
     color: #5D6A8E;
 }
 
+/* Admonitionblock */
+.icon {
+    & .title {
+        color: #24243B;
+    }
+}
+
 
 /* LINKS */
 

--- a/src/main/content/_config.yml
+++ b/src/main/content/_config.yml
@@ -11,7 +11,6 @@ asciidoctor:
   base_dir: :docdir
   safe: 0
   attributes:
-    - icons=font
     - source-highlighter=coderay
     - coderay-linenums-mode=inline
     - coderay-linenums=true


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Removed the asciidoctor `icons=font` settings that was converting the callout list into a table. I verified that removing this property only changed one other piece of text in a general ref doc where we can style the text as black to match what it was before.

Fixed callout list:
![image](https://user-images.githubusercontent.com/6392944/74669583-11320f80-516d-11ea-88f7-46a66d85885b.png)

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
