### PR TITLE
Add the target/jekyll-webapp back to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,12 @@
 					<configuration>
 						<failOnMissingWebXml>false</failOnMissingWebXml>
 						<warName>openliberty</warName>
+						<webResources>
+							<resource>
+								<!-- this is relative to the pom.xml directory -->
+								<directory>target/jekyll-webapp</directory>
+							</resource>
+						</webResources>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
The directory was accidentally removed in a previous PR.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
