### PR TITLE
Upgrade ruby to 2.5.7 and remove nokogiri fixed version

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,8 +13,8 @@ cat $SCRIPT_DIR/gpg/pkuczynski.asc | gpg --import -
 curl -sSL https://get.rvm.io | bash -s stable
 source /usr/local/rvm/scripts/rvm
 rvm requirements
-rvm install 2.4.1
-rvm use 2.4.1 --default
+rvm install 2.5.7
+rvm use 2.5.7 --default
 
 # Print out default locale and change it to en_US.UTF-8
 echo "Default locale:"

--- a/scripts/build/gem_dependencies.sh
+++ b/scripts/build/gem_dependencies.sh
@@ -1,6 +1,5 @@
 echo "Installing ruby packages..."
 gem install jekyll -v 3.8.6
-gem install nokogiri -v 1.10.10
 gem install jekyll-assets -v 2.4.0
 gem install bundler jekyll-feed jekyll-asciidoc jekyll-include-cache coderay uglifier octopress-minify-html octokit
 gem uninstall -i /usr/local/rvm/gems/ruby-2.4.1@global rubygems-bundler

--- a/scripts/build/ruby_install.sh
+++ b/scripts/build/ruby_install.sh
@@ -8,16 +8,14 @@ cat $BUILD_SCRIPTS_DIR/../gpg/pkuczynski.asc | gpg --import -
 curl -sSL https://get.rvm.io | bash -s stable
 source /usr/local/rvm/scripts/rvm
 rvm requirements
-rvm install 2.4.1
-rvm use 2.4.1 --default
+rvm install 2.5.7
+rvm use 2.5.7 --default
 echo "Ruby version:"
 echo `ruby -v`
 
 gem install jekyll -v 3.8.6
-gem install nokogiri -v 1.10.10
 gem install jekyll-assets -v 2.4.0
 gem install bundler jekyll-feed jekyll-asciidoc jekyll-include-cache coderay uglifier octopress-minify-html octokit
-gem uninstall -i /usr/local/rvm/gems/ruby-2.4.1@global rubygems-bundler
 
 timer_end=$(date +%s)
 echo "Total execution time for installing Ruby and required packages/gems: '$(date -u --date @$(( $timer_end - $timer_start )) +%H:%M:%S)'"

--- a/scripts/build_gem_dependencies.sh
+++ b/scripts/build_gem_dependencies.sh
@@ -1,6 +1,5 @@
 echo "Installing ruby packages..."
 gem install jekyll -v 3.8.6
-gem install nokogiri -v 1.10.10
 gem install jekyll-assets -v 2.4.0
 gem install bundler jekyll-feed jekyll-asciidoc jekyll-include-cache coderay uglifier octopress-minify-html octokit
 gem uninstall -i /usr/local/rvm/gems/ruby-2.4.1@global rubygems-bundler


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

