### PR TITLE
Upgrade bootstrap to 3.4.1 in docs

### DIFF
--- a/src/main/content/antora_ui/src/partials/head-scripts.hbs
+++ b/src/main/content/antora_ui/src/partials/head-scripts.hbs
@@ -3,4 +3,4 @@
     {{/if}}
     <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.10/highlight.min.js"></script>
     <script src="https://code.jquery.com/jquery-3.0.0.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>

--- a/src/main/content/antora_ui/src/partials/head-styles.hbs
+++ b/src/main/content/antora_ui/src/partials/head-styles.hbs
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
 <link href="https://fonts.googleapis.com/css?family=Asap:400,500" rel="stylesheet">
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.10/styles/default.min.css">
 <link rel="stylesheet" href="{{uiRootPath}}/css/site.css">


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
This matches what we have in jekyll pages and 3.3.7 is vulnerable.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
