### PR TITLE
Change the redirectFilter.java to handle pre-Antora doc urls

### DIFF
--- a/src/main/content/_assets/js/antora-redirect.js
+++ b/src/main/content/_assets/js/antora-redirect.js
@@ -1,4 +1,15 @@
-$(document).ready(function(){
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+ 
+ $(document).ready(function(){
     var href = window.location.href;
     var path = window.location.pathname;
     var hash = window.location.hash;

--- a/src/main/content/antora_ui/package-lock.json
+++ b/src/main/content/antora_ui/package-lock.json
@@ -7422,9 +7422,9 @@
       }
     },
     "js-base64": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.3.tgz",
-      "integrity": "sha512-fiUvdfCaAXoQTHdKMgTvg6IkecXDcVz6V5rlftUTclF9IKBjMizvSdQaCl/z/6TApDeby5NL+axYou3i0mu1Pg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
+      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
       "dev": true
     },
     "js-tokens": {

--- a/src/main/java/io/openliberty/website/RedirectFilter.java
+++ b/src/main/java/io/openliberty/website/RedirectFilter.java
@@ -61,18 +61,21 @@ public class RedirectFilter implements Filter {
         // url, it won't be a direct from and to.
         if (startsWithMatch) {
             String uri = ((HttpServletRequest)req).getRequestURI();
-            newURL = uri.replaceAll(from, to);
-            // It is possible that the filter intercepted, but the redirect rule does not apply
-            // in that case we set newURL to null so no redirect is sent and the filter chain is called.
-            if (newURL.equals(uri)) {
-                newURL = null;
-            }
+            // Do not redirect if the uri doesn't contain anything more than the 'from' redirect rule during a wildcard match.
+            if (!uri.endsWith(from)) {
+                newURL = uri.replaceAll(from, to);
+                // It is possible that the filter intercepted, but the redirect rule does not apply
+                // in that case we set newURL to null so no redirect is sent and the filter chain is called.
+                if (newURL.equals(uri)) {
+                    newURL = null;
+                }
+            } 
         } else {
             newURL = to;
         }
 
         if (newURL != null) {
-            // if there is a newURL send a redirect wiht that new url
+            // if there is a newURL send a redirect with that new url
             newURL = req.getScheme() + "://" + req.getServerName() + sPort + newURL;
             ((HttpServletResponse)resp).sendRedirect(newURL);
         } else {

--- a/src/main/webapp/WEB-INF/redirects.properties
+++ b/src/main/webapp/WEB-INF/redirects.properties
@@ -19,6 +19,7 @@
 
 # Blogs redirects. NOTE: These will move to the blogs repo in the future for customization by the blogs team.
 /news/=/blog/
+/news=/blog/
 /news/*=/blog/
 /blog/2017/11/29/liberty-spring-boot.html=/guides/spring-boot.html
 /blog/2019/03/01/microprofile-concurrency.html=/blog/2019/08/16/microprofile-context-propagation.html

--- a/src/main/webapp/WEB-INF/redirects.properties
+++ b/src/main/webapp/WEB-INF/redirects.properties
@@ -12,30 +12,51 @@
 /community/=/support/
 /community=/support/
 
-# Blogs
+# Blogs redirects. NOTE: These will move to the blogs repo in the future for customization by the blogs team.
+/news/=/blog/
 /news/*=/blog/
 /blog/2017/11/29/liberty-spring-boot.html=/guides/spring-boot.html
 /blog/2019/03/01/microprofile-concurrency.html=/blog/2019/08/16/microprofile-context-propagation.html
 /blog/2019/05/24/testing-database-connections-REST-APIs.html=/blog/2019/09/13/testing-database-connections-REST-APIs.html
 /blog/2019/09/13/microprofile-reactive-messsaging-19009.html=/blog/2019/09/13/microprofile-reactive-messaging-19009.html
 
-# Docs
+# Docs redirects. NOTE: These will move to the docs repo in the future for customization by the docs team.
 /config/rwlp_config_*=/docs/ref/config/#
+/config/=/docs/ref/config/
 /config/*=/docs/ref/config/#
+
+# Redirects for a file name change to feature-overview.html
+/docs/ref/feature/featureOverview.html=/docs/latest/feature/feature-overview.html
+/docs/20.0.0.7/reference/feature/featureOverview.html=/docs/20.0.0.7/reference/feature/feature-overview.html
+/docs/20.0.0.8/reference/feature/featureOverview.html=/docs/20.0.0.8/reference/feature/feature-overview.html
+
+# Redirects for a file name change to server-configuration-overview.html
+/docs/ref/config/serverConfiguration.html=/docs/latest/config/server-configuration-overview.html
+/docs/20.0.0.7/reference/config/serverConfiguration.html=/docs/20.0.0.7/reference/config/server-configuration-overview.html
+/docs/20.0.0.8/reference/config/serverConfiguration.html=/docs/20.0.0.8/reference/config/server-configuration-overview.html
+
+# Redirect the docs link in the header to the latest version
 /docs/=/docs/latest/
+
+# Redirect 'latest' docs to the latest doc version. Latest is used in the URL by the Doc macros at https://github.com/OpenLiberty/docs/blob/vNext/lib/ol-asciidoc.js. Latest is also used in links to always link to the most recent doc version even when new versions are released.
 /docs/latest/*=/docs/20.0.0.8/
+/docs/latest/=/docs/20.0.0.8/
+
+# Redirect the pre-Antora docs URLS to the new URL format post-Antora
+/docs/ref/general/*=/docs/latest/reference/
+/docs/ref/config/*=/docs/latest/reference/config/
+/docs/ref/command/*=/docs/latest/reference/command/
+/docs/ref/feature/*=/docs/latest/reference/feature/
+
+# Doc redirects that existed pre-Antora
 /docs/intro/=/docs/
 /docs/intro/microprofile.html=/docs/ref/general/#microprofile.html
 /docs/ref/=/docs/
 /docs/ref/javaee/=/docs/ref/javaee/8/
 /docs/ref/microprofile/=/docs/ref/microprofile/3.3/
 /javadocs/*=/docs/ref/javadocs/
-/docs/ref/feature/featureOverview.html=/docs/latest/feature/feature-overview.html
-/docs/20.0.0.7/reference/feature/featureOverview.html=/docs/20.0.0.7/reference/feature/feature-overview.html
-/docs/20.0.0.8/reference/feature/featureOverview.html=/docs/20.0.0.8/reference/feature/feature-overview.html
-/docs/ref/config/serverConfiguration.html=/docs/latest/config/server-configuration-overview.html
-/docs/20.0.0.7/reference/config/serverConfiguration.html=/docs/20.0.0.7/reference/config/server-configuration-overview.html
-/docs/20.0.0.8/reference/config/serverConfiguration.html=/docs/20.0.0.8/reference/config/server-configuration-overview.html
+
+# End of Docs redirects
 
 # Guides
 /guides/microprofile-intro.html=/guides/cdi-intro.html

--- a/src/main/webapp/WEB-INF/redirects.properties
+++ b/src/main/webapp/WEB-INF/redirects.properties
@@ -6,6 +6,11 @@
 # value. Unlike servlet url patterns a * can be at the end of a string without
 # a preceeding / However this should be done sparingly since it is more expensive.
 
+# If the pattern ends with [URI]* but the incoming request is for just [URI],
+# e.g. there's nothing for the * wildcard to match, then the redirect is not applied.  
+# For example, if /a/*=/b/ and the incoming request is for "/a/" it will not be redirect to "/b/"
+# (for that to happen, /a/=/b/ will also need to be included in the redirect list.
+
 /index.html/=/index.html
 /about/=/
 /about=/
@@ -43,6 +48,9 @@
 /docs/latest/=/docs/20.0.0.8/
 
 # Redirect the pre-Antora docs URLS to the new URL format post-Antora
+# Note that we are purposefully not redirecting these four URL patterns if they just end with "/" 
+# (e.g. nothing for the wildcard to match) because that's handled client-side in order 
+# to redirect our old hash based URLs via JS in antora-redirect.js
 /docs/ref/general/*=/docs/latest/reference/
 /docs/ref/config/*=/docs/latest/reference/config/
 /docs/ref/command/*=/docs/latest/reference/command/

--- a/src/main/webapp/WEB-INF/redirects.properties
+++ b/src/main/webapp/WEB-INF/redirects.properties
@@ -25,12 +25,12 @@
 /config/=/docs/ref/config/
 /config/*=/docs/ref/config/#
 
-# Redirects for a file name change to feature-overview.html
+# Redirects for a file name change to feature-overview.html. 20.0.0.8 was the latest version with the old file name.
 /docs/ref/feature/featureOverview.html=/docs/latest/feature/feature-overview.html
 /docs/20.0.0.7/reference/feature/featureOverview.html=/docs/20.0.0.7/reference/feature/feature-overview.html
 /docs/20.0.0.8/reference/feature/featureOverview.html=/docs/20.0.0.8/reference/feature/feature-overview.html
 
-# Redirects for a file name change to server-configuration-overview.html
+# Redirects for a file name change to server-configuration-overview.html. 20.0.0.8 was the latest version with the old file name.
 /docs/ref/config/serverConfiguration.html=/docs/latest/config/server-configuration-overview.html
 /docs/20.0.0.7/reference/config/serverConfiguration.html=/docs/20.0.0.7/reference/config/server-configuration-overview.html
 /docs/20.0.0.8/reference/config/serverConfiguration.html=/docs/20.0.0.8/reference/config/server-configuration-overview.html

--- a/src/main/webapp/WEB-INF/redirects.properties
+++ b/src/main/webapp/WEB-INF/redirects.properties
@@ -28,6 +28,7 @@
 # Docs redirects. NOTE: These will move to the docs repo in the future for customization by the docs team.
 /config/rwlp_config_*=/docs/ref/config/#
 /config/=/docs/ref/config/
+/config=/docs/ref/config/
 /config/*=/docs/ref/config/#
 
 # Redirects for a file name change to feature-overview.html. 20.0.0.8 was the latest version with the old file name.
@@ -46,12 +47,13 @@
 # Redirect 'latest' docs to the latest doc version. Latest is used in the URL by the Doc macros at https://github.com/OpenLiberty/docs/blob/vNext/lib/ol-asciidoc.js. Latest is also used in links to always link to the most recent doc version even when new versions are released.
 /docs/latest/*=/docs/20.0.0.8/
 /docs/latest/=/docs/20.0.0.8/
+/docs/latest=/docs/20.0.0.8/
 
 # Redirect the pre-Antora docs URLS to the new URL format post-Antora
 # Note that we are purposefully not redirecting these four URL patterns if they just end with "/" 
 # (e.g. nothing for the wildcard to match) because that's handled client-side in order 
 # to redirect our old hash based URLs via JS in antora-redirect.js
-/docs/ref/general/*=/docs/latest/reference/
+/docs/ref/general/*=/docs/latest/
 /docs/ref/config/*=/docs/latest/reference/config/
 /docs/ref/command/*=/docs/latest/reference/command/
 /docs/ref/feature/*=/docs/latest/reference/feature/


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Change the redirect filter to not redirect uris that end with the rule if they are a wildcard redirect;
Clean up the doc redirects and add comments;
Add server side redirects from pre-Antora urls to post-Antora latest urls
#### Were the changes tested on
demo1 site
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
