### PR TITLE
Style asiidoc callouts to make them look more like a list

### DIFF
--- a/src/main/content/_assets/css/coderay-custom.css
+++ b/src/main/content/_assets/css/coderay-custom.css
@@ -18,6 +18,15 @@ code {
   color: #5e6b8d;
 }
 
+code > b {   /* Callouts should not be copyable when copying the code to the clipboard */
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
 code a {     /* Anchor tags in code blocks need to be slightly darker since the 
                 code block background is a bit greyish */
   color: #2d6da3 

--- a/src/main/content/_assets/css/openliberty.scss
+++ b/src/main/content/_assets/css/openliberty.scss
@@ -648,10 +648,14 @@ footer {
     & tr {
         padding: 13px 0;
         & td:first-child {
-            width: 20px;
-            &:after{
-                /* Add a period to the number of each row */
-                content: ".";
+            width: 30px;
+            &:before {
+                /* Add parenthesis before the number of each row */
+                content: "(";
+            }  
+            &:after {
+                /* Add parenthesis after the number of each row */
+                content: ")";
             }            
         }
     }

--- a/src/main/content/_assets/css/openliberty.scss
+++ b/src/main/content/_assets/css/openliberty.scss
@@ -630,3 +630,30 @@ footer {
 .halign-right {
     text-align: right;
 }
+
+/* Callouts */
+.colist.arabic {
+    padding-left: 5px;
+
+    & table, & caption, & tbody, & tfoot, & thead, & tr, & th, & td {
+        margin: 0;
+        padding: 0;
+        border: 0;
+        outline: 0;
+        font-size: 100%;
+        vertical-align: baseline;
+        background: transparent;
+        box-shadow: none;
+    }
+    & tr {
+        padding: 13px 0;
+        & td:first-child {
+            width: 20px;
+            &:after{
+                /* Add a period to the number of each row */
+                content: ".";
+                margin-right: -5px;
+            }            
+        }
+    }
+}

--- a/src/main/content/_assets/css/openliberty.scss
+++ b/src/main/content/_assets/css/openliberty.scss
@@ -652,7 +652,6 @@ footer {
             &:after{
                 /* Add a period to the number of each row */
                 content: ".";
-                margin-right: -5px;
             }            
         }
     }


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Add styling for Asciidoctor callouts because when they're converted to html they look like a table instead of a list.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
