### PR TITLE
Make canonical tag point at latest doc version

### DIFF
--- a/src/main/content/antora_ui/src/partials/head-meta.hbs
+++ b/src/main/content/antora_ui/src/partials/head-meta.hbs
@@ -10,7 +10,7 @@
 <meta name="description" content="Open Liberty is the most flexible server runtime available to Earth’s Java developers.">
 {{/if}}
 {{#if page.url }} 
-<link rel="canonical" href="https://openliberty.io{{ page.url }}">
+<link rel="canonical" href="{{ page.canonicalUrl }}">
 {{/if}}
 
 <meta name="twitter:card" content="summary" />

--- a/src/main/content/antora_ui/src/partials/head-meta.hbs
+++ b/src/main/content/antora_ui/src/partials/head-meta.hbs
@@ -9,7 +9,7 @@
 {{ else }}
 <meta name="description" content="Open Liberty is the most flexible server runtime available to Earth’s Java developers.">
 {{/if}}
-{{#if page.url }} 
+{{#if page.canonicalUrl }} 
 <link rel="canonical" href="{{ page.canonicalUrl }}">
 {{/if}}
 


### PR DESCRIPTION
We want all versions of our documentation to point at the latest one when indexed by crawlers.

#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

