### PR TITLE
Fix feature linking to go to the highest version (Fixes #1755)

### DIFF
--- a/scripts/feature-template/common-feature-content-template.html
+++ b/scripts/feature-template/common-feature-content-template.html
@@ -1,9 +1,0 @@
-<div id="common_feature">
-    <div class="page"> 
-       <!-- put versions here -->
-    </div>
-
-    <!-- feature content section -->
-    <div id="common_feature_content">
-    </div>
-</div>

--- a/scripts/parse-feature-toc.py
+++ b/scripts/parse-feature-toc.py
@@ -47,7 +47,7 @@ for version in os.listdir(featurePath):
 for version in versions:
     # Read in front version/feature but write to all of the antora version later for changing the toc
     antora_path = featurePath + version + "/reference/"
-    featureIndex = BeautifulSoup(open(antora_path + 'feature/feature-overview.html'), "html.parser")
+    featureIndex = BeautifulSoup(open(antora_path + 'feature/feature-overview.html'), "html.parser")        
 
     # Keep track of new href with updated versions to update the TOCs later
     commonTOCs = {};
@@ -81,12 +81,12 @@ for version in versions:
         firstElement = True;
         # determine whether there are multiple versions
         if len(matchingTitleTOCs) > 1:
-            # multiple versions of the same title found, create a new html from the template
-            # to put the versions at the top of the page
+            # multiple versions of the same title found, put the versions at the top of the page
             firstHref = matchingTitleTOCs[0].get('href')
             featurePage  = BeautifulSoup(open(antora_path + '/feature/' + firstHref), "html.parser")
             versionHrefs = featurePage.find('h1', {'class': 'page'})
             versionHrefs.string = ''
+            newTOCHref = ''
             # in reverse descending order
             matchingTOCs = matchingTitleTOCs[::-1]
             for matchingTOC in matchingTOCs:
@@ -98,12 +98,20 @@ for version in versions:
                     htmlSplits = lastHrefSplit.split('-')
                     lastMatch = re.search(r'\d*.html$', htmlSplits[-1])
                     if lastMatch:
+                        del htmlSplits[-1]
+                        combineHtml = "-".join(htmlSplits) + '.html'
+                        del hrefSplits[-1]
+                        newTOCHref = '/'.join(hrefSplits) + '/' + combineHtml
                         hrefTag = createVersionHref(featurePage, tocHref, matchingTOC.string, True)
                         versionHrefs.append(hrefTag)
                 else:
                     hrefTag = createVersionHref(featurePage, tocHref, matchingTOC.string, False)
                     versionHrefs.append(hrefTag)
                     TOCToDecompose.append(matchingTOC.parent)
+
+            # write to the common version doc with the highest versioned content
+            with open(antora_path + 'feature' +  newTOCHref, "w") as file:
+                file.write(str(featurePage))
             
             # Go through the matching TOC pages and write the version switcher to the top of the page
             for matchingTOC in matchingTOCs:

--- a/src/main/content/antora_ui/src/js/05-features.js
+++ b/src/main/content/antora_ui/src/js/05-features.js
@@ -35,6 +35,20 @@ function highlightSelectedVersion(){
     }
 }
 
+// Versioned features have a non-versioned page to support linking to the latest version of a feature without having to supply the version. E.g. link:docs/ref/feature/appSecurity.adoc will create appSecurity.html which redirects to the highest version of that feature (at the time), appSecurity-3.0.html. If there are versions for the current page but the current href doesn't match any of them, then we're on a versionless page that should be versioned, so we should redirect to the highest version of this feature.
+function checkForNonVersionedPage(){
+    if($('.feature_version').length > 0){
+        var url = window.location.href;
+        var version = url.substring(url.lastIndexOf('/') + 1);
+        if($('.feature_version[href="' + version + '"]').length === 0){
+            // Redirect to the highest version
+            var href = $('.feature_version').first().attr('href');
+            var newUrl = url.substring(0,url.lastIndexOf('/')) + '/' + href;
+            window.location.href = newUrl;
+        }
+    }
+}
+
 // When loading the page, if the page from the url isn't selected in the TOC we need to look for its version in the TOC and highlight it since the multiple feature versions only have one TOC entry.
 function selectTOC(){
     var first_version = $('.feature_version').first();
@@ -59,6 +73,7 @@ function selectTOC(){
 }
 
 $(document).ready(function () {  
+    checkForNonVersionedPage();
     addVersionClick();
     acivateNavMenu();
     highlightSelectedVersion();


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

