### PR TITLE
Add jekyll-include-cache plugin to improve jekyll build time by 10%

### DIFF
--- a/scripts/build_gem_dependencies.sh
+++ b/scripts/build_gem_dependencies.sh
@@ -1,5 +1,5 @@
 echo "Installing ruby packages..."
 gem install jekyll -v 3.8.6
-gem install bundler jekyll-feed jekyll-asciidoc coderay uglifier octopress-minify-html octokit
+gem install bundler jekyll-feed jekyll-asciidoc jekyll-include-cache coderay uglifier octopress-minify-html octokit
 gem install jekyll-assets -v 2.4.0
 gem uninstall -i /usr/local/rvm/gems/ruby-2.4.1@global rubygems-bundler

--- a/src/main/content/_config.yml
+++ b/src/main/content/_config.yml
@@ -36,6 +36,7 @@ plugins:
   - jekyll-feed
   - jekyll-asciidoc
   - jekyll-assets
+  - jekyll-include-cache
   - ol-asciidoc
   - ol-target-blank
   - octopress-minify-html

--- a/src/main/content/_includes/analytics.html
+++ b/src/main/content/_includes/analytics.html
@@ -1,3 +1,3 @@
 {% if jekyll.environment == 'production' and site.google_tag_manager %}
-    {% include google_tag_manager_body.html %}
+    {% include_cached google_tag_manager_body.html %}
 {% endif %}

--- a/src/main/content/_includes/head.html
+++ b/src/main/content/_includes/head.html
@@ -35,7 +35,7 @@
   {% endfor %}
 
   {% if jekyll.environment == 'production' and site.google_tag_manager %}
-    {% include google_tag_manager_head.html %}
+    {% include_cached google_tag_manager_head.html %}
   {% endif %}
 
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
@@ -51,7 +51,7 @@
   <meta name="google-site-verification" content="h2P030H9b66CyL1nEmWfrZB8Fr14h9LmVMG7Ur0caBs" />
 
   {% if jekyll.environment != 'production' %}
-      {% include noindex.html %}
+      {% include_cached noindex.html %}
   {% endif %}
 
   <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/src/main/content/_layouts/default.html
+++ b/src/main/content/_layouts/default.html
@@ -12,9 +12,9 @@ js:
 
   <body>
     
-    {% include analytics.html %}
+    {% include_cached analytics.html %}
 
-    {% include header.html %}
+    {% include_cached header.html %}
 
     <main aria-label="Content">
 
@@ -22,7 +22,7 @@ js:
 
     </main>
 
-    {% include footer.html %}
+    {% include_cached footer.html %}
 
     {% include javascript.html %}
 

--- a/src/main/content/_layouts/doc.html
+++ b/src/main/content/_layouts/doc.html
@@ -15,7 +15,7 @@
 
     </main>
 
-    {% include footer.html %}
+    {% include_cached footer.html %}
 
     {% include javascript.html %}
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
This plugin caches certain liquid includes so liquid doesn't have to process the same html multiple times during the jekyll build. Common files included like the header and footer are loaded so many times that caching it makes sense if they are not page specific.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
