### PR TITLE
Decrease the padding between list items in guides

### DIFF
--- a/src/main/content/_assets/css/guide.scss
+++ b/src/main/content/_assets/css/guide.scss
@@ -96,13 +96,19 @@ header {
     margin-bottom: 0px;
 }
 
-#guide_content p {
-    font-size: 14px;
-    line-height: 24px;
-    padding-top: 15px;
-    padding-bottom: 15px;
-    margin-top: 0px;
-    margin-bottom: 0px;
+#guide_content {
+    & p {
+        font-size: 14px;
+        line-height: 24px;
+        padding-top: 15px;
+        padding-bottom: 15px;
+        margin-top: 0px;
+        margin-bottom: 0px;
+    }
+    & .olist p {
+        padding-top: 4px;
+        padding-bottom: 4px;
+    }
 }
 
 #guide_content .system {


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Decrease the spacing in lists in guides.The problem is on the yk-review branch of https://github.com/OpenLiberty/draft-guide-social-login in the LinkedIn section of the draft guide.

As you can see the spacing was really bad:
![image](https://user-images.githubusercontent.com/6392944/80503442-79ecf380-8937-11ea-9c89-c4da76a7620d.png)

Here is it fixed:
![image](https://user-images.githubusercontent.com/6392944/80503212-2da1b380-8937-11ea-9a41-8d578acaac8c.png)

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
