### PR TITLE
Use the latest node version in the build

### DIFF
--- a/scripts/build_jekyll_maven.sh
+++ b/scripts/build_jekyll_maven.sh
@@ -4,6 +4,12 @@ set -e
 
 ./scripts/build_gem_dependencies.sh
 
+# Install the latest node version using nvm (Node Version Manager)
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
+export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
+nvm install --lts
+
 echo "Ruby version:"
 echo `ruby -v`
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
This installs the latest node version using nvm, a node version manager. Our Travis builds used to be 30-35m each. Using the latest node version speeds up how fast we can process the docs that the Antora node modules use. 

This was tested by running 4 builds on Travis:
https://travis-ci.com/github/OpenLiberty/openliberty.io/builds/181507776
https://travis-ci.com/github/OpenLiberty/openliberty.io/builds/181511799
https://travis-ci.com/github/OpenLiberty/openliberty.io/builds/181511823
https://travis-ci.com/github/OpenLiberty/openliberty.io/builds/181511840

Build times:
26m 4s
29m 40s
29m 27s
27m 39s

Steps to install nvm were followed from here:
https://github.com/nvm-sh/nvm

Note that IBM Cloud already uses a recent version of node, but the Travis apps use 8.12.0 before this.

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

