### PR TITLE
Fix doc hash scrolling; Move javadoc clone after jekyll runs

### DIFF
--- a/scripts/build_jekyll_maven.sh
+++ b/scripts/build_jekyll_maven.sh
@@ -45,22 +45,6 @@ if [ "$JEKYLL_ENV" != "production" ]; then
     fi
 fi
 
-# Determine which branch of docs-javadoc repo to clone
-BRANCH_NAME="prod"
-if [ "$JEKYLL_STAGING_SITE" == "true" ]; then
-    echo "Cloning the staging branch of javadocs"
-    BRANCH_NAME="staging"
-elif [ "$JEKYLL_DRAFT_SITE" == "true" ]; then
-    echo "Cloning the draft branch of javadocs"
-    BRANCH_NAME="draft"
-else
-    echo "Cloning the prod branch of javadocs"
-fi
-# Clone docs-javadoc repo
-pushd src/main/content
-git clone https://github.com/OpenLiberty/docs-javadoc.git --branch $BRANCH_NAME
-popd
-
 # Special external link handling
 pushd gems/ol-target-blank
 gem build ol-target-blank.gemspec
@@ -107,6 +91,22 @@ if [ "$ga" = true ]
     # Set the --future flag to show blogs with date timestamps in the future
     jekyll build --future --source src/main/content --destination target/jekyll-webapp 
 fi
+
+# Determine which branch of docs-javadoc repo to clone
+BRANCH_NAME="prod"
+if [ "$JEKYLL_STAGING_SITE" == "true" ]; then
+    echo "Cloning the staging branch of javadocs"
+    BRANCH_NAME="staging"
+elif [ "$JEKYLL_DRAFT_SITE" == "true" ]; then
+    echo "Cloning the draft branch of javadocs"
+    BRANCH_NAME="draft"
+else
+    echo "Cloning the prod branch of javadocs"
+fi
+# Clone docs-javadoc repo
+pushd src/main/content
+git clone https://github.com/OpenLiberty/docs-javadoc.git --branch $BRANCH_NAME
+popd
 
 # Install Antora packages and build the Antora UI bundle
 ./scripts/build_antora_ui.sh

--- a/src/main/content/_assets/js/openliberty.js
+++ b/src/main/content/_assets/js/openliberty.js
@@ -8,10 +8,14 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-
-$(document).ready(function() {
+var openliberty = (function() {
+    $(document).ready(function() {
+    var scrollAllowed = true;
     var prevScrollTop = 0;
 	$(window).scroll(function() {
+        if(!scrollAllowed){
+            return;
+        }
         var currScrollTop = $(this).scrollTop();
         // if scrolled past nav bar, determine whether to hide or show nav bar
         if (currScrollTop > $("#nav_bar").outerHeight()) {
@@ -170,3 +174,18 @@ function copy_element_to_clipboard(target, callback){
         temp.remove(); // Remove temporary element.
     }
 }
+
+function preventScrolling(){
+    scrollAllowed = false;
+}
+
+function allowScrolling(){
+    scrollAllowed = true;
+}
+
+return {
+    preventScrolling: preventScrolling,
+    allowScrolling: allowScrolling
+};
+})();
+

--- a/src/main/content/antora_ui/src/js/02-fragment-jumper.js
+++ b/src/main/content/antora_ui/src/js/02-fragment-jumper.js
@@ -18,8 +18,10 @@
     if (e) {
       window.location.hash = '#' + this.id
       e.preventDefault()
-    }
-    window.scrollTo(0, computePosition(this, 0) - toolbar.getBoundingClientRect().bottom)
+    }    
+    navScroll.preventScrolling();
+    window.scrollTo(0, computePosition(this, 0) - $(".toolbar").outerHeight() - 15);
+    navScroll.allowScrolling();
   }
 
   window.addEventListener('load', function jumpOnLoad (e) {

--- a/src/main/content/antora_ui/src/js/05-features.js
+++ b/src/main/content/antora_ui/src/js/05-features.js
@@ -41,8 +41,12 @@ function highlightSelectedVersion(){
 function checkForNonVersionedPage(){
     if($('.feature_version').length > 0){
         var url = window.location.href;
-        var version = url.substring(url.lastIndexOf('/') + 1);
-        if($('.feature_version[href="' + version + '"]').length === 0){
+        var urlWithoutHash = url;
+        if(url.indexOf('#') > -1){
+            urlWithoutHash = url.substring(0, url.indexOf('#'));
+        }        
+        var href = urlWithoutHash.substring(urlWithoutHash.indexOf('/reference/feature/') + 19);
+        if($('.feature_version[href="' + href + '"]').length === 0){
             // Redirect to the highest version
             var href = $('.feature_version').first().attr('href');
             var newUrl = url.substring(0,url.lastIndexOf('/')) + '/' + href;

--- a/src/main/content/antora_ui/src/js/10-navscroll.js
+++ b/src/main/content/antora_ui/src/js/10-navscroll.js
@@ -8,10 +8,14 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-
-$(document).ready(function() {
+var navScroll = (function(){
+    $(document).ready(function() {
+    var scrollAllowed = true;
     var prevScrollTop = 0;
 	$(window).scroll(function() {
+        if(!scrollAllowed){
+            return;
+        }
         var currScrollTop = $(this).scrollTop();
         // if scrolled past nav bar, determine whether to hide or show nav bar
         if (currScrollTop > $("#nav_bar").outerHeight()) {
@@ -135,3 +139,19 @@ function hideNav() {
     // move config breadcrumb back up when nav bar slides out of view
     $(".contentStickyBreadcrumbHeader").css("top", $(".toolbar").outerHeight() + "px");
 }
+
+function preventScrolling(){
+    scrollAllowed = false;
+}
+
+function allowScrolling(){
+    scrollAllowed = true;
+}
+
+return {
+    showNav: showNav,
+    hideNav: hideNav,
+    preventScrolling: preventScrolling,
+    allowScrolling: allowScrolling
+}
+})();


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

