### PR TITLE
Remove the search label next to the search box in some javadoc versions

### DIFF
--- a/src/main/content/antora_ui/src/sass/javadoc-extended-stylesheet.scss
+++ b/src/main/content/antora_ui/src/sass/javadoc-extended-stylesheet.scss
@@ -138,7 +138,7 @@ ul.navListSearch {
     margin: 5px 14px 0 0;
 }
 
-ul.navListSearch li span {
+ul.navListSearch li label, ul.navListSearch li span {
     display: none;
 }
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Newer versions of javadoc have a search label next to the search box: https://openliberty.io/docs/20.0.0.8/reference/javadoc/microprofile-3.2-javadoc.html
Older ones don't have it:
https://openliberty.io/docs/20.0.0.8/reference/javadoc/microprofile-2.2-javadoc.html

This will unify them.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
