### PR TITLE
Update scripts to use 2.6 of build pipeline

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,16 +2,14 @@
 #
 #
 sudo apt-get update
-sudo apt-get install libgdbm-dev libncurses5-dev automake libtool bison libffi-dev -y
-sudo apt-get install python3-bs4 -y
+sudo apt-get install nodejs python3-bs4 libgdbm-dev libncurses5-dev automake libtool bison libffi-dev -y
 
 gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 curl -sSL https://get.rvm.io | bash -s stable
-source /home/pipeline/.rvm/scripts/rvm
+source /usr/local/rvm/scripts/rvm
 rvm requirements
 rvm install 2.4.1
 rvm use 2.4.1 --default
-sudo apt-get -y install nodejs
 
 # Print out default locale and change it to en_US.UTF-8
 echo "Default locale:"

--- a/scripts/build_gem_dependencies.sh
+++ b/scripts/build_gem_dependencies.sh
@@ -2,4 +2,4 @@ echo "Installing ruby packages..."
 gem install jekyll -v 3.8.6
 gem install bundler jekyll-feed jekyll-asciidoc coderay uglifier octopress-minify-html octokit
 gem install jekyll-assets -v 2.4.0
-gem uninstall -i /home/pipeline/.rvm/gems/ruby-2.4.1@global rubygems-bundler
+gem uninstall -i /usr/local/rvm/gems/ruby-2.4.1@global rubygems-bundler


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
The current website build runs on v1.0 of the build. The latest version is 2.6 and the docker image docker.io/ibmcom/pipeline-base-image:2.6 is used. Updating our build scripts so they work using the latest version. The advantage of this is it'll upgrade the build JVM to Java SE 8 so we can start making use of Jakarta EE and MicroProfile APIs.

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
