### PR TITLE
Fix accessibility issue

### DIFF
--- a/src/main/content/_layouts/guide-multipane.html
+++ b/src/main/content/_layouts/guide-multipane.html
@@ -28,7 +28,7 @@ js:
 <!-- Remove any documents deemed private (archived, templates, etc) -->
 {% for guide in all-markdown-files %}
     {% unless guide.archived or guide.path contains "guides/guides-template" or guide.path contains "guides/guides-common" or guide.path contains "guides/iguides-common" %}
-        {% assign all-guides = all-guides | push: guide %} 
+        {% assign all-guides = all-guides | push: guide %}
     {% endunless %}
 {% endfor %}
 
@@ -49,8 +49,8 @@ js:
 {% assign all_guides_by_date = all-guides | sort: "releasedate" | reverse %}
 
 <div id="background_container">
-        <div id="toc_hotspot"></div>            
-        <!-- Guide's table of contents section -->            
+        <div id="toc_hotspot"></div>
+        <!-- Guide's table of contents section -->
         <div id="toc_column" class="collapse inline open">
             <div id="toc_inner">
                 {% assign toc = page.document | tocify_asciidoc %}
@@ -66,8 +66,8 @@ js:
                 {% endif %}
                 <h3 id="tag_title">Tags</h3>
                 <div id="tags_container"></div>
-            </div>                                
-        </div>      
+            </div>
+        </div>
         <div id="toc_indicator" tabindex="0" aria-label="Open the table of contents" class="hidden">
             <img src="/img/arrow_white.svg" alt="arrow">
         </div>
@@ -85,7 +85,7 @@ js:
                         <!-- Add New flag to guides from the past 30 days or 4 most recent posts. -->
                         <!-- If new posts count is less than 4, use 4 most recent posts -->
                         {% if new_guide_count < 4 %}
