### PR TITLE
Fix downloads page string to reflect MicroProfile 4 package download

### DIFF
--- a/src/main/content/_assets/js/builds.js
+++ b/src/main/content/_assets/js/builds.js
@@ -111,8 +111,11 @@ function render_builds(builds, parent) {
                         else if (package_name.indexOf("web") > -1) {
                             var package_column = "<td headers='" + tableID + "_package'>Web Profile 8</td>";
                         }
-                        else if (package_name.indexOf("microprofile") > -1) {
+                        else if (package_name.indexOf("microprofile3") > -1) {
                             var package_column = '<td headers="' + tableID + '_package">MicroProfile 3</td>';
+                        }
+                        else if (package_name.indexOf("microprofile4") > -1) {
+                            var package_column = '<td headers="' + tableID + '_package">MicroProfile 4</td>';
                         }
                         else if (package_name.indexOf("kernel") > -1) {
                             var package_column = '<td headers="' + tableID + '_package">Kernel</td>';


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Add check for MicroProfile 4 in the package locations since new releases will use 4.

![image](https://user-images.githubusercontent.com/6392944/111789925-a97a5680-888f-11eb-8cba-b09a941bacb5.png)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

