### PR TITLE
Set nokogiri to v1.10.10 due to failing build

### DIFF
--- a/scripts/build/gem_dependencies.sh
+++ b/scripts/build/gem_dependencies.sh
@@ -1,5 +1,6 @@
 echo "Installing ruby packages..."
 gem install jekyll -v 3.8.6
-gem install bundler jekyll-feed jekyll-asciidoc jekyll-include-cache coderay uglifier octopress-minify-html octokit
+gem install nokogiri -v 1.10.10
 gem install jekyll-assets -v 2.4.0
+gem install bundler jekyll-feed jekyll-asciidoc jekyll-include-cache coderay uglifier octopress-minify-html octokit
 gem uninstall -i /usr/local/rvm/gems/ruby-2.4.1@global rubygems-bundler


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
This was due to the most recent version of a ruby gem failing our builds with the current ruby version:

```  
Successfully built RubyGem
  Name: ol-target-blank
  Version: 0.0.1
  File: ol-target-blank-0.0.1.gem
Building native extensions.  This could take a while...
ERROR:  Error installing ol-target-blank-0.0.1.gem:
	nokogiri requires Ruby version < 3.1.dev, >= 2.5.
Successfully installed racc-1.5.2 
```

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

