### PR TITLE
Javadoc redirects from pre-Antora

### DIFF
--- a/src/main/content/_assets/js/antora-redirect.js
+++ b/src/main/content/_assets/js/antora-redirect.js
@@ -42,15 +42,5 @@
             }
         }
         window.location.replace(window.location.origin + '/docs/latest/reference/' + resource_type + '/' + page + hash);
-    } else if(path.indexOf('/docs/ref/javaee/') > -1){
-       // Remove /docs/ref/javaee/ and the version
-       var version_path = path.substring(17);
-       var version = version_path.substring(0, version_path.indexOf('/'));
-        window.location.replace(window.location.origin + '/docs/latest/reference/javadoc/liberty-javaee' + version + '-javadoc.html' + hash);
-    } else if(path.indexOf('/docs/ref/microprofile/') > -1) {
-        // Remove /docs/ref/microprofile and the version
-       var version_path = path.substring(23);
-       var version = version_path.substring(0, version_path.indexOf('/'));
-        window.location.replace(window.location.origin + '/docs/latest/reference/javadoc/microprofile-' + version + '-javadoc.html' + hash);
     }
 });

--- a/src/main/content/antora_redirects/redirect_javaee_7.html
+++ b/src/main/content/antora_redirects/redirect_javaee_7.html
@@ -1,8 +1,0 @@
----
-layout: default
-title: Javadoc
-js: antora-redirect
-css: header-dark
-permalink: /docs/ref/javaee/7/
----
-<span>Redirecting...</span>

--- a/src/main/content/antora_redirects/redirect_javaee_8.html
+++ b/src/main/content/antora_redirects/redirect_javaee_8.html
@@ -1,8 +1,0 @@
----
-layout: default
-title: Javadoc
-js: antora-redirect
-css: header-dark
-permalink: /docs/ref/javaee/8/
----
-<span>Redirecting...</span>

--- a/src/main/content/antora_redirects/redirect_microprofile_1.2.html
+++ b/src/main/content/antora_redirects/redirect_microprofile_1.2.html
@@ -1,8 +1,0 @@
----
-layout: default
-title: Javadoc
-js: antora-redirect
-css: header-dark
-permalink: /docs/ref/microprofile/1.2/
----
-<span>Redirecting...</span>

--- a/src/main/content/antora_redirects/redirect_microprofile_1.3.html
+++ b/src/main/content/antora_redirects/redirect_microprofile_1.3.html
@@ -1,8 +1,0 @@
----
-layout: default
-title: Javadoc
-js: antora-redirect
-css: header-dark
-permalink: /docs/ref/microprofile/1.3/
----
-<span>Redirecting...</span>

--- a/src/main/content/antora_redirects/redirect_microprofile_1.4.html
+++ b/src/main/content/antora_redirects/redirect_microprofile_1.4.html
@@ -1,8 +1,0 @@
----
-layout: default
-title: Javadoc
-js: antora-redirect
-css: header-dark
-permalink: /docs/ref/microprofile/1.4/
----
-<span>Redirecting...</span>

--- a/src/main/content/antora_redirects/redirect_microprofile_2.0.html
+++ b/src/main/content/antora_redirects/redirect_microprofile_2.0.html
@@ -1,8 +1,0 @@
----
-layout: default
-title: Javadoc
-js: antora-redirect
-css: header-dark
-permalink: /docs/ref/microprofile/2.0/
----
-<span>Redirecting...</span>

--- a/src/main/content/antora_redirects/redirect_microprofile_2.1.html
+++ b/src/main/content/antora_redirects/redirect_microprofile_2.1.html
@@ -1,8 +1,0 @@
----
-layout: default
-title: Javadoc
-js: antora-redirect
-css: header-dark
-permalink: /docs/ref/microprofile/2.1/
----
-<span>Redirecting...</span>

--- a/src/main/content/antora_redirects/redirect_microprofile_2.2.html
+++ b/src/main/content/antora_redirects/redirect_microprofile_2.2.html
@@ -1,8 +1,0 @@
----
-layout: default
-title: Javadoc
-js: antora-redirect
-css: header-dark
-permalink: /docs/ref/microprofile/2.2/
----
-<span>Redirecting...</span>

--- a/src/main/content/antora_redirects/redirect_microprofile_3.0.html
+++ b/src/main/content/antora_redirects/redirect_microprofile_3.0.html
@@ -1,8 +1,0 @@
----
-layout: default
-title: Javadoc
-js: antora-redirect
-css: header-dark
-permalink: /docs/ref/microprofile/3.0/
----
-<span>Redirecting...</span>

--- a/src/main/content/antora_redirects/redirect_microprofile_3.2.html
+++ b/src/main/content/antora_redirects/redirect_microprofile_3.2.html
@@ -1,8 +1,0 @@
----
-layout: default
-title: Javadoc
-js: antora-redirect
-css: header-dark
-permalink: /docs/ref/microprofile/3.2/
----
-<span>Redirecting...</span>

