### PR TITLE
Split the feature title and versions into separate divs (Closes #1768)

### DIFF
--- a/scripts/parse-feature-toc.py
+++ b/scripts/parse-feature-toc.py
@@ -12,7 +12,15 @@ def getTOCVersion(tocString):
     else:
         return None
 
-def createVersionHref(parent, tocHref, tocString, firstElement):
+def createTitle(parent, tocHref, tocString):
+    TitleDiv = parent.new_tag('div', id="feature_name_string")
+    TitleDiv['full_title'] = "{}".format(tocString)
+    TitleDiv['aria-label'] = "{}".format(tocString)
+    TitleDiv['tabindex'] = '0'
+    TitleDiv.string = tocString
+    return TitleDiv
+
+def createVersionHref(parent, tocHref, tocString):
     hrefTag = parent.new_tag('div', href=tocHref)
     hrefTag['role'] = 'button'
     hrefTag['class'] = 'feature_version'
@@ -21,15 +29,9 @@ def createVersionHref(parent, tocHref, tocString, firstElement):
     hrefTag['tabindex'] = '0'
     docVersion = getTOCVersion(tocString)
     if docVersion is not None:
-        if firstElement:
-            hrefTag.string = tocString
-        else:
-            hrefTag.string = docVersion
+        hrefTag.string = docVersion
     else:
-        if firstElement:
-            hrefTag.string = tocString + " " + getTOCVersion(tocHref)
-        else:
-            hrefTag.string = getTOCVersion(tocHref)
+        hrefTag.string = getTOCVersion(tocHref)
     return hrefTag
 
 # Get all of the Antora versions
@@ -84,8 +86,10 @@ for version in versions:
             # multiple versions of the same title found, put the versions at the top of the page
             firstHref = matchingTitleTOCs[0].get('href')
             featurePage  = BeautifulSoup(open(antora_path + '/feature/' + firstHref), "lxml")
-            versionHrefs = featurePage.find('h1', {'class': 'page'})
-            versionHrefs.string = ''
+            pageTitle = featurePage.find('h1', {'class': 'page'})
+            titleDiv = featurePage.new_tag('div', id='feature_name')
+            versionDiv = featurePage.new_tag('div', id='feature_versions')
+            pageTitle.string = ''
             newTOCHref = ''
             # in reverse descending order
             matchingTOCs = matchingTitleTOCs[::-1]
@@ -102,12 +106,17 @@ for version in versions:
                         combineHtml = "-".join(htmlSplits) + '.html'
                         del hrefSplits[-1]
                         newTOCHref = '/'.join(hrefSplits) + '/' + combineHtml
-                        hrefTag = createVersionHref(featurePage, tocHref, matchingTOC.string, True)
-                        versionHrefs.append(hrefTag)
+                        title = createTitle(featurePage, tocHref, matchingTOC.string)
+                        titleDiv.append(title)
+                        hrefTag = createVersionHref(featurePage, tocHref, matchingTOC.string)
+                        versionDiv.append(hrefTag)
                 else:
-                    hrefTag = createVersionHref(featurePage, tocHref, matchingTOC.string, False)
-                    versionHrefs.append(hrefTag)
+                    hrefTag = createVersionHref(featurePage, tocHref, matchingTOC.string)
+                    versionDiv.append(hrefTag)
                     TOCToDecompose.append(matchingTOC.parent)
+            # Write the feature title and the versions to the page div
+            pageTitle.append(titleDiv)
+            pageTitle.append(versionDiv)
 
             # write to the common version doc with the highest versioned content
             with open(antora_path + 'feature' +  newTOCHref, "w") as file:
@@ -119,7 +128,7 @@ for version in versions:
                 versionHref = antora_path + 'feature/' + matchingTOC.get('href')
                 versionPage = BeautifulSoup(open(versionHref), "lxml")
                 versionTitle = versionPage.find('h1', {'class': 'page'})
-                versionTitle.replace_with(versionHrefs)
+                versionTitle.replace_with(pageTitle)
                 with open(versionHref, "w") as file:
                     file.write(str(versionPage))
 

--- a/scripts/parse-feature-toc.py
+++ b/scripts/parse-feature-toc.py
@@ -24,14 +24,12 @@ def createVersionHref(parent, tocHref, tocString):
     hrefTag = parent.new_tag('div', href=tocHref)
     hrefTag['role'] = 'button'
     hrefTag['class'] = 'feature_version'
-    hrefTag['full_title'] = "{}".format(tocString)
-    hrefTag['aria-label'] = "{}".format(tocString)
     hrefTag['tabindex'] = '0'
     docVersion = getTOCVersion(tocString)
-    if docVersion is not None:
-        hrefTag.string = docVersion
-    else:
-        hrefTag.string = getTOCVersion(tocHref)
+    if docVersion is None:        
+        docVersion = getTOCVersion(tocHref)
+    hrefTag['aria-label'] = 'Version ' + docVersion
+    hrefTag.string = docVersion
     return hrefTag
 
 # Get all of the Antora versions

--- a/src/main/content/antora_ui/src/css/doc.css
+++ b/src/main/content/antora_ui/src/css/doc.css
@@ -42,7 +42,6 @@
   font-size: 35px;
   color: #24233C;
   letter-spacing: 0;
-  overflow-x: auto;
 
   @media screen and (min-width: 767.98px) {
     margin-top: 0;

--- a/src/main/content/antora_ui/src/js/05-features.js
+++ b/src/main/content/antora_ui/src/js/05-features.js
@@ -32,6 +32,8 @@ function highlightSelectedVersion(){
     var versionHref = $('.feature_version[href="' + version + '"]');
     if(versionHref.length === 1){
         versionHref.addClass('feature_version_selected');
+        var ariaLabel = versionHref.attr('aria-label');
+        versionHref.attr('aria-label', aria-label + ' selected');
     }
 }
 

--- a/src/main/content/antora_ui/src/js/05-features.js
+++ b/src/main/content/antora_ui/src/js/05-features.js
@@ -33,7 +33,7 @@ function highlightSelectedVersion(){
     if(versionHref.length === 1){
         versionHref.addClass('feature_version_selected');
         var ariaLabel = versionHref.attr('aria-label');
-        versionHref.attr('aria-label', aria-label + ' selected');
+        versionHref.attr('aria-label', ariaLabel + ' selected');
     }
 }
 

--- a/src/main/content/antora_ui/src/sass/feature.scss
+++ b/src/main/content/antora_ui/src/sass/feature.scss
@@ -15,6 +15,29 @@
 
 /* content styling */
 
+#feature_name, #feature_versions {
+    display: inline-block;
+    &:focus {
+        outline: none;
+    }
+}
+
+#feature_name {
+    margin-right: 20px;
+}
+
+#feature_name_string:focus {
+    outline: none;
+}
+
+@media (max-width: 767.98px) {
+    #feature_versions {
+        width: 100%;
+        overflow-x: auto;
+    }
+}
+
+
 .feature_version {
     display: inline;
     margin-left: 20px;

--- a/src/main/content/antora_ui/src/sass/feature.scss
+++ b/src/main/content/antora_ui/src/sass/feature.scss
@@ -23,7 +23,7 @@
 }
 
 #feature_name {
-    margin-right: 20px;
+    margin-right: 15px;
 }
 
 #feature_name_string:focus {

--- a/src/main/content/antora_ui/src/sass/feature.scss
+++ b/src/main/content/antora_ui/src/sass/feature.scss
@@ -17,17 +17,10 @@
 
 #feature_name, #feature_versions {
     display: inline-block;
-    &:focus {
-        outline: none;
-    }
 }
 
 #feature_name {
     margin-right: 15px;
-}
-
-#feature_name_string:focus {
-    outline: none;
 }
 
 @media (max-width: 767.98px) {
@@ -42,7 +35,6 @@
     display: inline;
     margin-left: 20px;
     opacity: 0.5;
-    outline: none;
     font-family: BunueloLight, Arial Narrow, Helvetica, Arial;
     font-size: 35px;
     letter-spacing: 0;


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
This is to make the feature versions scrollable without the name moving in mobile view. See "Microprofile" for a feature with a lot of versions.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

