### PR TITLE
Merge from Staging - Scroll TOC at 1440 width when EOGuide comes in

### DIFF
--- a/src/main/content/_assets/js/toc.js
+++ b/src/main/content/_assets/js/toc.js
@@ -86,7 +86,7 @@ function updateTOCHighlighting(id) {
 function handleTOCScrolling() {
     var visible_background_height = heightOfVisibleBackground();
     var toc_height = $('#toc_inner').height();
-    if (toc_height > visible_background_height && window.innerWidth > threeColumnBreakpoint) {
+    if (toc_height > visible_background_height && window.innerWidth >= threeColumnBreakpoint) {
         // The TOC cannot fit in the dark background, allow the TOC to scroll out of viewport
         // to avoid the TOC overflowing out of the dark background
         var negativeNumber = visible_background_height - toc_height + 100;


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Copied from #2080

Fixes issue #2072.

It seemed that at exactly a window width of 1440, the TOC height did not end properly but ran into the `#end_of_guide` section as portrayed in #2072.    In Toc.js, the handleTOCScrolling() method was setting scrolling into place for widths > 1440 instead of >= 1440.


#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

