### PR TITLE
Make the docs toc match guides toc height

### DIFF
--- a/src/main/content/antora_ui/src/sass/nav.scss
+++ b/src/main/content/antora_ui/src/sass/nav.scss
@@ -143,7 +143,6 @@ html.is-clipped--nav {
     font-size: 14px;
     color: #313653;
     letter-spacing: 0.2px;
-    line-height: 26px;
     border-bottom: 2px solid #d4d7e3;
     padding-left: var(--TOC-indention-first-level);
 
@@ -166,7 +165,6 @@ html.is-clipped--nav {
 .nav-item {
   list-style: none;
   color: #5D6A8E;
-  line-height: 26px;
 
   & > a, & > span {
     padding-top: 5px;
@@ -190,14 +188,14 @@ html.is-clipped--nav {
     background: transparent url(../img/chevron.svg) no-repeat center / 50%;
     transform: rotate(270deg);
     border: none;
-    outline: none;
-    line-height: inherit;    
+    outline: none;  
     height: var(--TOC-toggle-icon-size);
     width: var(--TOC-toggle-icon-size);
     margin-left: -23px;
     margin-top: -3px;
   }
   & > span, & > a {
+    display: inline-block;
     &:hover{
       color: #f4914d;
       cursor: pointer;


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
