### PR TITLE
Remove noindex robots meta tag from the antora_ui

### DIFF
--- a/src/main/content/antora_ui/src/partials/head-meta.hbs
+++ b/src/main/content/antora_ui/src/partials/head-meta.hbs
@@ -1,5 +1,4 @@
 {{!-- Add additional meta tags here --}}
-<meta name="robots" content="noindex">
 
 {{#if page.attributes.seo-description }} 
 <meta name="description" content="{{page.attributes.seo-description}}">


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Removed noindex meta tag from the docs which shouldn't be there.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
