### PR TITLE
Revert "Add another javadoc redirect"

### DIFF
--- a/src/main/webapp/WEB-INF/redirects.properties
+++ b/src/main/webapp/WEB-INF/redirects.properties
@@ -62,13 +62,10 @@
 /docs/ref/feature/*=/docs/latest/reference/feature/
 
 # Javadocs pre-Antora to post-Antora
-/docs/modules/reference/*=/docs/ref/javadocs/
-
 /docs/ref/javaee/7/=/docs/latest/reference/javadoc/liberty-javaee7-javadoc.html
 /docs/ref/javaee/7/*=/docs/latest/reference/javadoc/liberty-javaee7-javadoc.html
 /docs/ref/javaee/8/=/docs/latest/reference/javadoc/liberty-javaee8-javadoc.html
 /docs/ref/javaee/8/*=/docs/latest/reference/javadoc/liberty-javaee8-javadoc.html
-
 /docs/ref/microprofile/1.2/=/docs/latest/reference/javadoc/microprofile-1.2-javadoc.html
 /docs/ref/microprofile/1.3/=/docs/latest/reference/javadoc/microprofile-1.3-javadoc.html
 /docs/ref/microprofile/1.4/=/docs/latest/reference/javadoc/microprofile-1.4-javadoc.html


### PR DESCRIPTION
Reverts OpenLiberty/openliberty.io#1836

Seems to be causing the javadoc to become nested:
![image](https://user-images.githubusercontent.com/3076261/91740443-ec394300-eb78-11ea-8c71-5bc50db281b1.png)
