### PR TITLE
Revert "Bump highlight.js from 9.15.10 to 10.1.2 in /src/main/content/antora_ui"

### DIFF
--- a/src/main/content/antora_ui/package-lock.json
+++ b/src/main/content/antora_ui/package-lock.json
@@ -6498,9 +6498,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.1.2.tgz",
-      "integrity": "sha512-Q39v/Mn5mfBlMff9r+zzA+gWxRsCRKwEMvYTiisLr/XUiFI/4puWt0Ojdko3R3JCNWGdOWaA5g/Yxqa23kC5AA==",
+      "version": "9.15.10",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz",
+      "integrity": "sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==",
       "dev": true
     },
     "hmac-drbg": {

--- a/src/main/content/antora_ui/package.json
+++ b/src/main/content/antora_ui/package.json
@@ -37,7 +37,7 @@
     "gulp-uglify": "~3.0",
     "gulp-vinyl-zip": "~2.1 >=2.1.2",
     "handlebars": "~4.7",
-    "highlight.js": "~10.1",
+    "highlight.js": "~9.15",
     "js-yaml": "~3.13",
     "merge-stream": "~2.0",
     "node-sass": "^4.14.1",


### PR DESCRIPTION
Reverts OpenLiberty/openliberty.io#1949

This caused a break:

> [02:30:14] Starting 'build'...
[02:30:17] gulp-imagemin: Minified 14 images (saved 24.8 kB - 59.7%)
[02:30:17] 'build' errored after 2.65 s
[02:30:17] Error: Cannot find module 'highlight.js/lib/languages/cs' from '/home/pipeline/2e1b1020-4c07-4072-9a82-c526cb029b0d/src/main/content/antora_ui/src/js/vendor'
    at /home/pipeline/2e1b1020-4c07-4072-9a82-c526cb029b0d/src/main/content/antora_ui/node_modules/browser-resolve/node_modules/resolve/lib/async.js:46:17
    at process (/home/pipeline/2e1b1020-4c07-4072-9a82-c526cb029b0d/src/main/content/antora_ui/node_modules/browser-resolve/node_modules/resolve/lib/async.js:173:43)
    at ondir (/home/pipeline/2e1b1020-4c07-4072-9a82-c526cb029b0d/src/main/content/antora_ui/node_modules/browser-resolve/node_modules/resolve/lib/async.js:188:17)
    at load (/home/pipeline/2e1b1020-4c07-4072-9a82-c526cb029b0d/src/main/content/antora_ui/node_modules/browser-resolve/node_modules/resolve/lib/async.js:69:43)
    at onex (/home/pipeline/2e1b1020-4c07-4072-9a82-c526cb029b0d/src/main/content/antora_ui/node_modules/browser-resolve/node_modules/resolve/lib/async.js:92:31)
    at /home/pipeline/2e1b1020-4c07-4072-9a82-c526cb029b0d/src/main/content/antora_ui/node_modules/browser-resolve/node_modules/resolve/lib/async.js:22:47
    at FSReqCallback.oncomplete (fs.js:158:21)