### PR TITLE
Remove italicize formatting from doc lists

### DIFF
--- a/src/main/content/antora_ui/src/css/doc.css
+++ b/src/main/content/antora_ui/src/css/doc.css
@@ -519,10 +519,6 @@
   display: none;
 }
 
-.doc .dlist dt {
-  font-style: italic;
-}
-
 .doc .dlist dd {
   margin: 0 0 0.3rem 1.5rem;
 }

--- a/src/main/content/antora_ui/src/partials/head-info.hbs
+++ b/src/main/content/antora_ui/src/partials/head-info.hbs
@@ -1,5 +1,5 @@
     {{#if page.url}}
-    <link rel="canonical" href="https://openliberty.io{{replace_version page.url '21.0.0.1' }}">
+    <link rel="canonical" href="https://openliberty.io{{replace_version page.url '21.0.0.2' }}">
     {{/if}}
     {{#if page.component}}
     {{#if page.keywords}}

--- a/src/main/content/sitemap.xml
+++ b/src/main/content/sitemap.xml
@@ -8,7 +8,7 @@
         <changefreq>monthly</changefreq>
     </url>
     <url>
-        <loc>https://openliberty.io/docs/21.0.0.1/overview.html</loc>
+        <loc>https://openliberty.io/docs/21.0.0.2/overview.html</loc>
         <changefreq>weekly</changefreq>
     </url>
     <url>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
The documentation team wants to remove italicize formatting from the lists like `--password=pwd` in this topic: https://docs-draft-openlibertyio.mybluemix.net/docs/21.0.0.3/reference/command/securityUtility-createLTPAKeys.html.
Before:
![image](https://user-images.githubusercontent.com/6392944/108727648-69bd8a80-74ee-11eb-827a-c9806595c920.png)
After:
![image](https://user-images.githubusercontent.com/6392944/108727694-73df8900-74ee-11eb-9a52-a5c0f4003ce8.png)
 
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

