### PR TITLE
Redirect /blogs/ to /blog/

### DIFF
--- a/src/main/webapp/WEB-INF/redirects.properties
+++ b/src/main/webapp/WEB-INF/redirects.properties
@@ -21,6 +21,8 @@
 /news/=/blog/
 /news=/blog/
 /news/*=/blog/
+/blogs=/blog/
+/blogs/=/blog/
 /blog/2017/11/29/liberty-spring-boot.html=/guides/spring-boot.html
 /blog/2019/03/01/microprofile-concurrency.html=/blog/2019/08/16/microprofile-context-propagation.html
 /blog/2019/05/24/testing-database-connections-REST-APIs.html=/blog/2019/09/13/testing-database-connections-REST-APIs.html


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

