### PR TITLE
Increase Frequency of updates for docs & blogs

### DIFF
--- a/src/main/content/sitemap.xml
+++ b/src/main/content/sitemap.xml
@@ -9,7 +9,7 @@
     </url>
     <url>
         <loc>https://openliberty.io/docs/20.0.0.9/overview.html</loc>
-        <changefreq>monthly</changefreq>
+        <changefreq>weekly</changefreq>
     </url>
     <url>
         <loc>https://openliberty.io/guides/</loc>
@@ -25,7 +25,7 @@
     </url>
     <url>
         <loc>https://openliberty.io/blog/</loc>
-        <changefreq>weekly</changefreq>
+        <changefreq>daily</changefreq>
     </url>
     <url>
         <loc>https://openliberty.io/contribute/</loc>


### PR DESCRIPTION
Google seems to take sometime to update our doc links to our latest version, hopefully this will help.
update change frequency in sitemap for docs (to weekly) and blogs (daily)