### PR TITLE
Change how the text is used in the skills network button area

### DIFF
--- a/src/main/content/_assets/js/guide-static.js
+++ b/src/main/content/_assets/js/guide-static.js
@@ -53,9 +53,10 @@
         var skills_network_url = host === "openliberty.io" ? data.skillNetworkUrl : data.stagingSkillNetworkUrl;
         skills_network_url = skills_network_url.replace('{projectid}', guide_name);
         if(data.guides.indexOf(guide_name) > -1){
-            $('.skills_network_description').text(data.tooltipText);
+            $('.skills_network_description').text(data.buttonLabel);
             var skills_network_button = $('<a class="skills_network_button" target="_blank" rel="noopener"></a>');
             skills_network_button.attr('href', skills_network_url);
+            skills_network_button.attr('title', data.tooltipText);
 
             var skills_network_button_text = $('<div class="skills_network_button_text"></div>');
             skills_network_button_text.text(data.buttonText);


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Use the buttonLabel for the text left of the button and tooltipText for when you hover over the button. Data comes from https://github.com/OpenLiberty/guides-common/blob/dev/cloud-hosted-guides.json. Example at: https://draft-openlibertyio.mybluemix.net/guides/getting-started.html
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

