### PR TITLE
Fix feature hashes and move javadoc script after jekyll runs

### DIFF
--- a/scripts/build_jekyll_maven.sh
+++ b/scripts/build_jekyll_maven.sh
@@ -45,22 +45,6 @@ if [ "$JEKYLL_ENV" != "production" ]; then
     fi
 fi
 
-# Determine which branch of docs-javadoc repo to clone
-BRANCH_NAME="prod"
-if [ "$JEKYLL_STAGING_SITE" == "true" ]; then
-    echo "Cloning the staging branch of javadocs"
-    BRANCH_NAME="staging"
-elif [ "$JEKYLL_DRAFT_SITE" == "true" ]; then
-    echo "Cloning the draft branch of javadocs"
-    BRANCH_NAME="draft"
-else
-    echo "Cloning the prod branch of javadocs"
-fi
-# Clone docs-javadoc repo
-pushd src/main/content
-git clone https://github.com/OpenLiberty/docs-javadoc.git --branch $BRANCH_NAME
-popd
-
 # Special external link handling
 pushd gems/ol-target-blank
 gem build ol-target-blank.gemspec
@@ -107,6 +91,22 @@ if [ "$ga" = true ]
     # Set the --future flag to show blogs with date timestamps in the future
     jekyll build --future --source src/main/content --destination target/jekyll-webapp 
 fi
+
+# Determine which branch of docs-javadoc repo to clone
+BRANCH_NAME="prod"
+if [ "$JEKYLL_STAGING_SITE" == "true" ]; then
+    echo "Cloning the staging branch of javadocs"
+    BRANCH_NAME="staging"
+elif [ "$JEKYLL_DRAFT_SITE" == "true" ]; then
+    echo "Cloning the draft branch of javadocs"
+    BRANCH_NAME="draft"
+else
+    echo "Cloning the prod branch of javadocs"
+fi
+# Clone docs-javadoc repo
+pushd src/main/content
+git clone https://github.com/OpenLiberty/docs-javadoc.git --branch $BRANCH_NAME
+popd
 
 # Install Antora packages and build the Antora UI bundle
 ./scripts/build_antora_ui.sh

--- a/src/main/content/antora_ui/src/js/05-features.js
+++ b/src/main/content/antora_ui/src/js/05-features.js
@@ -41,8 +41,12 @@ function highlightSelectedVersion(){
 function checkForNonVersionedPage(){
     if($('.feature_version').length > 0){
         var url = window.location.href;
-        var version = url.substring(url.lastIndexOf('/') + 1);
-        if($('.feature_version[href="' + version + '"]').length === 0){
+        var urlWithoutHash = url;
+        if(url.indexOf('#') > -1){
+            urlWithoutHash = url.substring(0, url.indexOf('#'));
+        }        
+        var href = urlWithoutHash.substring(urlWithoutHash.indexOf('/reference/feature/') + 19);
+        if($('.feature_version[href="' + href + '"]').length === 0){
             // Redirect to the highest version
             var href = $('.feature_version').first().attr('href');
             var newUrl = url.substring(0,url.lastIndexOf('/')) + '/' + href;


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

