### PR TITLE
Add back support for loading size_in_bytes

### DIFF
--- a/src/main/java/io/openliberty/website/data/BuildInfo.java
+++ b/src/main/java/io/openliberty/website/data/BuildInfo.java
@@ -24,11 +24,6 @@ import io.openliberty.website.Constants;
  * returning directly from the Open Liberty REST API. Not all fields are mandatory. The DHE usage of this
  * has all locations relative, but from the Open Liberty REST API they are all absolute.
  * 
- * <p>At this time the size_in_bytes field is present, but does not appear used. The package_locations may not
- * be present. If present this is a list of alternative package locations. The format of this differs between
- * the DHE version of this and the Open Liberty REST API version. In DHE each entry is a simple file name, in
- * the Open Liberty REST API each entry in the array is a name = url format.</p>
- * 
  * <p>This can be used as a key in Map, if it is not set then a NPE will occur. The resolveLocations method is 
  * the primary method used prior to using this in this way, this is because the equals/hashcode uses dateTime
  * field for identity.</p>

--- a/src/main/java/io/openliberty/website/dheclient/DHEBuildParser.java
+++ b/src/main/java/io/openliberty/website/dheclient/DHEBuildParser.java
@@ -200,6 +200,8 @@ public class DHEBuildParser {
 			for (String version : versions) {
 				BuildInfo info = store.getBuildInfo(type, version);
 
+				info.sizeInBytes = store.getFileSize(type, version, info.driverLocation);
+
 				add(type, version, info);
 			}
 		}

--- a/src/test/java/io/openliberty/website/mock/EmptyVersionsBuildStore.java
+++ b/src/test/java/io/openliberty/website/mock/EmptyVersionsBuildStore.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package io.openliberty.website.mock;
 
+import javax.ws.rs.core.Response;
+
 import io.openliberty.website.data.BuildInfo;
 import io.openliberty.website.dheclient.BuildStore;
 import io.openliberty.website.dheclient.data.BuildListInfo;
