### PR TITLE
Add table styling to blogs

### DIFF
--- a/src/main/content/_assets/css/post.scss
+++ b/src/main/content/_assets/css/post.scss
@@ -372,9 +372,11 @@ footer {
 table {
     margin-top: 30px;
     margin-bottom: 54px;
-    margin-left: -20px;
-    box-shadow: 0 4px #D6D9E4;
     width: calc(100% + 20px); 
+}
+
+table, th, td {
+    border: 1px solid #D6D9E4;
 }
   
 table.subsection {

--- a/src/main/content/_assets/css/post.scss
+++ b/src/main/content/_assets/css/post.scss
@@ -367,3 +367,67 @@ footer {
         width: 100%;
     }
 }
+
+// Table Styling
+table {
+    margin-top: 30px;
+    margin-bottom: 54px;
+    margin-left: -20px;
+    box-shadow: 0 4px #D6D9E4;
+    width: calc(100% + 20px); 
+}
+  
+table.subsection {
+margin-left: 59px; }
+
+th {
+background: #D6D9E4;
+line-height: 26px;
+font-family: BunueloBold, Arial Narrow, Helvetica, Arial;
+font-size: 11px;
+color: #24243B;
+padding-left: 14px;
+text-transform: uppercase;
+border-right: 1px solid rgba(93, 106, 142, 0.3); }
+
+th:first-child, td:first-child {
+padding-left: 18px; }
+
+td:first-child {
+color: #5D6A8E;
+font-weight: 500; }
+
+td {
+font-size: 14px;
+color: #24243B;
+letter-spacing: 0;
+line-height: 26px;
+padding: 10px 31px 10px 14px;
+border-right: 1px solid rgba(93, 106, 142, 0.3);
+vertical-align: top; }
+
+
+#article_body td p {
+margin: 0;
+line-height: inherit;
+font-size: 14px; }
+
+tr {
+border-bottom: 1px solid rgba(93, 106, 142, 0.3); }
+
+tr:last-child {
+border-bottom: none; }
+
+tr:nth-child(even) {
+background: #EEEFF3; }
+
+tr:nth-child(odd) {
+background: #FFFFFF; }
+
+tableblock {
+min-width: 100px; }
+
+#article_container table code, #article_container table pre {
+    background-color: inherit;
+    color: inherit;
+}


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Fixes #1684 
Style the table here: https://draft-openlibertyio.mybluemix.net/blog/2020/06/05/graphql-open-liberty-20006.html
with what we have in docs like: https://openliberty.io/docs/ref/config/#application.html

Result:
![image](https://user-images.githubusercontent.com/6392944/83791564-8dd6f400-a65f-11ea-9477-c1d2f2b97c2b.png)

#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [x] Dymanic Accessability Plugin (DAP)
