### PR TITLE
Add handlebars helper to sort our version schema

### DIFF
--- a/src/main/content/antora_ui/src/helpers/sort_component_versions.js
+++ b/src/main/content/antora_ui/src/helpers/sort_component_versions.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const { posix: path } = require('path')
+
+// Map the versions to an array of numbers, then sort the version arrays by number, then join the version numbers again with periods.
+function sort_component_versions (versions) {
+  versions = versions.map(function(version){
+      version.displayVersion = version.displayVersion.split('.').map(function(number){
+          return parseInt(number);
+      })
+      return version;
+  }).sort(function(versionA,versionB){
+    let a = versionA.displayVersion;
+    let b = versionB.displayVersion;
+    for (var i = 0; i < Math.max(a.length, b.length); i++) {
+        if (b[i]-a[i] != 0) return b[i]-a[i]; 
+    }
+    return 0;
+  }).map(function(version){
+      version.displayVersion = version.displayVersion.join('.');
+      return version;
+  })
+  return versions;
+}
+
+module.exports = sort_component_versions

--- a/src/main/content/antora_ui/src/partials/nav-explore.hbs
+++ b/src/main/content/antora_ui/src/partials/nav-explore.hbs
@@ -9,13 +9,13 @@
     {{#each site.components}}
     <li class="component{{#if (eq this @root.page.component)}} is-current{{/if}}">
       <ul class="versions">
-        {{#each ./versions}}
+        {{#each ( sort_component_versions ./versions )}}
           <li class="version
             {{~#if (and (eq ../this @root.page.component) (eq this @root.page.componentVersion))}} is-current{{/if~}}
             {{~#if (eq this ../latestVersion)}} is-latest{{/if}}">
             <span class="title">Version</span>
             {{#if ../../page.versions }}
-              {{#each ../../page.versions }}
+              {{#each ( sort_component_versions ../../page.versions) }}
                 {{#if (eq ./version ../version)}}
                     {{#if missing }}
                       <a href="/docs/{{./version}}/noversion.html" aria-label="Version {{./displayVersion}}">{{./displayVersion}}</a>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Our versions are longer than what Antora's default version sorter sorts by. The native Antora tool sorts by Major.Minor.patch as specified here: https://semver.org/ and we have an extra decimal in our versions so we wrote a custom helper to sort our versions so they are in order. In the future, Antora might expose a version extension here: https://gitlab.com/antora/antora/-/issues/454.

![image](https://user-images.githubusercontent.com/6392944/92277174-05fbc280-eeb8-11ea-9b30-2b40bbba172d.png)

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