--- a/src/main/content/antora_redirects/redirect_microprofile_3.3.html
+++ b/src/main/content/antora_redirects/redirect_microprofile_3.3.html
@@ -1,8 +1,0 @@
----
-layout: default
-title: Javadoc
-js: antora-redirect
-css: header-dark
-permalink: /docs/ref/microprofile/3.3/
----
-<span>Redirecting...</span>

--- a/src/main/webapp/WEB-INF/redirects.properties
+++ b/src/main/webapp/WEB-INF/redirects.properties
@@ -59,7 +59,7 @@
 /docs/ref/command/*=/docs/latest/reference/command/
 /docs/ref/feature/*=/docs/latest/reference/feature/
 
-# Javadocs
+# Javadocs pre-Antora to post-Antora
 /docs/ref/javaee/7/=/docs/latest/reference/javadoc/liberty-javaee7-javadoc.html
 /docs/ref/javaee/7/*=/docs/latest/reference/javadoc/liberty-javaee7-javadoc.html
 /docs/ref/javaee/8/=/docs/latest/reference/javadoc/liberty-javaee8-javadoc.html

--- a/src/main/webapp/WEB-INF/redirects.properties
+++ b/src/main/webapp/WEB-INF/redirects.properties
@@ -59,6 +59,30 @@
 /docs/ref/command/*=/docs/latest/reference/command/
 /docs/ref/feature/*=/docs/latest/reference/feature/
 
+# Javadocs
+/docs/ref/javaee/7/=/docs/latest/reference/javadoc/liberty-javaee7-javadoc.html
+/docs/ref/javaee/7/*=/docs/latest/reference/javadoc/liberty-javaee7-javadoc.html
+/docs/ref/javaee/8/=/docs/latest/reference/javadoc/liberty-javaee8-javadoc.html
+/docs/ref/javaee/8/*=/docs/latest/reference/javadoc/liberty-javaee8-javadoc.html
+/docs/ref/javadocs/microprofile-1.2-javadoc/=/docs/latest/reference/javadoc/microprofile-1.2-javadoc.html
+/docs/ref/javadocs/microprofile-1.2-javadoc/*=/docs/latest/reference/javadoc/microprofile-1.2-javadoc.html
+/docs/ref/javadocs/microprofile-1.3-javadoc/=/docs/latest/reference/javadoc/microprofile-1.3-javadoc.html
+/docs/ref/javadocs/microprofile-1.3-javadoc/*=/docs/latest/reference/javadoc/microprofile-1.3-javadoc.html
+/docs/ref/javadocs/microprofile-1.4-javadoc/=/docs/latest/reference/javadoc/microprofile-1.4-javadoc.html
+/docs/ref/javadocs/microprofile-1.4-javadoc/*=/docs/latest/reference/javadoc/microprofile-1.4-javadoc.html
+/docs/ref/javadocs/microprofile-2.0-javadoc/=/docs/latest/reference/javadoc/microprofile-2.0-javadoc.html
+/docs/ref/javadocs/microprofile-2.0-javadoc/*=/docs/latest/reference/javadoc/microprofile-2.0-javadoc.html
+/docs/ref/javadocs/microprofile-2.1-javadoc/=/docs/latest/reference/javadoc/microprofile-2.1-javadoc.html
+/docs/ref/javadocs/microprofile-2.1-javadoc/*=/docs/latest/reference/javadoc/microprofile-2.1-javadoc.html
+/docs/ref/javadocs/microprofile-2.2-javadoc/=/docs/latest/reference/javadoc/microprofile-2.2-javadoc.html
+/docs/ref/javadocs/microprofile-2.2-javadoc/*=/docs/latest/reference/javadoc/microprofile-2.2-javadoc.html
+/docs/ref/javadocs/microprofile-3.0-javadoc/=/docs/latest/reference/javadoc/microprofile-3.0-javadoc.html
+/docs/ref/javadocs/microprofile-3.0-javadoc/*=/docs/latest/reference/javadoc/microprofile-3.0-javadoc.html
+/docs/ref/javadocs/microprofile-3.2-javadoc/=/docs/latest/reference/javadoc/microprofile-3.2-javadoc.html
+/docs/ref/javadocs/microprofile-3.2-javadoc/*=/docs/latest/reference/javadoc/microprofile-3.2-javadoc.html
+/docs/ref/javadocs/microprofile-3.3-javadoc/=/docs/latest/reference/javadoc/microprofile-3.3-javadoc.html
+/docs/ref/javadocs/microprofile-3.3-javadoc/*=/docs/latest/reference/javadoc/microprofile-3.3-javadoc.html
+
 # Doc redirects that existed pre-Antora
 /docs/intro/=/docs/
 /docs/intro/microprofile.html=/docs/ref/general/#microprofile.html


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
