### PR TITLE
Make suggested tag buttons work on windows touchpad click (closes #1471)

### DIFF
--- a/src/main/content/_assets/js/guides.js
+++ b/src/main/content/_assets/js/guides.js
@@ -787,7 +787,7 @@ $(document).ready(function() {
     });
 
     // Click buttons to fill search bar
-    $('#guides_search_container').on('click', '.tag_button', function() {
+    $('#guides_search_container').on('click focus', '.tag_button', function() {
         var inputValue = 'tag: ' + $(this).html();
         $('#guide_search_input').val(inputValue);
         $('.tag_button').removeClass('hidden');


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
