### PR TITLE
Merge to prod - Scroll selected TOC item to view

### DIFF
--- a/src/main/content/antora_ui/src/js/01-nav.js
+++ b/src/main/content/antora_ui/src/js/01-nav.js
@@ -12,6 +12,9 @@ var navigation = (function(){
     var menuPanel = navContainer.querySelector('[data-panel=menu]');
     if (!menuPanel) return;
 
+    // Expand all first level doc categories
+    $(".nav-menu > .nav-list > .nav-item").addClass('is-active');
+
     var currentPageItem = menuPanel.querySelector('.is-current-page');
     if (currentPageItem) {
       activateCurrentPath(currentPageItem);
@@ -37,7 +40,7 @@ var navigation = (function(){
 
     document.querySelector('.nav-container .nav .context').addEventListener('click', function () {
       var currentPanel = document.querySelector('.nav .is-active[data-panel]');
-      var activatePanel = currentPanel.dataset.panel === 'menu' ? 'explore' : 'menu';	
+      var activatePanel = currentPanel.dataset.panel === 'menu' ? 'explore' : 'menu';
       currentPanel.classList.toggle('is-active');
       document.querySelector('.nav [data-panel=' + activatePanel + ']').classList.toggle('is-active');
     });
@@ -59,10 +62,7 @@ var navigation = (function(){
       if (e.detail > 1) e.preventDefault();
     });
 
-    // Expand all first level doc categories
-    $(".nav-menu > .nav-list > .nav-item").addClass('is-active')
-
-  };  
+  };
 
   $('.components .versions li a').on('click', function(e){
     e.stopPropagation();
@@ -120,13 +120,13 @@ var navigation = (function(){
       }
     }
   }
-  
-  
+
+
   function closeVersionPicker (e) {
     if($('.nav-panel-explore').hasClass('is-active')){
       $('.nav-panel-explore').toggleClass('is-active');
       $('.nav-panel-menu').toggleClass('is-active'); // Change active panel to the nav menu
-    }    
+    }
   }
 
   function showNav (e) {
@@ -164,7 +164,16 @@ var navigation = (function(){
     var effectiveHeight = rect.height;
     var navStyle = window.getComputedStyle(nav);
     if (navStyle.position === 'sticky') effectiveHeight -= rect.top - parseFloat(navStyle.top);
-    panel.scrollTop = Math.max(0, (el.getBoundingClientRect().height - effectiveHeight) * 0.5 + el.offsetTop);
+
+    var elementHeight = el.getBoundingClientRect().height;
+    if ((el.offsetTop + elementHeight) > effectiveHeight) {
+      // If you must scroll to see the TOC element, then move TOC so that the element
+      // is displayed about the middle of the TOC.
+      panel.scrollTop = Math.max(0, (elementHeight - effectiveHeight) * 0.5 + el.offsetTop);
+    } else {
+      // Else, just leave the user on the initial TOC (at the top) with the element highlighted.
+      panel.scrollTop = 0;
+    }
   }
 
   return {


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Reference Issue #1742.

When an element that appears lower in the TOC, so that the user must scroll the TOC to reach the element, the browser page is refreshed with the new doc content showing.  However, the TOC may not be scrolled so that the selected element is in view.

The expected behavior on the Antora website (see docs.antora.org) is for the TOC entry for the selected item to be scrolled into view as well as highlighted.

The problem occurs within 01-nav.js.  Within init(), the TOC is adjusted so that the selected item is displayed with a call to `scrollItemToMidpoint(tocElement)`.   However, at the very end of this method we adjust the height of the TOC by expanding all first level TOC categories with this statement:
`$(".nav-menu > .nav-list > .nav-item").addClass('is-active');`

Now, the TOC, which had been previously adjusted to show the selected element, has itself had its height changed so that the selected element may no longer be in view.  To fix, I moved the above statement that expands all the first level TOC categories to be above the call to `scrollItemToMidpoint(tocElement)` so that the adjustment of the TOC to display the selected element can be made accurately.

I also updated `scrollItemToMidpoint(tocelement)' so that if the selected tocElement is displayed when the TOC is scrolled to the top then the adjustment to move the selected tocElement to the middle of the TOC div will not occur so as to avoid too much page movement.

#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [x] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)


