### PR TITLE
Prevent callouts from being copied

### DIFF
--- a/src/main/content/_assets/js/builds.js
+++ b/src/main/content/_assets/js/builds.js
@@ -441,40 +441,6 @@ $(document).ready(function() {
             }).stop().fadeIn().delay(3500).fadeOut();
         });	
     });
-
-    /* Copy the target element to the clipboard
-    target: element to copy
-    callback: function to run if the copy is successful
-    */
-    function copy_element_to_clipboard(target, callback){
-        // IE
-        if(window.clipboardData){
-            window.clipboardData.setData("Text", target.innerText);
-        } 
-        else{
-            var temp = $('<textarea>');
-            temp.css({
-                position: "absolute",
-                left:     "-1000px",
-                top:      "-1000px",
-            });       
-            
-            // Create a temporary element for copying the text.
-            // Prepend <br> with newlines because jQuery .text() strips the <br>'s and we use .text() because we don't want all of the html tags copied to the clipboard.
-            var text = $(target).clone().find('br').prepend('\r\n').end().text().trim();
-            temp.text(text);
-            $("body").append(temp);
-            temp.trigger('select');
-            
-            // Try to copy the selection and if it fails display a popup to copy manually.
-            if(document.execCommand('copy')) { 
-                callback();
-            } else {
-                alert('Copy failed. Copy the command manually: ' + target.innerText);
-            }
-            temp.remove(); // Remove temporary element.
-        }
-    }
 });
 
 $(window).on("load", function(){

--- a/src/main/content/_assets/js/general-references.js
+++ b/src/main/content/_assets/js/general-references.js
@@ -335,40 +335,6 @@ $(document).ready(function () {
             }).stop().fadeIn().delay(3500).fadeOut();
         });	
     });
-    
-    /* Copy the target element to the clipboard
-    target: element to copy
-    callback: function to run if the copy is successful
-    */
-    function copy_element_to_clipboard(target, callback){
-        // IE
-        if(window.clipboardData){
-            window.clipboardData.setData("Text", target.innerText);
-        } 
-        else{
-            var temp = $('<textarea>');
-            temp.css({
-                position: "absolute",
-                left:     "-1000px",
-                top:      "-1000px",
-            });       
-            
-            // Create a temporary element for copying the text.
-            // Prepend <br> with newlines because jQuery .text() strips the <br>'s and we use .text() because we don't want all of the html tags copied to the clipboard.
-            var text = $(target).clone().find('br').prepend('\r\n').end().text().trim();
-            temp.text(text);
-            $("body").append(temp);
-            temp.trigger('select');
-            
-            // Try to copy the selection and if it fails display a popup to copy manually.
-            if(document.execCommand('copy')) { 
-                callback();
-            } else {
-                alert('Copy failed. Copy the command manually: ' + target.innerText);
-            }
-            temp.remove(); // Remove temporary element.
-        }
-    }
 });
 
 // Change height of toc if footer is in view so that fixed toc isn't visible through footer

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -45,40 +45,6 @@ function debounce(func, wait, immediate) {
     };
 }
 
-/* Copy the target element to the clipboard
-   target: element to copy
-   callback: function to run if the copy is successful
-*/
-function copy_element_to_clipboard(target, callback){
-    // IE
-    if(window.clipboardData){
-        window.clipboardData.setData("Text", target.innerText);
-    } 
-    else{
-        var temp = $('<textarea>');
-        temp.css({
-            position: "absolute",
-            left:     "-1000px",
-            top:      "-1000px",
-        });       
-        
-        // Create a temporary element for copying the text.
-        // Prepend <br> with newlines because jQuery .text() strips the <br>'s and we use .text() because we don't want all of the html tags copied to the clipboard.
-        var text = $(target).clone().find('br').prepend('\r\n').end().text().trim();
-        temp.text(text);
-        $("body").append(temp);
-        temp.trigger('select');
-        
-        // Try to copy the selection and if it fails display a popup to copy manually.
-        if(document.execCommand('copy')) { 
-            callback();
-        } else {
-            alert('Copy failed. Copy the command manually: ' + target.innerText);
-        }
-        temp.remove(); // Remove temporary element.
-    }
-}
-
 // Handle sticky header in IE, because IE doesn't support position: sticky
 function handleStickyHeader() {
     if (!inSingleColumnView()) {

--- a/src/main/content/_assets/js/openliberty.js
+++ b/src/main/content/_assets/js/openliberty.js
@@ -135,3 +135,38 @@ function hideNav() {
     // move config breadcrumb back up when nav bar slides out of view
     $(".contentStickyBreadcrumbHeader").css("top", $(".toolbar").outerHeight() + "px");
 }
+
+/* Copy the target element to the clipboard
+target: element to copy
+callback: function to run if the copy is successful
+*/
+function copy_element_to_clipboard(target, callback){
+    // IE
+    if(window.clipboardData){
+        window.clipboardData.setData("Text", target.innerText);
+    } 
+    else{
+        var temp = $('<textarea>');
+        temp.css({
+            position: "absolute",
+            left:     "-1000px",
+            top:      "-1000px",
+        });       
+        
+        // Create a temporary element for copying the text.
+        // Prepend <br> with newlines because jQuery .text() strips the <br>'s and we use .text() because we don't want all of the html tags copied to the clipboard.
+        // Remove <b> tags that contain callouts
+        var text = $(target).clone().find('br').prepend('\r\n').end().find("b").remove().end().text().trim();
+        temp.text(text);
+        $("body").append(temp);
+        temp.trigger('select');
+        
+        // Try to copy the selection and if it fails display a popup to copy manually.
+        if(document.execCommand('copy')) { 
+            callback();
+        } else {
+            alert('Copy failed. Copy the command manually: ' + target.innerText);
+        }
+        temp.remove(); // Remove temporary element.
+    }
+}

--- a/src/main/content/_assets/js/post.js
+++ b/src/main/content/_assets/js/post.js
@@ -62,37 +62,3 @@ $(document).on("click", "#copy_to_clipboard", function(event) {
         }).stop().fadeIn().delay(3500).fadeOut();
     });	
 });
