### PR TITLE
Improve the doc link macro to work with single version features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,13 @@
 .project
 .classpath
 .DS_Store
-src/main/content/javadocs/*/stylesheet.css
 /_site
+src/main/content/robots.txt
+src/main/content/javadocs/*/stylesheet.css
+src/main/content/_assets/js/custom-include-processor.js
 src/main/content/antora_ui/public/
 src/main/content/antora_ui/node_modules/
+src/main/content/antora_ui/src/partials/noindex.hbs
 .asset-cache
 /**/.jekyll-cache
 /node_modules/

--- a/scripts/build/ToC_parse_features.py
+++ b/scripts/build/ToC_parse_features.py
@@ -88,56 +88,54 @@ for version in versions:
             commonTOCMatchString = commonTOCs[commonTOC]
             matchingTitleTOCs = featureIndex.find_all('a', {'class': 'nav-link'}, href=re.compile(commonTOCMatchString))
             firstElement = True;
-            # determine whether there are multiple versions
-            if len(matchingTitleTOCs) > 1:
-                # multiple versions of the same title found, put the versions at the top of the page
-                firstHref = matchingTitleTOCs[0].get('href')
-                featurePage  = BeautifulSoup(open(antora_path + '/feature/' + firstHref), "lxml")
-                pageTitle = featurePage.find('h1', {'class': 'page'})
-                titleDiv = featurePage.new_tag('div', id='feature_name')
-                versionDiv = featurePage.new_tag('div', id='feature_versions')
-                pageTitle.string = ''
-                newTOCHref = ''
-                # in reverse descending order
-                matchingTOCs = matchingTitleTOCs[::-1]
-                for matchingTOC in matchingTOCs:
-                    tocHref = matchingTOC.get('href')
-                    if firstElement:
-                        firstElement = False
-                        hrefSplits = tocHref.split('/')
-                        lastHrefSplit = hrefSplits[-1]
-                        htmlSplits = lastHrefSplit.split('-')
-                        lastMatch = re.search(r'\d*.html$', htmlSplits[-1])
-                        if lastMatch:
-                            del htmlSplits[-1]
-                            combineHtml = "-".join(htmlSplits) + '.html'
-                            del hrefSplits[-1]
-                            newTOCHref = '/'.join(hrefSplits) + '/' + combineHtml
-                            title = createTitle(featurePage, tocHref, matchingTOC.string)
-                            titleDiv.append(title)
-                            hrefTag = createVersionHref(featurePage, tocHref, matchingTOC.string)
-                            versionDiv.append(hrefTag)
-                    else:
+            # determine whether there are multiple versions            
+            firstHref = matchingTitleTOCs[0].get('href')
+            featurePage  = BeautifulSoup(open(antora_path + '/feature/' + firstHref), "lxml")
+            pageTitle = featurePage.find('h1', {'class': 'page'})
+            titleDiv = featurePage.new_tag('div', id='feature_name')
+            versionDiv = featurePage.new_tag('div', id='feature_versions')
+            pageTitle.string = ''
+            newTOCHref = ''
+            # in reverse descending order
+            matchingTOCs = matchingTitleTOCs[::-1]
+            for matchingTOC in matchingTOCs:
+                tocHref = matchingTOC.get('href')
+                if firstElement:
+                    firstElement = False
+                    hrefSplits = tocHref.split('/')
+                    lastHrefSplit = hrefSplits[-1]
+                    htmlSplits = lastHrefSplit.split('-')
+                    lastMatch = re.search(r'\d*.html$', htmlSplits[-1])
+                    if lastMatch:
+                        del htmlSplits[-1]
+                        combineHtml = "-".join(htmlSplits) + '.html'
+                        del hrefSplits[-1]
+                        newTOCHref = '/'.join(hrefSplits) + '/' + combineHtml
+                        title = createTitle(featurePage, tocHref, matchingTOC.string)
+                        titleDiv.append(title)
                         hrefTag = createVersionHref(featurePage, tocHref, matchingTOC.string)
                         versionDiv.append(hrefTag)
