### PR TITLE
Fix TOC formatting issues

### DIFF
--- a/src/main/content/_assets/js/openliberty.js
+++ b/src/main/content/_assets/js/openliberty.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,7 +25,7 @@ var openliberty = (function() {
             // if scrolling down, hide nav bar
             if (currScrollTop > prevScrollTop) {
                 hideNav();
-            } 
+            }
             // if scrolling up, show nav bar
             else {
                 showNav();
@@ -71,7 +71,7 @@ function showNav() {
 
     // push toc column, toc indicator and code column down below nav bar
     $("#toc_column").css("top", nav_height + "px");
-    if (window.outerWidth > 1440) {
+    if (window.innerWidth > 1440) {
         $("#toc_inner").css("margin-top", nav_height + "px");
     }
     $("#toc_indicator").css("margin-top", nav_height + "px");
@@ -92,7 +92,7 @@ function showNav() {
 
     // adjust docs toolbar and nav position
     $(".toolbar").css("top", nav_height + "px");
-    if (window.outerWidth < 1024) {
+    if (window.innerWidth < 1024) {
         $(".nav-container").css("top", nav_height + $(".toolbar").outerHeight() + "px");
         $(".nav").css("top", "");
     }
@@ -112,7 +112,7 @@ function hideNav() {
 
     // reset toc column, toc indicator and code column position
     $("#toc_column").css("top", "0px");
-    if (window.outerWidth > 1440) {
+    if (window.innerWidth > 1440) {
         $("#toc_inner").css("margin-top", "0px");
     }
     $("#toc_indicator").css("margin-top", "0px");
@@ -127,7 +127,7 @@ function hideNav() {
 
     // adjust docs toolbar and nav position
     $(".toolbar").css("top", "0px");
-    if (window.outerWidth < 1024) {
+    if (window.innerWidth < 1024) {
         $(".nav-container").css("top", $(".toolbar").outerHeight() + "px");
         $(".nav").css("top", "");
     }
@@ -148,15 +148,15 @@ function copy_element_to_clipboard(target, callback){
     // IE
     if(window.clipboardData){
         window.clipboardData.setData("Text", target.innerText);
-    } 
+    }
     else{
         var temp = $('<textarea>');
         temp.css({
             position: "absolute",
             left:     "-1000px",
             top:      "-1000px",
-        });       
-        
+        });
+
         // Create a temporary element for copying the text.
         // Prepend <br> with newlines because jQuery .text() strips the <br>'s and we use .text() because we don't want all of the html tags copied to the clipboard.
         // Remove <b> tags that contain callouts
@@ -164,9 +164,9 @@ function copy_element_to_clipboard(target, callback){
         temp.text(text);
         $("body").append(temp);
         temp.trigger('select');
-        
+
         // Try to copy the selection and if it fails display a popup to copy manually.
-        if(document.execCommand('copy')) { 
+        if(document.execCommand('copy')) {
             callback();
         } else {
             alert('Copy failed. Copy the command manually: ' + target.innerText);

--- a/src/main/content/_assets/js/toc.js
+++ b/src/main/content/_assets/js/toc.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,7 @@ $(window).on('scroll', function(event) {
     if ($(this).scrollTop() > nav_bottom){
         $('#toc_indicator').css({'position': 'fixed', 'top': '0px'});
 
-        if (window.outerWidth < 1440) {
+        if (window.innerWidth < 1440) {
             $('#toc_column').css({'position': 'fixed', 'top': '0px'});
         }
     }
@@ -49,7 +49,7 @@ function disableFloatingTOC() {
 }
 
 function enableFloatingTOC() {
-    $('#toc_inner').css({"position":"fixed", "top":"0px"});    
+    $('#toc_inner').css({"position":"fixed", "top":"0px"});
 }
 
 function calculateTOCHeight(){
@@ -59,7 +59,7 @@ function calculateTOCHeight(){
 
 function shrinkTOCIndicator() {
     $('#toc_line').css({
-        "position": "", 
+        "position": "",
         "top": "0px",
         "height": calculateTOCHeight()
     });
@@ -86,7 +86,7 @@ function updateTOCHighlighting(id) {
 function handleTOCScrolling() {
     var visible_background_height = heightOfVisibleBackground();
     var toc_height = $('#toc_inner').height();
-    if (toc_height > visible_background_height && window.outerWidth > threeColumnBreakpoint) {
+    if (toc_height > visible_background_height && window.innerWidth > threeColumnBreakpoint) {
         // The TOC cannot fit in the dark background, allow the TOC to scroll out of viewport
         // to avoid the TOC overflowing out of the dark background
         var negativeNumber = visible_background_height - toc_height + 100;
@@ -113,7 +113,7 @@ function handleFloatingTOCAccordion() {
         // which causes a bounce in the page.
         $('.scroller_anchor').css('height', accordion.height());
         // Fix the TOC accordion to the top of the page.
-        accordion.addClass('fixed_toc_accordion');        
+        accordion.addClass('fixed_toc_accordion');
     };
 
     if(inSingleColumnView()){
@@ -205,7 +205,7 @@ function open_TOC(){
         }
         $("#guide_column").removeClass('expanded');
 
-        $("#toc_line").addClass("open");            
+        $("#toc_line").addClass("open");
         $("#toc_column").addClass("open");
         $("#guide_column").addClass("open");
 
@@ -235,7 +235,7 @@ function close_TOC(){
     $("#guide_column").removeClass("open");
 
     // if in 3 column view and user closes TOC, show bounce animation
-    if (window.outerWidth >= threeColumnBreakpoint) {
+    if (window.innerWidth >= threeColumnBreakpoint) {
         $("#toc_indicator").removeClass('hidden');
         TocIndicatorBounce();
     }
@@ -246,7 +246,7 @@ function close_TOC(){
     restoreCurrentStep();
 }
 
-function setInitialTOCLineHeight(){  
+function setInitialTOCLineHeight(){
     $("#toc_line").css(
         {'height': calculateTOCHeight()}
     );
@@ -270,14 +270,14 @@ $(document).ready(function() {
         TocIndicatorBounce();
     }
     reorganizeTOCElements();
-    setInitialTOCLineHeight();    
+    setInitialTOCLineHeight();
 
     // Add listener for clicking on the
     $("#toc_hotspot, #toc_indicator").on('mouseenter', function(){
         // Animate out the arrow and highlight the left side of the screen orange to indicate there is a TOC
         if(!$("#toc_indicator").hasClass('open')){
-            $("#toc_indicator").addClass('open');            
-        }        
+            $("#toc_indicator").addClass('open');
+        }
     });
 
     $("#toc_hotspot").on('mouseleave', function(){
@@ -286,7 +286,7 @@ $(document).ready(function() {
             var y = event.y;
             var headerHeight = $('header').height();
             var indicatorHeight = $("#toc_indicator").outerHeight();
-            
+
             y = y - headerHeight;
             if(x >= 0 && x <= this.offsetWidth && y >= 0 && y <= indicatorHeight){
                 // Still hovering over the TOC indicator arrow, so don't remove the orange line and arrow.
@@ -294,7 +294,7 @@ $(document).ready(function() {
             }
 
             $("#toc_indicator").removeClass('open');
-        }        
+        }
     });
 
     $("#toc_indicator").on('click', function(){
@@ -306,7 +306,7 @@ $(document).ready(function() {
             open_TOC();
         }
     });
-    
+
     $("#breadcrumb_hamburger").on('click', function(){
         // Handle resizing of the guide column when collapsing/expanding the TOC in 3 column view.
         if(window.innerWidth >= threeColumnBreakpoint){
@@ -321,7 +321,7 @@ $(document).ready(function() {
             restoreCurrentStep();
         }
         // Handle table of content floating if in the middle of the guide.
-        handleFloatingTableOfContent();        
+        handleFloatingTableOfContent();
     });
 
     //In single column view, set focus on 'X' initially when TOC is expanded
@@ -381,11 +381,11 @@ $(document).ready(function() {
         }
     });
 
-    var width = window.outerWidth;
+    var width = window.innerWidth;
     $(window).on('resize', function() {
 
         // going from 3 column to 2 column view
-        if (width >= threeColumnBreakpoint && $(this).outerWidth() < threeColumnBreakpoint) {
+        if (width >= threeColumnBreakpoint && $(this).innerWidth() < threeColumnBreakpoint) {
             if (!$('#guide_column').hasClass('expanded')) {
                 TocIndicatorBounce();
             }
@@ -393,13 +393,13 @@ $(document).ready(function() {
         }
 
         // going from single column to 2 column view
-        if (width < twoColumnBreakpoint && $(this).outerWidth() >= twoColumnBreakpoint) {
+        if (width < twoColumnBreakpoint && $(this).innerWidth() >= twoColumnBreakpoint) {
             // close_TOC();
             TocIndicatorBounce();
         }
 
         // going from 2 column to 3 column view
-        if (width < threeColumnBreakpoint && $(this).outerWidth() >= threeColumnBreakpoint) {
+        if (width < threeColumnBreakpoint && $(this).innerWidth() >= threeColumnBreakpoint) {
             console.log("going from 2 col to 3 col view");
             $('#toc_column').css({'position': '', 'top': ''});
         }
@@ -415,8 +415,8 @@ $(document).ready(function() {
         }
 
         // update width with new width after resizing
-        if ($(this).outerWidth() != width) {
-            width = $(this).outerWidth();
+        if ($(this).innerWidth() != width) {
+            width = $(this).innerWidth();
         }
 
     });


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Copied from #2051.

Fixes issue #1924 and #1878.

I was unable to recreate the problem that Steven described in the issue. My problems with the TOC displayed improperly are also described in the issue. I traced it down to having a zoom level in my browser window other than 100%. This was causing window.outerWidth to return what seemed to be an incorrect value to designate one-, two-, or three-column formatting for the guide. It turned out that window.innerWidth seemed to be the value we were after in toc.js to determine the layout of the guide, and in looking at the code, had been used in many of our calculations already. In particular, the change from window.outerWidth to window.innerWidth made in toc.js on line 18 solved the majority of both problems Steven and I were seeing. I also made several other changes from outWidth to innerWidth and tested each one and they seem to solve the other problems described in issue #1924 as well.

It should be noted that we use window.outerWidth in guides.js, which executes when the user is on the openliberty.io/guides page. But switching out outerWidth to innerWidth in this file caused issues, especially going from one- to two-columns in the smaller widths. So, since I did not see any obvious formatting issues on this page I decided to leave guides.js alone.

#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

