### PR TITLE
Update openliberty.scss

### DIFF
--- a/src/main/content/_assets/css/openliberty.scss
+++ b/src/main/content/_assets/css/openliberty.scss
@@ -642,6 +642,7 @@ footer {
         outline: 0;
         font-size: 100%;
         vertical-align: baseline;
+        text-align: left;
         background: transparent;
         box-shadow: none;
     }


### PR DESCRIPTION
We need to align the text in the callout list to the left. In features, the text was centered in the middle of the page: https://draft-openlibertyio.mybluemix.net/docs/ref/feature/#spnego-1.0.html.

#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
