### PR TITLE
Shorten version picker, the space above doc title, and mobile feature…

### DIFF
--- a/src/main/content/antora_ui/src/css/doc.css
+++ b/src/main/content/antora_ui/src/css/doc.css
@@ -42,6 +42,11 @@
   font-size: 35px;
   color: #24233C;
   letter-spacing: 0;
+  overflow-x: auto;
+
+  @media screen and (min-width: 767.98px) {
+    margin-top: 0;
+  }
 }
 
 #preamble + .sect1,

--- a/src/main/content/antora_ui/src/sass/nav.scss
+++ b/src/main/content/antora_ui/src/sass/nav.scss
@@ -277,7 +277,7 @@ html.is-clipped--nav {
 
 .nav-panel-explore .context {
   height: 32px;
-  width: 148px;
+  width: 130px;
   font-size: 11px;
   line-height: 11px;
   flex-shrink: 0;

--- a/src/main/content/antora_ui/src/sass/nav.scss
+++ b/src/main/content/antora_ui/src/sass/nav.scss
@@ -277,7 +277,7 @@ html.is-clipped--nav {
 
 .nav-panel-explore .context {
   height: 32px;
-  width: 130px;
+  width: 108px;
   font-size: 11px;
   line-height: 11px;
   flex-shrink: 0;


### PR DESCRIPTION
… verison scroll

#### What was fixed?  (Issue # or description of fix)
Shorten the version picker since there's no chevron right now.
Reduce space above the doc title in desktop view/ tablet view
Add side scroll to features version list if there's not enough space
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
