### PR TITLE
Make the canonical url the full url

### DIFF
--- a/src/main/content/antora_ui/src/partials/head-info.hbs
+++ b/src/main/content/antora_ui/src/partials/head-info.hbs
@@ -1,5 +1,5 @@
     {{#if page.url}}
-    <link rel="canonical" href="{{ replace_version page.url "20.0.0.8" }}">
+    <link rel="canonical" href="https://openliberty.io{{replace_version page.url '20.0.0.8' }}">
     {{/if}}
     {{#if page.component}}
     {{#if page.keywords}}


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
I tested locally:
![image](https://user-images.githubusercontent.com/6392944/90910625-3a8e5b00-e39d-11ea-809a-8b54ea41f6f6.png)

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

