### PR TITLE
Remove blog redirects from ui repo, that are now in the blogs repo.

### DIFF
--- a/src/main/content/antora_ui/src/partials/head-info.hbs
+++ b/src/main/content/antora_ui/src/partials/head-info.hbs
@@ -1,5 +1,5 @@
     {{#if page.url}}
-    <link rel="canonical" href="https://openliberty.io{{replace_version page.url '21.0.0.2' }}">
+    <link rel="canonical" href="https://openliberty.io{{replace_version page.url '21.0.0.3' }}">
     {{/if}}
     {{#if page.component}}
     {{#if page.keywords}}

--- a/src/main/content/sitemap.xml
+++ b/src/main/content/sitemap.xml
@@ -8,7 +8,7 @@
         <changefreq>monthly</changefreq>
     </url>
     <url>
-        <loc>https://openliberty.io/docs/21.0.0.2/overview.html</loc>
+        <loc>https://openliberty.io/docs/21.0.0.3/overview.html</loc>
         <changefreq>weekly</changefreq>
     </url>
     <url>

--- a/src/main/webapp/WEB-INF/ui-redirects.properties
+++ b/src/main/webapp/WEB-INF/ui-redirects.properties
@@ -17,17 +17,5 @@
 /community/=/support/
 /community=/support/
 
-# Blogs redirects. NOTE: These will move to the blogs repo in the future for customization by the blogs team.
-/news/=/blog/
-/news=/blog/
-/news/*=/blog/
-/blogs=/blog/
-/blogs/=/blog/
-/blog/2017/11/29/liberty-spring-boot.html=/guides/spring-boot.html
-/blog/2019/03/01/microprofile-concurrency.html=/blog/2019/08/16/microprofile-context-propagation.html
-/blog/2019/05/24/testing-database-connections-REST-APIs.html=/blog/2019/09/13/testing-database-connections-REST-APIs.html
-/blog/2019/09/13/microprofile-reactive-messsaging-19009.html=/blog/2019/09/13/microprofile-reactive-messaging-19009.html
-/blog/2019/11/07/ibm-red-hat-support-open-liberty.html=/blog/?search=OpenShift
-
 # Guides
 /guides/microprofile-intro.html=/guides/cdi-intro.html


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
The file exists in the blogs repo in prod at https://github.com/OpenLiberty/blogs/blob/prod/blog-redirects.properties.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

