### PR TITLE
Make sub lists 14px so they aren't larger than the first level of lists

### DIFF
--- a/src/main/content/_assets/css/openliberty.scss
+++ b/src/main/content/_assets/css/openliberty.scss
@@ -88,7 +88,7 @@ div.sectionbody div.ulist > ul, div.sectionbody > div.olist > ol {
     padding-left: 20px;
 }
 
-div.sectionbody div.ulist > ul > li > p, div.sectionbody > div.olist > ol > li > p {
+div.sectionbody div.ulist > ul > li p, div.sectionbody > div.olist > ol > li p {
     font-size: 14px;
     color: #24243B;
     letter-spacing: 0;

--- a/src/main/content/antora_ui/src/sass/openliberty.scss
+++ b/src/main/content/antora_ui/src/sass/openliberty.scss
@@ -87,7 +87,7 @@ div.sectionbody div.ulist > ul, div.sectionbody > div.olist > ol {
     padding-left: 20px;
 }
 
-div.sectionbody div.ulist > ul > li > p, div.sectionbody > div.olist > ol > li > p {
+div.sectionbody div.ulist > ul > li p, div.sectionbody > div.olist > ol > li p {
     font-size: 14px;
     color: #24243B;
     letter-spacing: 0;


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
This is to fix the problem here: https://blogs-draft-openlibertyio.mybluemix.net/blog/2021/04/15/admin-center-21004.html
where the inner lists are larger text than their parent:
![image](https://user-images.githubusercontent.com/6392944/113883116-7edf3780-9783-11eb-8883-0dc71b3c7688.png)

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

