### PR TITLE
Add another javadoc redirect

### DIFF
--- a/src/main/webapp/WEB-INF/redirects.properties
+++ b/src/main/webapp/WEB-INF/redirects.properties
@@ -62,10 +62,13 @@
 /docs/ref/feature/*=/docs/latest/reference/feature/
 
 # Javadocs pre-Antora to post-Antora
+/docs/modules/reference/*=/docs/ref/javadocs/
+
 /docs/ref/javaee/7/=/docs/latest/reference/javadoc/liberty-javaee7-javadoc.html
 /docs/ref/javaee/7/*=/docs/latest/reference/javadoc/liberty-javaee7-javadoc.html
 /docs/ref/javaee/8/=/docs/latest/reference/javadoc/liberty-javaee8-javadoc.html
 /docs/ref/javaee/8/*=/docs/latest/reference/javadoc/liberty-javaee8-javadoc.html
+
 /docs/ref/microprofile/1.2/=/docs/latest/reference/javadoc/microprofile-1.2-javadoc.html
 /docs/ref/microprofile/1.3/=/docs/latest/reference/javadoc/microprofile-1.3-javadoc.html
 /docs/ref/microprofile/1.4/=/docs/latest/reference/javadoc/microprofile-1.4-javadoc.html


### PR DESCRIPTION
These types of javadoc URLs should redirect to the corresponding docs page for the latest version:
https://openliberty.io/docs/modules/reference/microprofile-3.3-javadoc/javax/enterprise/inject/spi/InjectionPoint.html
