### PR TITLE
Switch to MP 3.3 javadoc as default MP Javadoc

### DIFF
--- a/src/main/webapp/WEB-INF/redirects.properties
+++ b/src/main/webapp/WEB-INF/redirects.properties
@@ -8,7 +8,7 @@
 
 /index.html/=/index.html
 /docs/ref/javaee/=/docs/ref/javaee/8/
-/docs/ref/microprofile/=/docs/ref/microprofile/3.2/
+/docs/ref/microprofile/=/docs/ref/microprofile/3.3/
 /docs/ref/=/docs/
 /docs/intro/=/docs/
 /docs/intro/microprofile.html=/docs/ref/general/#microprofile.html


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Now Liberty supports MicroProfile 3.3 we need to default to the Javadoc for that rather than an older version so updated the redirect.

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