-
-/* Copy the target element to the clipboard
-target: element to copy
-callback: function to run if the copy is successful
-*/
-function copy_element_to_clipboard(target, callback){
-    // IE
-    if(window.clipboardData){
-        window.clipboardData.setData("Text", target.innerText);
-    } 
-    else{
-        var temp = $('<textarea>');
-        temp.css({
-            position: "absolute",
-            left:     "-1000px",
-            top:      "-1000px",
-        });       
-        
-        // Create a temporary element for copying the text.
-        // Prepend <br> with newlines because jQuery .text() strips the <br>'s and we use .text() because we don't want all of the html tags copied to the clipboard.
-        var text = $(target).clone().find('br').prepend('\r\n').end().text().trim();
-        temp.text(text);
-        $("body").append(temp);
-        temp.trigger('select');
-        
-        // Try to copy the selection and if it fails display a popup to copy manually.
-        if(document.execCommand('copy')) { 
-            callback();
-        } else {
-            alert('Copy failed. Copy the command manually: ' + target.innerText);
-        }
-        temp.remove(); // Remove temporary element.
-    }
-}

--- a/src/main/content/_assets/js/server-commands.js
+++ b/src/main/content/_assets/js/server-commands.js
@@ -362,40 +362,6 @@ $(document).ready(function () {
             }).stop().fadeIn().delay(3500).fadeOut();
         });	
     });
-    
-    /* Copy the target element to the clipboard
-    target: element to copy
-    callback: function to run if the copy is successful
-    */
-    function copy_element_to_clipboard(target, callback){
-        // IE
-        if(window.clipboardData){
-            window.clipboardData.setData("Text", target.innerText);
-        } 
-        else{
-            var temp = $('<textarea>');
-            temp.css({
-                position: "absolute",
-                left:     "-1000px",
-                top:      "-1000px",
-            });       
-            
-            // Create a temporary element for copying the text.
-            // Prepend <br> with newlines because jQuery .text() strips the <br>'s and we use .text() because we don't want all of the html tags copied to the clipboard.
-            var text = $(target).clone().find('br').prepend('\r\n').end().text().trim();
-            temp.text(text);
-            $("body").append(temp);
-            temp.trigger('select');
-            
-            // Try to copy the selection and if it fails display a popup to copy manually.
-            if(document.execCommand('copy')) { 
-                callback();
-            } else {
-                alert('Copy failed. Copy the command manually: ' + target.innerText);
-            }
-            temp.remove(); // Remove temporary element.
-        }
-    }
 });
 
 // Change height of toc if footer is in view so that fixed toc isn't visible through footer

--- a/src/main/content/antora_ui/src/js/11-copy-to-clipboard.js
+++ b/src/main/content/antora_ui/src/js/11-copy-to-clipboard.js
@@ -69,7 +69,8 @@ $(document).ready(function () {
             
             // Create a temporary element for copying the text.
             // Prepend <br> with newlines because jQuery .text() strips the <br>'s and we use .text() because we don't want all of the html tags copied to the clipboard.
-            var text = $(target).clone().find('br').prepend('\r\n').end().text().trim();
+            // Remove <b> tags that contain callouts
+            var text = $(target).clone().find('br').prepend('\r\n').end().find("b").remove().end().text().trim();
             temp.text(text);
             $("body").append(temp);
             temp.trigger('select');


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

