### PR TITLE
Add noindex meta tag to non prod sites doc pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ jobs:
 
 script: >
     if [ $JEKYLL_ENV == "production" ]; then
-      cp robots.txt src/main/content/robots.txt      
+      cp robots.txt src/main/content/robots.txt
+      cp src/main/content/_includes/noindex.html src/main/content/antora_ui/src/partials/noindex.hbs      
       ./scripts/build_jekyll_maven.sh
     else
       ./scripts/build_jekyll_maven.sh

--- a/scripts/build_jekyll_maven.sh
+++ b/scripts/build_jekyll_maven.sh
@@ -24,6 +24,7 @@ if [ "$JEKYLL_ENV" != "production" ]; then
     echo "Not in production environment..."
     echo "Adding robots.txt"
     cp robots.txt src/main/content/robots.txt
+    cp src/main/content/_includes/noindex.html src/main/content/antora_ui/src/partials/noindex.hbs
 
     # Development environments with draft docs/guides
     if [ "$JEKYLL_DRAFT_GUIDES" == "true" ]; then

--- a/src/main/content/antora_ui/src/partials/head-meta.hbs
+++ b/src/main/content/antora_ui/src/partials/head-meta.hbs
@@ -1,5 +1,7 @@
 {{!-- Add additional meta tags here --}}
 
+{{> noindex}}
+
 {{#if page.attributes.seo-description }} 
 <meta name="description" content="{{page.attributes.seo-description}}">
 {{else if page.attributes.description }}


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Copy over the noindex.html into the Antora partials so it can be included during the doc build. The Antora partials will start with an empty noindex file so the include is resolved even when it's the production site.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
