### PR TITLE
Reverse the versions array so the highest version is on top

### DIFF
--- a/src/main/content/antora_ui/src/helpers/reverse_array.js
+++ b/src/main/content/antora_ui/src/helpers/reverse_array.js
@@ -1,0 +1,7 @@
+'use strict'
+
+function reverse_array(arr) {
+    return arr.reverse();
+};
+
+module.exports = reverse_array

--- a/src/main/content/antora_ui/src/partials/nav-explore.hbs
+++ b/src/main/content/antora_ui/src/partials/nav-explore.hbs
@@ -9,7 +9,7 @@
     {{#each site.components}}
     <li class="component{{#if (eq this @root.page.component)}} is-current{{/if}}">
       <ul class="versions">
-        {{#each ./versions}}
+        {{#each (reverse_array ./versions) }}
           <li class="version
             {{~#if (and (eq ../this @root.page.component) (eq this @root.page.componentVersion))}} is-current{{/if~}}
             {{~#if (eq this ../latestVersion)}} is-latest{{/if}}">


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
This will reverse the versions of our docs in the version picker so the highest version is on top.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

