### PR TITLE
Vertically align the first level doc categories

### DIFF
--- a/src/main/content/antora_ui/src/sass/nav.scss
+++ b/src/main/content/antora_ui/src/sass/nav.scss
@@ -159,6 +159,11 @@ html.is-clipped--nav {
     & .nav-item {
       list-style: none;
     }
+
+    & > a, & > span {
+      padding-top: 5px;
+      padding-bottom: 3px;
+    }
   }
 }
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