-                            {% if page.title ==  all_guides_by_date[0].title or page.title ==  all_guides_by_date[1].title 
+                            {% if page.title ==  all_guides_by_date[0].title or page.title ==  all_guides_by_date[1].title
                             or page.title ==  all_guides_by_date[2].title or page.title ==  all_guides_by_date[3].title %}
                                 <div class="new_guide_container">
                                     <span class="guide_new">New</span>
@@ -112,7 +112,7 @@ js:
                 </div>
 
                 <div class="scroller_anchor"></div>
-                <div role="menu" id="mobile_toc_accordion_container" data-toggle="collapse" data-target="#toc_column" aria-expanded="false" aria-controls="toc_column">
+                <div role="menu" id="mobile_toc_accordion_container" data-toggle="collapse" data-target="#toc_column" aria-expanded="false" aria-controls="toc_column" role="button">
                     <div role="menuitem" id="mobile_toc_accordion">
                         <button class="breadcrumb_hamburger toc-toggle collapsed" type="button" tabindex="0">
                                 <span class="sr-only">Toggle navigation</span>
@@ -127,7 +127,7 @@ js:
 
                 <!-- Guide content section -->
                 {{ content }}
-            
+
             </div>
             <div id="guide_section_copied_confirmation">Copied to clipboard</div>
             <img id="copy_to_clipboard" src='/img/guides_copy_button.svg' alt='Copy code block' title='Copy code block'>
@@ -138,7 +138,7 @@ js:
             <div id='code_column_title_container'>
                 <div id='code_column_tabs_container' class='dimmed'>
                     <ul id='code_column_tabs' class='nav' role='tablist'></ul>
-                </div>                    
+                </div>
                 <div class='copyFileButton' tabindex="0">
                     <img src='/img/guides_copy_button.svg' alt='Copy file contents' title='Copy file contents'>
                 </div>

--- a/src/main/content/_layouts/guide-multipane.html
+++ b/src/main/content/_layouts/guide-multipane.html
@@ -112,7 +112,7 @@ js:
                 </div>
 
                 <div class="scroller_anchor"></div>
-                <div role="menu" id="mobile_toc_accordion_container" data-toggle="collapse" data-target="#toc_column" aria-expanded="false" aria-controls="toc_column" role="button">
+                <div id="mobile_toc_accordion_container" data-toggle="collapse" data-target="#toc_column" aria-expanded="false" aria-controls="toc_column" role="button">
                     <div role="menuitem" id="mobile_toc_accordion">
                         <button class="breadcrumb_hamburger toc-toggle collapsed" type="button" tabindex="0">
                                 <span class="sr-only">Toggle navigation</span>

--- a/src/main/content/_layouts/guide.html
+++ b/src/main/content/_layouts/guide.html
@@ -109,7 +109,7 @@ js:
                 </div>
 
                 <div class="scroller_anchor"></div>
-                <div role="menu" id="mobile_toc_accordion_container" data-toggle="collapse" data-target="#toc_column" aria-expanded="false" aria-controls="toc_column" role="button">
+                <div id="mobile_toc_accordion_container" data-toggle="collapse" data-target="#toc_column" aria-expanded="false" aria-controls="toc_column" role="button">
                     <div role="menuitem" id="mobile_toc_accordion">
                         <button class="breadcrumb_hamburger toc-toggle collapsed" type="button" tabindex="0">
                                 <span class="sr-only">Toggle navigation</span>

--- a/src/main/content/_layouts/guide.html
+++ b/src/main/content/_layouts/guide.html
@@ -26,7 +26,7 @@ js:
 <!-- Remove any documents deemed private (archived, templates, etc) -->
 {% for guide in all-markdown-files %}
     {% unless guide.archived or guide.path contains "guides/guides-template" or guide.path contains "guides/guides-common" or guide.path contains "guides/iguides-common" %}
-        {% assign all-guides = all-guides | push: guide %} 
+        {% assign all-guides = all-guides | push: guide %}
     {% endunless %}
 {% endfor %}
 
@@ -48,7 +48,7 @@ js:
 
 <div id="background_container">
     <div class="toc_hotspot">
-        <!-- Guide's table of contents section -->            
+        <!-- Guide's table of contents section -->
         <div id="toc_column" class="collapse inline open">
             <div id="toc_inner">
                 {% assign toc = page.document | tocify_asciidoc %}
@@ -64,8 +64,8 @@ js:
                 {% endif %}
                 <h3 id="tag_title">Tags</h3>
                 <div id="tags_container"></div>
-            </div>                                
-        </div> 
+            </div>
+        </div>
         <div id="toc_indicator" tabindex="0" aria-label="Open the table of contents" class="hidden">
             <img src="/img/arrow_white.svg" alt="arrow">
         </div>
@@ -83,7 +83,7 @@ js:
                         <!-- Add New flag to guides from the past 30 days or 4 most recent posts. -->
                         <!-- If new posts count is less than 4, use 4 most recent posts -->
                         {% if new_guide_count < 4 %}
-                            {% if page.title ==  all_guides_by_date[0].title or page.title ==  all_guides_by_date[1].title 
+                            {% if page.title ==  all_guides_by_date[0].title or page.title ==  all_guides_by_date[1].title
                             or page.title ==  all_guides_by_date[2].title or page.title ==  all_guides_by_date[3].title %}
                                 <div class="new_guide_container">
                                     <span class="guide_new">New</span>
@@ -109,7 +109,7 @@ js:
                 </div>
 
                 <div class="scroller_anchor"></div>
-                <div role="menu" id="mobile_toc_accordion_container" data-toggle="collapse" data-target="#toc_column" aria-expanded="false" aria-controls="toc_column">
+                <div role="menu" id="mobile_toc_accordion_container" data-toggle="collapse" data-target="#toc_column" aria-expanded="false" aria-controls="toc_column" role="button">
                     <div role="menuitem" id="mobile_toc_accordion">
                         <button class="breadcrumb_hamburger toc-toggle collapsed" type="button" tabindex="0">
                                 <span class="sr-only">Toggle navigation</span>
@@ -124,20 +124,20 @@ js:
 
                 <!-- Guide content section -->
                 {{ content }}
-            
+
             </div>
             <div id="guide_section_copied_confirmation">Copied to clipboard</div>
             <img id="copy_to_clipboard" src='/img/guides_copy_button.svg' alt='Copy code block' title='Copy code block'>
-        </div> 
-        
-    </div>    
+        </div>
+
+    </div>
 </div>
 
 <div id="end_of_guide_background">
     <div class="centered_content">
-        {% include end-of-guide.html %} 
-    </div>         
-</div>    
+        {% include end-of-guide.html %}
+    </div>
+</div>
 
 
 

--- a/src/main/content/_layouts/iguide-multipane.html
+++ b/src/main/content/_layouts/iguide-multipane.html
@@ -24,7 +24,7 @@ js:
 <!-- Remove any documents deemed private (archived, templates, etc) -->
 {% for guide in all-markdown-files %}
     {% unless guide.archived or guide.path contains "guides/guides-template" or guide.path contains "guides/guides-common" or guide.path contains "guides/iguides-common" %}
-        {% assign all-guides = all-guides | push: guide %} 
+        {% assign all-guides = all-guides | push: guide %}
     {% endunless %}
 {% endfor %}
 
@@ -78,7 +78,7 @@ js:
                     <!-- Add New flag to guides from the past 30 days or 4 most recent posts. -->
                     <!-- If new posts count is less than 4, use 4 most recent posts -->
                     {% if new_guide_count < 4 %}
-                        {% if page.title ==  all_guides_by_date[0].title or page.title ==  all_guides_by_date[1].title 
+                        {% if page.title ==  all_guides_by_date[0].title or page.title ==  all_guides_by_date[1].title
                         or page.title ==  all_guides_by_date[2].title or page.title ==  all_guides_by_date[3].title %}
                             <div class="new_guide_container">
                                 <span class="guide_new">New</span>
@@ -107,7 +107,7 @@ js:
 
             <!-- This div is used to indicate the original position of the scrollable fixed div. -->
             <div class="scroller_anchor"></div>
-            <div id="mobile_toc_accordion_container" data-toggle="collapse" data-target="#toc_column" aria-expanded="false" aria-controls="toc_column">
+            <div id="mobile_toc_accordion_container" data-toggle="collapse" data-target="#toc_column" aria-expanded="false" aria-controls="toc_column" role="button">
                 <div id="mobile_toc_accordion">
                     <button class="breadcrumb_hamburger toc-toggle collapsed" type="button" tabindex="0">
                             <span class="sr-only">Toggle navigation</span>


### PR DESCRIPTION
Copied from PR https://github.com/OpenLiberty/openliberty.io/pull/2037

#### What was fixed?  (Issue # or description of fix)
Accessibility Checker flagged an issue with the TOC <div> element.

<img width="429" alt="image" src="https://user-images.githubusercontent.com/29490139/107989152-9b3ecf00-6f9f-11eb-91ba-a642c93a196d.png">

This fixes the issue by setting the TOC `<div>` that is visible when the window width is thin so that the guide appears as a single column to have `role="button"`.   The `<div>` acts as a button causing the TOC to appear when it is selected and 'aria-expanded' is valid for a button.

#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
- [ ] 
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [x] Accessibility Checker
- [ ] Lighthouse (in Chrome dev tools)



This issue was fixed as part of https://github.com/openliberty/iguide-microprofile-config-intro/issues/254