### PR TITLE
Update redirect.properties to support more pre-antora URLs

### DIFF
--- a/src/main/webapp/WEB-INF/redirects.properties
+++ b/src/main/webapp/WEB-INF/redirects.properties
@@ -35,12 +35,12 @@
 /config/*=/docs/ref/config/#
 
 # Redirects for a file name change to feature-overview.html. 20.0.0.8 was the latest version with the old file name.
-/docs/ref/feature/featureOverview.html=/docs/latest/feature/feature-overview.html
+/docs/ref/feature/featureOverview.html=/docs/latest/reference/feature/feature-overview.html
 /docs/20.0.0.7/reference/feature/featureOverview.html=/docs/20.0.0.7/reference/feature/feature-overview.html
 /docs/20.0.0.8/reference/feature/featureOverview.html=/docs/20.0.0.8/reference/feature/feature-overview.html
 
 # Redirects for a file name change to server-configuration-overview.html. 20.0.0.8 was the latest version with the old file name.
-/docs/ref/config/serverConfiguration.html=/docs/latest/config/server-configuration-overview.html
+/docs/ref/config/serverConfiguration.html=/docs/latest/reference/config/server-configuration-overview.html
 /docs/20.0.0.7/reference/config/serverConfiguration.html=/docs/20.0.0.7/reference/config/server-configuration-overview.html
 /docs/20.0.0.8/reference/config/serverConfiguration.html=/docs/20.0.0.8/reference/config/server-configuration-overview.html
 
@@ -86,15 +86,21 @@
 /docs/ref/javadocs/microprofile-3.2-javadoc/=/docs/latest/reference/javadoc/microprofile-3.2-javadoc.html
 /docs/ref/javadocs/microprofile-3.3-javadoc/=/docs/latest/reference/javadoc/microprofile-3.3-javadoc.html
 
-/docs/ref/javadocs/microprofile-1.2-javadoc/*=/docs/latest/reference/javadoc/microprofile-1.2-javadoc.html
-/docs/ref/javadocs/microprofile-1.3-javadoc/*=/docs/latest/reference/javadoc/microprofile-1.3-javadoc.html
-/docs/ref/javadocs/microprofile-1.4-javadoc/*=/docs/latest/reference/javadoc/microprofile-1.4-javadoc.html
-/docs/ref/javadocs/microprofile-2.0-javadoc/*=/docs/latest/reference/javadoc/microprofile-2.0-javadoc.html
-/docs/ref/javadocs/microprofile-2.1-javadoc/*=/docs/latest/reference/javadoc/microprofile-2.1-javadoc.html
-/docs/ref/javadocs/microprofile-2.2-javadoc/*=/docs/latest/reference/javadoc/microprofile-2.2-javadoc.html
-/docs/ref/javadocs/microprofile-3.0-javadoc/*=/docs/latest/reference/javadoc/microprofile-3.0-javadoc.html
-/docs/ref/javadocs/microprofile-3.2-javadoc/*=/docs/latest/reference/javadoc/microprofile-3.2-javadoc.html
-/docs/ref/javadocs/microprofile-3.3-javadoc/*=/docs/latest/reference/javadoc/microprofile-3.3-javadoc.html
+/docs/ref/javadocs/microprofile-1.2-javadoc/*=/docs/latest/reference/javadoc/microprofile-1.2-javadoc.html#
+/docs/ref/javadocs/microprofile-1.3-javadoc/*=/docs/latest/reference/javadoc/microprofile-1.3-javadoc.html#
+/docs/ref/javadocs/microprofile-1.4-javadoc/*=/docs/latest/reference/javadoc/microprofile-1.4-javadoc.html#
+/docs/ref/javadocs/microprofile-2.0-javadoc/*=/docs/latest/reference/javadoc/microprofile-2.0-javadoc.html#
+/docs/ref/javadocs/microprofile-2.1-javadoc/*=/docs/latest/reference/javadoc/microprofile-2.1-javadoc.html#
+/docs/ref/javadocs/microprofile-2.2-javadoc/*=/docs/latest/reference/javadoc/microprofile-2.2-javadoc.html#
+/docs/ref/javadocs/microprofile-3.0-javadoc/*=/docs/latest/reference/javadoc/microprofile-3.0-javadoc.html#
+/docs/ref/javadocs/microprofile-3.2-javadoc/*=/docs/latest/reference/javadoc/microprofile-3.2-javadoc.html#
+/docs/ref/javadocs/microprofile-3.3-javadoc/*=/docs/latest/reference/javadoc/microprofile-3.3-javadoc.html#
+
+/docs/ref/javadocs/liberty-javaee7-javadoc/=/docs/latest/reference/javadoc/liberty-javaee7-javadoc.html
+/docs/ref/javadocs/liberty-javaee8-javadoc/=/docs/latest/reference/javadoc/liberty-javaee8-javadoc.html
+
+/docs/ref/javadocs/liberty-javaee7-javadoc/*=/docs/latest/reference/javadoc/liberty-javaee7-javadoc.html#
+/docs/ref/javadocs/liberty-javaee8-javadoc/*=/docs/latest/reference/javadoc/liberty-javaee8-javadoc.html#
 # End of Javadoc redirects
 
 # Doc redirects that existed pre-Antora


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

