### PR TITLE
Remove coderay react regex highlighting

### DIFF
--- a/src/main/content/_assets/css/coderay-custom.css
+++ b/src/main/content/_assets/css/coderay-custom.css
@@ -129,10 +129,6 @@ table.CodeRay td { padding: 2px 4px; vertical-align: top; }
 .CodeRay .predefined-type { color:#566D17; font-weight:500 }
 .CodeRay .preprocessor { color:#517394 }
 .CodeRay .pseudo-class { color:#00C; font-weight:500 }
-.CodeRay .regexp { background-color:hsla(300,100%,50%,0.06); }
-.CodeRay .regexp .content { color:#808 }
-.CodeRay .regexp .delimiter { color:#404 }
-.CodeRay .regexp .modifier { color:#C2C }
 .CodeRay .reserved { color:#080; font-weight:500 }
 .CodeRay .shell { background-color:hsla(120,100%,50%,0.06); }
 .CodeRay .shell .content { color:#2B2 }


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Fixes #1687 
Remove awkward pink highlighting from a draft guide
The css is unused in other code blocks on the site
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
