### PR TITLE
Replace spaces with underscores in blog post tag links

### DIFF
--- a/src/main/content/_assets/js/post.js
+++ b/src/main/content/_assets/js/post.js
@@ -17,7 +17,7 @@ $.getJSON( "../../../../blog_tags.json", function(data) {
     var tags_html = "";
     $.each(data.blog_tags, function(j, tag) {
         if (tag.posts.indexOf(post_name) > -1) {
-            tags_html = '<a href="/blog/?search=' + tag.name + '" class="post_tag">' + tag.name + '</a>' + '<span>, </span>';
+            tags_html = '<a href="/blog/?search=' + tag.name.replace(" ", "_") + '" class="post_tag">' + tag.name + '</a>' + '<span>, </span>';
             $(".post_tags_container").append(tags_html);
         }
     });


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

