### PR TITLE
Move to Prod - Correct tables so bottom border doesn't extend beyond content

### DIFF
--- a/src/main/content/antora_ui/src/css/doc.css
+++ b/src/main/content/antora_ui/src/css/doc.css
@@ -165,11 +165,13 @@
   border-collapse: collapse;
   font-size: calc(15 / var(--rem-base) * 1rem);
   margin: 2rem 0;
-  display: block;
-  overflow-x: auto;
   /* enable table-layout: fixed if you want the table width to be enforced strictly */
   /* alternative is to wrap table in div and set overflow-x: auto on the wrapper */
   /* table-layout: fixed; */
+}
+
+.doc table.stretch {
+  width: 100%;
 }
 
 .doc table.spread {


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Coped from PR #2073 


Please refer to issue #1866.

To summarize, many tables appeared with their bottom borders extending past their cell content, like this

![image](https://user-images.githubusercontent.com/29490139/113314071-83ae7200-92d1-11eb-8e7d-f44537f7a3ec.png)

This occurs when the cell content was small enough that it did not need to expand to another line within any of the cells.  By changing the formatting for the `<table>` elements back to `display: table` (default) from `display: block` the cells were again able to format correctly to reach 100% of the containing content block width.

![image](https://user-images.githubusercontent.com/29490139/113313951-61b4ef80-92d1-11eb-82ca-4aa1755b48b2.png)

Note that depending on the browser window width, some tables simply cannot shrink down the cell content any further and there may be a need to scroll the table data horizontally.   With the `<table>` element width set to `display: table`, the horizontal scrolling for pages containing wide width tables falls on the page itself and you will see a horizontal scroll bar appear at the bottom of the browser window.   This can best be seen with our largest tables, for example
https://openliberty.io/docs/21.0.0.3/reference/metrics-1-dif.html or
https://openliberty.io/docs/21.0.0.3/reference/metrics-1-dif.html
But my testing showed the rest of the pages containing tables should not be affected at decent window sizes.  There still is a chance that, if the browser window width is made slimmer, other pages containing tables will also show a horizontal scrollbar if the table cell data is unable to flow further to another line within the cell.  However, especially on these large tables, it is much easier to read the data in the table with the horizontal scrollbar being located on the page and not on the table itself to prevent constant scrolling up and down the height of the table to reach the scrollbar while you are traversing the table.

Also note that there had been code added that set the `<table>` elements width to be (100% + 20px) in config.css.  This caused unnecessary scrolling in some tables and the  width of 100% seems to work better.  Therefore, I added to the CSS a block to set the table widths to 100%, as defined by the `stretch` class in asciiDoc.

#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)


- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

