### PR TITLE
Restore version picker to 148px

### DIFF
--- a/src/main/content/antora_ui/src/sass/nav.scss
+++ b/src/main/content/antora_ui/src/sass/nav.scss
@@ -277,7 +277,7 @@ html.is-clipped--nav {
 
 .nav-panel-explore .context {
   height: 32px;
-  width: 108px;
+  width: 148px;
   font-size: 11px;
   line-height: 11px;
   flex-shrink: 0;


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
