### PR TITLE
Exclude docs in jekyll build command

### DIFF
--- a/src/main/content/_config.yml
+++ b/src/main/content/_config.yml
@@ -41,7 +41,7 @@ plugins:
   - octopress-minify-html
 exclude:
   - vendor # TravisCI bundles all gems in the vendor directory on its build servers, which Jekyll will mistakenly read and explode on.
-  - docs/templates
+  - docs
   - "*.md"
   - "*.gendoc"
   - "*.examples"

--- a/src/main/content/_dev_config.yml
+++ b/src/main/content/_dev_config.yml
@@ -17,5 +17,5 @@ assets:
 minify_html: false
 
 exclude:
+  - docs
   - feature
-  - docs/templates


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

