### PR TITLE
Set toc height to match height of doc content (fixes #1643)

### DIFF
--- a/src/main/content/_assets/js/general-references.js
+++ b/src/main/content/_assets/js/general-references.js
@@ -72,6 +72,10 @@ function setupDisplayContent() {
     }, 400);
 }
 
+function setTOCHeight() {
+    $('#toc_inner').height($('footer').offset().top - $('#toc_inner').offset().top);
+}
+
 // This function
 // - highlight the selected TOC 
 // - load the doc for the selected TOC
@@ -99,7 +103,8 @@ function loadContent(targetTOC, tocHref, addHash) {
             }
 
             $(this).trigger('focus'); // switch focus to the content for the reader
-
+            
+            setTOCHeight();
         }
     });
 }
@@ -316,5 +321,5 @@ $(document).ready(function () {
 
 // Change height of toc if footer is in view so that fixed toc isn't visible through footer
 $(document).on('scroll', function() {
-    $('#toc_inner').height($('footer').offset().top - $('#toc_inner').offset().top);
+    setTOCHeight();
 });


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
