### PR TITLE
1018 force init of the build data on startup rather than 1st request

### DIFF
--- a/src/main/java/io/openliberty/website/ContainerInit.java
+++ b/src/main/java/io/openliberty/website/ContainerInit.java
@@ -3,7 +3,11 @@ package io.openliberty.website;
 import java.io.IOException;
 import java.util.Set;
 
+import javax.enterprise.inject.spi.CDI;
 import javax.servlet.ServletContext;
+
+import io.openliberty.website.dheclient.DHEBuildParser;
+
 import javax.servlet.ServletContainerInitializer;
 
 public class ContainerInit implements ServletContainerInitializer {
@@ -13,5 +17,10 @@ public class ContainerInit implements ServletContainerInitializer {
     } catch (IOException e) {
       e.printStackTrace();
     }
+
+    // By initializing the DHE Build Parser and calling scheduleAsyncUpdate
+    // we start building the build list from external data sources at startup
+    // rather than on first request.
+    CDI.current().select(DHEBuildParser.class).get().scheduleAsyncUpdate();
   }
 }

--- a/src/main/java/io/openliberty/website/dheclient/DHEBuildParser.java
+++ b/src/main/java/io/openliberty/website/dheclient/DHEBuildParser.java
@@ -135,7 +135,7 @@ public class DHEBuildParser {
 	 * should NOT schedule a new job. The first job's Future should be returned to
 	 * the second thread.
 	 */
-	private synchronized Future<LastUpdate> scheduleAsyncUpdate() {
+	public synchronized Future<LastUpdate> scheduleAsyncUpdate() {
 		if (scheduledUpdate == null) {
 			scheduledUpdate = exec.submit(new UpdateBuildData());
 		}

--- a/website-api.yml
+++ b/website-api.yml
@@ -1,0 +1,115 @@
+openapi: '3.0.2'
+info:
+  title: Open Liberty Website API
+  version: '1.0'
+servers:
+  - url: https://openliberty.io/api/
+components:
+  schemas:
+    update: 
+      type: object
+      properties:
+        last_update_attempt:
+          type: string
+        last_successful_update:
+          type: string
+    latestReleases:
+      type: object
+      properties: 
+        runtime:
+          $ref: "#/components/schemas/build"
+        tools:
+          $ref: "#/components/schemas/build"
+    build:
+      type: object
+      properties:
+        version:
+          type: "string"
+        date_time:
+          type: "string"
+        driver_location:
+          type: "string"
+        size_in_bytes:
+          type: "string"
+          description: "Why isn't this an int?"
+        total_tests:
+          type: "string"
+          description: "Why isn't this an int?"
+        test_passed:
+          type: "string"
+          description: "Why isn't this an int?"
+        build_log:
+          type: "string"
+        tests_log:
+          type: "string"
+        package_locations:
+          type: array
+          items:
+            type: string
+          description: "This is an array of strings whose values are name=value, this should totally be an object"
+paths:
+  /builds:
+    get:
+      responses:
+        '200':
+          description: "The timestamp for the last attempt to update the builds, and the last successful run"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/update"
+    put:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/update"
+  /builds/data:
+    get:
+      responses: 
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                properties:
+                  latest_releases:
+                    $ref: "#/components/schemas/latestReleases"
+                  builds:
+                    type: object
+                    properties:
+                      runtime_releases:
+                        type: array
+                        items: 
+                          $ref: "#/components/schemas/build"
+                      runtime_nightly_builds:
+                        type: array
+                        items:  
+                          $ref: "#/components/schemas/build"
+                      tools_releases:
+                        type: array
+                        items:  
+                          $ref: "#/components/schemas/build"
+                      tools_nightly_builds:
+                        type: array
+                        items:  
+                          $ref: "#/components/schemas/build"
+  /builds/latest:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/latestReleases"
+  /github/issues:
+    get:
+      responses:
+        '200':
+          description: "Returns the top 30 github issues using the format defined by GitHub. This is really just a pass through."
+          content:
+            application/json:
+              schema:
+                type: array


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Fixes issue #1018

Currently build data is loaded on first request, this can be an issue because the first person to request builds gets nothing. Instead propose a change to run the update when the servletcontainerinitializer is called. It runs inline and on my machine it takes around 6s. This means it will be inited during deployment and not first request.

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
