### PR TITLE
Update staging site memory

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -23,7 +23,7 @@ applications:
   routes:
     - route: openlibertydev.mybluemix.net
 - name: staging-openlibertyio
-  memory: 256M
+  memory: 384M
   routes:
     - route: staging-openlibertyio.mybluemix.net
 - name: ui-staging-openlibertyio


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Staging deployments keep failing for `https://staging-openlibertyio.mybluemix.net/`. Error messages in cf logs say `./app/wlp/usr/servers/defaultServer/apps/myapp.war/img/guide: Cannot mkdir: Disk quota exceeded` so i am going to try and increase the memory of the app.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