-                        TOCToDecompose.append(matchingTOC.parent)
-                # Write the feature title and the versions to the page div
-                pageTitle.append(titleDiv)
-                pageTitle.append(versionDiv)
+                else:
+                    hrefTag = createVersionHref(featurePage, tocHref, matchingTOC.string)
+                    versionDiv.append(hrefTag)
+                    TOCToDecompose.append(matchingTOC.parent)
+            # Write the feature title and the versions to the page div
+            pageTitle.append(titleDiv)
+            pageTitle.append(versionDiv)
 
-                # write to the common version doc with the highest versioned content
-                with open(antora_path + 'feature' +  newTOCHref, "w") as file:
-                    file.write(str(featurePage))
-                
-                # Go through the matching TOC pages and write the version switcher to the top of the page
-                for matchingTOC in matchingTOCs:
-                    # Open page and rewrite the version part
-                    versionHref = antora_path + 'feature/' + matchingTOC.get('href')
-                    versionPage = BeautifulSoup(open(versionHref), "lxml")
-                    versionTitle = versionPage.find('h1', {'class': 'page'})
-                    versionTitle.replace_with(pageTitle)
-                    with open(versionHref, "w") as file:
-                        file.write(str(versionPage))
+            # write to the common version doc with the highest versioned content
+            with open(antora_path + 'feature' +  newTOCHref, "w") as file:
+                file.write(str(featurePage))
+            
+            # Go through the matching TOC pages and write the version switcher to the top of the page
+            for matchingTOC in matchingTOCs:
+                # Open page and rewrite the version part
+                versionHref = antora_path + 'feature/' + matchingTOC.get('href')
+                versionPage = BeautifulSoup(open(versionHref), "lxml")
+                versionTitle = versionPage.find('h1', {'class': 'page'})
+                versionTitle.replace_with(pageTitle)
+                with open(versionHref, "w") as file:
+                    file.write(str(versionPage))
 
         for TOC in TOCToDecompose:
             TOC.decompose()

--- a/src/main/content/antora_ui/package-lock.json
+++ b/src/main/content/antora_ui/package-lock.json
@@ -1361,9 +1361,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
-      "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
     },
     "bach": {
@@ -6353,9 +6353,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.12.4",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
-          "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -7498,7 +7498,7 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
       "dev": true
     },
     "json-stable-stringify": {
@@ -11056,9 +11056,9 @@
           }
         },
         "y18n": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+          "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
           "dev": true
         },
         "yargs": {
@@ -13368,7 +13368,7 @@
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
@@ -13377,7 +13377,7 @@
         "punycode": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
           "dev": true
         }
       }

--- a/src/main/content/antora_ui/src/js/05-features.js
+++ b/src/main/content/antora_ui/src/js/05-features.js
@@ -9,8 +9,13 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-// Setup and listen to version clicks
+// Setup and listen to version clicks if there is more than one version of a feature on the version picker.
 function addVersionClick(){
+    if($('.feature_version').length ===  1){
+        // If there's just one version, then disable the hover/click behavior for the version.
+        $('.feature_version').css('cursor', 'default');
+        return;
+    }
     var onclick = function(event) {
         var resource = $(event.currentTarget);
         var href = resource.attr("href");
@@ -18,7 +23,7 @@ function addVersionClick(){
         var newUrl = url.substring(0,url.lastIndexOf('/')) + '/' + href;
         window.location.href = newUrl;
     };
-    $(".feature_version").on("click", onclick);
+    $(".feature_version").on("click", onclick);       
 }
 
 function acivateNavMenu(){


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Removed the check if there is more than one instance of a feature in the TOC, for creating a landing page for the feature. This enables the doc macro to work for single versions of features. I also removed the hover ability and click if there's only one feature version as a result of enabling the extra code for single features.

Added a few files to the .gitignore that were always changed when running the build locally.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