@@ -22,6 +24,11 @@ public class EmptyVersionsBuildStore implements BuildStore {
 
     @Override
     public BuildInfo getBuildInfo(String downloadType, String buildType, String version) {
+        return null;
+    }
+
+    @Override
+    public Response getFileData(String downloadType, String buildType, String version, String fileName) {
         return null;
     }
     

--- a/src/test/java/io/openliberty/website/mock/MockBuildStore.java
+++ b/src/test/java/io/openliberty/website/mock/MockBuildStore.java
@@ -12,8 +12,11 @@ package io.openliberty.website.mock;
 
 import java.util.Arrays;
 
+import javax.ws.rs.core.Response;
+
 import io.openliberty.website.Constants;
 import io.openliberty.website.data.BuildInfo;
+import io.openliberty.website.data.BuildType;
 import io.openliberty.website.dheclient.BuildStore;
 import io.openliberty.website.dheclient.data.BuildListInfo;
 
@@ -21,19 +24,19 @@ public class MockBuildStore implements BuildStore {
 
     @Override
     public BuildListInfo getBuildListInfo(String downloadType, String buildType) {
-        BuildListInfo result = new BuildListInfo(); 
+        BuildListInfo result = new BuildListInfo();
         if (Constants.RUNTIME.equals(downloadType)) {
             if (Constants.DHE_RELEASE_PATH_SEGMENT.equals(buildType)) {
-                result.versions.addAll(Arrays.asList("2020-01-08_0300","2020-02-04_1746","2020-03-05_1433"));
+                result.versions.addAll(Arrays.asList("2020-01-08_0300", "2020-02-04_1746", "2020-03-05_1433"));
             } else {
-                result.versions.addAll(Arrays.asList("2020-04-01_1714","2020-04-01_1739","2020-04-01_1900"));
+                result.versions.addAll(Arrays.asList("2020-04-01_1714", "2020-04-01_1739", "2020-04-01_1900"));
             }
         } else if (Constants.TOOLS.equals(downloadType)) {
             if (Constants.DHE_RELEASE_PATH_SEGMENT.equals(buildType)) {
                 result.versions.addAll(Arrays.asList("2019-09-12_1520", "2019-12-13_0905", "2020-03-09_0937"));
             } else {
-                
-                result.versions.addAll(Arrays.asList("2020-03-27_0905","2020-03-29_0905","2020-03-30_0918"));
+
+                result.versions.addAll(Arrays.asList("2020-03-27_0905", "2020-03-29_0905", "2020-03-30_0918"));
             }
         }
         return result;
@@ -43,17 +46,26 @@ public class MockBuildStore implements BuildStore {
     public BuildInfo getBuildInfo(String downloadType, String buildType, String version) {
         switch (version) {
             case "2020-01-08_0300":
-                return new BuildInfo("gradle.log", "openliberty-20.0.0.1.zip", 12503, 12503, "open-liberty.unitTest.results.zip", "20.0.0.1", "openliberty-javaee8-20.0.0.1.zip", "openliberty-webProfile8-20.0.0.1.zip","openliberty-microProfile3-20.0.0.1.zip");
+                return new BuildInfo("gradle.log", "openliberty-20.0.0.1.zip", 12503, 12503,
+                        "open-liberty.unitTest.results.zip", "20.0.0.1", "openliberty-javaee8-20.0.0.1.zip",
+                        "openliberty-webProfile8-20.0.0.1.zip", "openliberty-microProfile3-20.0.0.1.zip");
             case "2020-02-04_1746":
-                return new BuildInfo("gradle.log", "openliberty-20.0.0.2.zip", 12480, 12480, "open-liberty.unitTest.results.zip", "20.0.0.2", "openliberty-javaee8-20.0.0.2.zip", "openliberty-webProfile8-20.0.0.2.zip","openliberty-microProfile3-20.0.0.2.zip");
+                return new BuildInfo("gradle.log", "openliberty-20.0.0.2.zip", 12480, 12480,
+                        "open-liberty.unitTest.results.zip", "20.0.0.2", "openliberty-javaee8-20.0.0.2.zip",
+                        "openliberty-webProfile8-20.0.0.2.zip", "openliberty-microProfile3-20.0.0.2.zip");
             case "2020-03-05_1433":
-                return new BuildInfo("gradle.log", "openliberty-20.0.0.3.zip", 12976, 12976, "open-liberty.unitTest.results.zip", "20.0.0.3", "openliberty-javaee8-20.0.0.3.zip", "openliberty-webProfile8-20.0.0.3.zip","openliberty-microProfile3-20.0.0.3.zip");
+                return new BuildInfo("gradle.log", "openliberty-20.0.0.3.zip", 12976, 12976,
+                        "open-liberty.unitTest.results.zip", "20.0.0.3", "openliberty-javaee8-20.0.0.3.zip",
+                        "openliberty-webProfile8-20.0.0.3.zip", "openliberty-microProfile3-20.0.0.3.zip");
             case "2020-04-01_1714":
-                return new BuildInfo("gradle.log", "openliberty-all-20.0.0.4-cl200420200401-1714.zip", 13051, 13051, "open-liberty.unitTest.results.zip", "20.0.0.4-202004011949");
+                return new BuildInfo("gradle.log", "openliberty-all-20.0.0.4-cl200420200401-1714.zip", 13051, 13051,
+                        "open-liberty.unitTest.results.zip", "20.0.0.4-202004011949");
             case "2020-04-01_1739":
-                return new BuildInfo("gradle.log", "openliberty-all-20.0.0.4-cl200420200401-1739.zip", 13051, 13051, "open-liberty.unitTest.results.zip", "20.0.0.4-202004012010");
+                return new BuildInfo("gradle.log", "openliberty-all-20.0.0.4-cl200420200401-1739.zip", 13051, 13051,
+                        "open-liberty.unitTest.results.zip", "20.0.0.4-202004012010");
             case "2020-04-01_1900":
-                return new BuildInfo("gradle.log", "openliberty-all-20.0.0.4-cl200420200401-1900.zip", 13051, 13051, "open-liberty.unitTest.results.zip", "20.0.0.4-202004012136");
+                return new BuildInfo("gradle.log", "openliberty-all-20.0.0.4-cl200420200401-1900.zip", 13051, 13051,
+                        "open-liberty.unitTest.results.zip", "20.0.0.4-202004012136");
             case "2019-09-12_1520":
                 return new BuildInfo("openlibertytools-19.0.0.9.zip", "19.0.0.9");
             case "2019-12-13_0905":
@@ -61,13 +73,24 @@ public class MockBuildStore implements BuildStore {
             case "2020-03-09_0937":
                 return new BuildInfo("openlibertytools-20.0.0.3.zip", "20.0.0.3");
             case "2020-03-27_0905":
-                return new BuildInfo("build.log", "openlibertytools-20.0.0.6.v2020-03-27_0905.zip", 122, 122, "test_results.html");
+                return new BuildInfo("build.log", "openlibertytools-20.0.0.6.v2020-03-27_0905.zip", 122, 122,
+                        "test_results.html");
             case "2020-03-29_0905":
-               return new BuildInfo("build.log", "openlibertytools-20.0.0.6.v2020-03-29_0905.zip", 122, 122, "test_results.html");
+                return new BuildInfo("build.log", "openlibertytools-20.0.0.6.v2020-03-29_0905.zip", 122, 122,
+                        "test_results.html");
             case "2020-03-30_0918":
-                return new BuildInfo("build.log", "openlibertytools-20.0.0.6.v2020-03-30_0918.zip", 122, 122, "test_results.html");
+                return new BuildInfo("build.log", "openlibertytools-20.0.0.6.v2020-03-30_0918.zip", 122, 122,
+                        "test_results.html");
         }
         return null;
     }
+
+    @Override
+    public Response getFileData(String downloadType, String buildType, String version, String fileName) {
+        return null;
+    }
     
+    public int getFileSize(BuildType type, String version, String fileName) {
+        return 0;
+    }
 }

--- a/src/test/java/io/openliberty/website/mock/NullBuildStore.java
+++ b/src/test/java/io/openliberty/website/mock/NullBuildStore.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package io.openliberty.website.mock;
 
+import javax.ws.rs.core.Response;
+
 import io.openliberty.website.data.BuildInfo;
 import io.openliberty.website.dheclient.BuildStore;
 import io.openliberty.website.dheclient.data.BuildListInfo;
@@ -23,6 +25,11 @@ public class NullBuildStore implements BuildStore {
 
     @Override
     public BuildInfo getBuildInfo(String downloadType, String buildType, String version) {
+        return null;
+    }
+
+    @Override
+    public Response getFileData(String downloadType, String buildType, String version, String fileName) {
         return null;
     }
     


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
PR #1604 accidentally stopped providing the file size in bytes  so adding this back in.

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
