### PR TITLE
Add the jekyll-include-cache plugin to save build time on common files

### DIFF
--- a/scripts/build_gem_dependencies.sh
+++ b/scripts/build_gem_dependencies.sh
@@ -1,5 +1,5 @@
 echo "Installing ruby packages..."
 gem install jekyll -v 3.8.6
-gem install bundler jekyll-feed jekyll-asciidoc coderay uglifier octopress-minify-html octokit
+gem install bundler jekyll-feed jekyll-asciidoc jekyll-include-cache coderay uglifier octopress-minify-html octokit
 gem install jekyll-assets -v 2.4.0
 gem uninstall -i /usr/local/rvm/gems/ruby-2.4.1@global rubygems-bundler

--- a/src/main/content/_config.yml
+++ b/src/main/content/_config.yml
@@ -36,6 +36,7 @@ plugins:
   - jekyll-feed
   - jekyll-asciidoc
   - jekyll-assets
+  - jekyll-include-cache
   - ol-asciidoc
   - ol-target-blank
   - octopress-minify-html

--- a/src/main/content/_includes/head.html
+++ b/src/main/content/_includes/head.html
@@ -51,7 +51,7 @@
   <meta name="google-site-verification" content="h2P030H9b66CyL1nEmWfrZB8Fr14h9LmVMG7Ur0caBs" />
 
   {% if jekyll.environment != 'production' %}
-      {% include noindex.html %}
+      {% include_cached noindex.html %}
   {% endif %}
 
   <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/src/main/content/_includes/header.html
+++ b/src/main/content/_includes/header.html
@@ -35,46 +35,4 @@
             </div>
         </div>
     </nav>
-    {% if page.type == 'config' or page.type == 'feature' or page.type == 'command' or page.type == 'general' %}	
-        <div class="breadcrumb_hamburger_nav" role="button" data-toggle="collapse" data-target="#toc_column" aria-expanded="true" aria-controls="toc_column">	
-            <!-- Hamburger icon for showing the table of contents -->	
-            <button id="breadcrumb_hamburger" class="collapsed" type="button">	
-                <span class="sr-only">Toggle navigation</span>	
-                <span class="icon-bar"></span>	
-                <span class="icon-bar"></span>	
-                <span class="icon-bar"></span>	
-            </button>	
-            <span id="breadcrumb_hamburger_title">Table of Contents</span>	
-        </div>	
-    {% endif %} 
-
-    <!-- Javadocs -->
-    {% if page.type == 'Javadoc' %}
-    <div id="breadcrumb_row">
-        <ol class="breadcrumb fluid-container">   
-            <li>
-                <a href="/docs">Docs</a>
-            </li>
-            <li>
-                <a class="inactive_link">Reference</a>
-            </li>
-            <li class="active"> {{ page.doc-type }} </li>
-            {% assign versions = site.pages | where: 'doc-type', page.doc-type | sort: 'version' | reverse %}
-            {% if versions | size > 1 %}
-                <span id="breadcrumb_line">|</span>
-                <li id="breadcrumb_version">VERSION:</li>
-
-                {% for javadoc in versions %}
-                <li class="javadoc_version">
-                    {% if page.version == javadoc.version %}
-                        <a class="selected_javadoc__version">{{ javadoc.version }}</a>
-                    {% else %}
-                        <a href="{{ javadoc.url }}" onclick="versionClick(event)">{{ javadoc.version }}</a>
-                    {% endif %}
-                </li>
-                {% endfor %} 
-            {% endif %}
-        </ol>
-    </div>
-    {% endif %}
 </header>

--- a/src/main/content/_layouts/default.html
+++ b/src/main/content/_layouts/default.html
@@ -10,9 +10,9 @@ css:
 
   <body>
     
-    {% include analytics.html %}
+    {% include_cached analytics.html %}
 
-    {% include header.html %}
+    {% include_cached header.html %}
 
     <main aria-label="Content">
 
@@ -20,7 +20,7 @@ css:
 
     </main>
 
-    {% include footer.html %}
+    {% include_cached footer.html %}
 
     {% include javascript.html %}
 

--- a/src/main/content/_layouts/doc.html
+++ b/src/main/content/_layouts/doc.html
@@ -10,9 +10,9 @@ css:
 
   <body>
     
-    {% include analytics.html %}
+    {% include_cached analytics.html %}
 
-    {% include header.html %}
+    {% include_cached header.html %}
 
     <main aria-label="Content">
 
@@ -20,7 +20,7 @@ css:
 
     </main>
 
-    {% include footer.html %}
+    {% include_cached footer.html %}
 
     {% include javascript.html %}
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

