### PR TITLE
Change the BeautifulSoup parser from html.parser to lxml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
 - 2.4.1
 
 before_install:
-  - sudo apt-get install python3-bs4 -y
+  - sudo apt-get install python3-bs4 python3-lxml -y
 
 # Trigger a build for each environment; QA == STAGING
 jobs:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,7 +2,7 @@
 #
 #
 sudo apt-get update
-sudo apt-get install nodejs python3-bs4 libgdbm-dev libncurses5-dev automake libtool bison libffi-dev -y
+sudo apt-get install nodejs python3-bs4 libgdbm-dev libncurses5-dev automake libtool bison libffi-dev python3-lxml -y
 
 SCRIPT_DIR=$(dirname $0)
 

--- a/scripts/parse-feature-toc.py
+++ b/scripts/parse-feature-toc.py
@@ -47,7 +47,7 @@ for version in os.listdir(featurePath):
 for version in versions:
     # Read in front version/feature but write to all of the antora version later for changing the toc
     antora_path = featurePath + version + "/reference/"
-    featureIndex = BeautifulSoup(open(antora_path + 'feature/feature-overview.html'), "html.parser")        
+    featureIndex = BeautifulSoup(open(antora_path + 'feature/feature-overview.html'), "lxml")        
 
     # Keep track of new href with updated versions to update the TOCs later
     commonTOCs = {};
@@ -83,7 +83,7 @@ for version in versions:
         if len(matchingTitleTOCs) > 1:
             # multiple versions of the same title found, put the versions at the top of the page
             firstHref = matchingTitleTOCs[0].get('href')
-            featurePage  = BeautifulSoup(open(antora_path + '/feature/' + firstHref), "html.parser")
+            featurePage  = BeautifulSoup(open(antora_path + '/feature/' + firstHref), "lxml")
             versionHrefs = featurePage.find('h1', {'class': 'page'})
             versionHrefs.string = ''
             newTOCHref = ''
@@ -117,7 +117,7 @@ for version in versions:
             for matchingTOC in matchingTOCs:
                 # Open page and rewrite the version part
                 versionHref = antora_path + 'feature/' + matchingTOC.get('href')
-                versionPage = BeautifulSoup(open(versionHref), "html.parser")
+                versionPage = BeautifulSoup(open(versionHref), "lxml")
                 versionTitle = versionPage.find('h1', {'class': 'page'})
                 versionTitle.replace_with(versionHrefs)
                 with open(versionHref, "w") as file:
@@ -136,7 +136,7 @@ for version in versions:
         file.write(str(featureIndex))
 
     # Record the toc in the featureIndex to write over the other pages
-    featureIndex = BeautifulSoup(open(antora_path + 'feature/feature-overview.html'), "html.parser")
+    featureIndex = BeautifulSoup(open(antora_path + 'feature/feature-overview.html'), "lxml")
     toc = featureIndex.find_all('ul', {'class': 'nav-list'})[0]
     featureTOC = toc.find('span', text='Features').parent
 
@@ -153,12 +153,12 @@ for version in versions:
             if fnmatch.fnmatch(basename, "*.html"):
                 if(basename != "index.html"):
                     href = os.path.join(root, basename)
-                    page = BeautifulSoup(open(href), "html.parser")
+                    page = BeautifulSoup(open(href), "lxml")
 
                     # Find the toc and replace it with the modified toc
                     page_toc = page.find_all('ul', {'class': 'nav-list'})[0]
                     toc_to_replace = page_toc.find('span', text='Features').parent
                     toc_to_replace.clear()
                     toc_to_replace.append(featureTOC)
-                    with open(href, "w") as file:            
+                    with open(href, "w") as file:           
                         file.write(str(page))


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Each doc version used to take ~66 seconds to iterate over and write a new feature TOC to every page. Changing the html parser that BeautifulSoup uses from html.parser written in Python regex to "lxml" which is written in C reduces the time per doc version to ~44s. I tested this using the time library:

html.parser
Modifying the docs TOCs of version 20.0.0.8 to remove the duplicate feature versions.
66.656714
Modifying the docs TOCs of version 20.0.0.7 to remove the duplicate feature versions.
67.14323900000001

lxml
Modifying the docs TOCs of version 20.0.0.8 to remove the duplicate feature versions.
44.970226000000004
Modifying the docs TOCs of version 20.0.0.7 to remove the duplicate feature versions.
43.74981

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

