### PR TITLE
Make it so you can't copy the callouts in code blocks

### DIFF
--- a/src/main/content/_assets/css/openliberty.scss
+++ b/src/main/content/_assets/css/openliberty.scss
@@ -669,6 +669,15 @@ footer {
     }
 }
 
+code b {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
 /* Code copy button */
 #copied_confirmation {
     position: absolute;

--- a/src/main/content/_assets/css/openliberty.scss
+++ b/src/main/content/_assets/css/openliberty.scss
@@ -640,37 +640,46 @@ footer {
 
 /* Callouts */
 .colist.arabic {
-    padding-left: 5px;
-
     & table, & caption, & tbody, & tfoot, & thead, & tr, & th, & td {
         margin: 0;
         padding: 0;
         border: 0;
         outline: 0;
-        font-size: 100%;
         vertical-align: baseline;
         text-align: left;
         background: transparent;
         box-shadow: none;
     }
     & tr {
-        padding: 13px 0;
-        & td:first-child {
-            width: 30px;
-            &:before {
-                /* Add parenthesis before the number of each row */
-                content: "( ";
-            }  
-            &:after {
-                /* Add parenthesis after the number of each row */
-                content: " )";
-            }            
+        & td:first-child{
+            width: 25px;
+            & .conum[data-value] {
+                border: 1px solid;
+                border-radius: 100%;
+                display: inline-block;
+                font-family: Roboto,sans-serif;
+                font-size: 14px;
+                font-style: normal;
+                height: 1.25em;
+                line-height: 1.2;
+                text-align: center;
+                width: 1.25em;
+                letter-spacing: -.25ex;
+                text-indent: -.25ex;
+                
+                &:after {
+                    content: attr(data-value);
+                }
+            }
+
+            & .conum[data-value]+b {
+                display: none;
+            }
         }
     }
 }
 
-code .conum[data-value]:after {
-    content: attr(data-value);
+code .conum[data-value] {
     border: 1px solid;
     border-radius: 100%;
     display: inline-block;
@@ -683,6 +692,10 @@ code .conum[data-value]:after {
     width: 1.25em;
     letter-spacing: -.25ex;
     text-indent: -.25ex;
+}
+
+code .conum[data-value]:after {
+    content: attr(data-value);
 }
 
 code .conum[data-value]+b {

--- a/src/main/content/_assets/css/openliberty.scss
+++ b/src/main/content/_assets/css/openliberty.scss
@@ -669,13 +669,24 @@ footer {
     }
 }
 
-code b {
-    -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
+code .conum[data-value]:after {
+    content: attr(data-value);
+    border: 1px solid;
+    border-radius: 100%;
+    display: inline-block;
+    font-family: Roboto,sans-serif;
+    font-size: 14px;
+    font-style: normal;
+    height: 1.25em;
+    line-height: 1.2;
+    text-align: center;
+    width: 1.25em;
+    letter-spacing: -.25ex;
+    text-indent: -.25ex;
+}
+
+code .conum[data-value]+b {
+    display: none;
 }
 
 /* Code copy button */

--- a/src/main/content/antora_ui/src/sass/openliberty.scss
+++ b/src/main/content/antora_ui/src/sass/openliberty.scss
@@ -666,14 +666,25 @@ footer {
         }
     }
 }
+    
+code .conum[data-value]:after {
+    content: attr(data-value);
+    border: 1px solid;
+    border-radius: 100%;
+    display: inline-block;
+    font-family: Roboto,sans-serif;
+    font-size: 14px;
+    font-style: normal;
+    height: 1.25em;
+    line-height: 1.2;
+    text-align: center;
+    width: 1.25em;
+    letter-spacing: -.25ex;
+    text-indent: -.25ex;
+}
 
-code b {
-    -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
+code .conum[data-value]+b {
+    display: none;
 }
 
 /* Code copy button */

--- a/src/main/content/antora_ui/src/sass/openliberty.scss
+++ b/src/main/content/antora_ui/src/sass/openliberty.scss
@@ -667,6 +667,15 @@ footer {
     }
 }
 
+code b {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
 /* Code copy button */
 #copied_confirmation {
     position: absolute;

--- a/src/main/content/antora_ui/src/sass/openliberty.scss
+++ b/src/main/content/antora_ui/src/sass/openliberty.scss
@@ -639,8 +639,6 @@ footer {
 
 /* Callouts */
 .colist.arabic {
-    padding-left: 5px;
-
     & table, & caption, & tbody, & tfoot, & thead, & tr, & th, & td {
         margin: 0;
         padding: 0;
@@ -652,23 +650,35 @@ footer {
         box-shadow: none;
     }
     & tr {
-        padding: 13px 0;
-        & td:first-child {
-            width: 30px;
-            &:before {
-                /* Add parenthesis before the number of each row */
-                content: "( ";
-            }  
-            &:after {
-                /* Add parenthesis after the number of each row */
-                content: " )";
-            }            
+        & td:first-child{
+            width: 25px;
+            & .conum[data-value] {
+                border: 1px solid;
+                border-radius: 100%;
+                display: inline-block;
+                font-family: Roboto,sans-serif;
+                font-size: 14px;
+                font-style: normal;
+                height: 1.25em;
+                line-height: 1.2;
+                text-align: center;
+                width: 1.25em;
+                letter-spacing: -.25ex;
+                text-indent: -.25ex;
+                
+                &:after {
+                    content: attr(data-value);
+                }
+            }
+
+            & .conum[data-value]+b {
+                display: none;
+            }
         }
     }
 }
     
-code .conum[data-value]:after {
-    content: attr(data-value);
+code .conum[data-value] {
     border: 1px solid;
     border-radius: 100%;
     display: inline-block;
@@ -681,6 +691,10 @@ code .conum[data-value]:after {
     width: 1.25em;
     letter-spacing: -.25ex;
     text-indent: -.25ex;
+}
+
+code .conum[data-value]:after {
+    content: attr(data-value);
 }
 
 code .conum[data-value]+b {


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

