### PR TITLE
Remove octopress-minify-html gem and uglifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ src/main/content/antora_ui/src/partials/noindex.hbs
 .asset-cache
 /**/.jekyll-cache
 /node_modules/
+src/main/webapp/WEB-INF/*-redirects.properties
+!src/main/webapp/WEB-INF/ui-redirects.properties

--- a/scripts/build/clone_certifications.sh
+++ b/scripts/build/clone_certifications.sh
@@ -25,14 +25,9 @@ fi
 
 echo "Cloning the $BRANCH_NAME branch of certifications repository..."
 
-mkdir certifications
-cd certifications
+git clone https://github.com/OpenLiberty/certifications.git --branch $BRANCH_NAME
 
-# This is how you clone a repo without autocreating a parent folder with the name of the repo
-# The clone is picky about cloning into a folder that is not empty (src/main/content)
-git clone https://github.com/OpenLiberty/certifications.git --branch $BRANCH_NAME .
-
-# Move the blog redirect file to the WEB-INF directory
+# Move the certifications redirect file to the WEB-INF directory
 if [ -f certifications/cert-redirects.properties ]; then
    echo "Moving the certifications redirects file"
    mv certifications/cert-redirects.properties src/main/webapp/WEB-INF/cert-redirects.properties

--- a/scripts/build/clone_certifications.sh
+++ b/scripts/build/clone_certifications.sh
@@ -30,7 +30,7 @@ git clone https://github.com/OpenLiberty/certifications.git --branch $BRANCH_NAM
 # Move the certifications redirect file to the WEB-INF directory
 if [ -f certifications/cert-redirects.properties ]; then
    echo "Moving the certifications redirects file"
-   mv certifications/cert-redirects.properties src/main/webapp/WEB-INF/cert-redirects.properties
+   mv certifications/cert-redirects.properties ../webapp/WEB-INF/cert-redirects.properties
 fi
 
 popd

--- a/scripts/build/clone_certifications.sh
+++ b/scripts/build/clone_certifications.sh
@@ -31,5 +31,12 @@ cd certifications
 # This is how you clone a repo without autocreating a parent folder with the name of the repo
 # The clone is picky about cloning into a folder that is not empty (src/main/content)
 git clone https://github.com/OpenLiberty/certifications.git --branch $BRANCH_NAME .
+
+# Move the blog redirect file to the WEB-INF directory
+if [ -f certifications/cert-redirects.properties ]; then
+   echo "Moving the certifications redirects file"
+   mv certifications/cert-redirects.properties src/main/webapp/WEB-INF/cert-redirects.properties
+fi
+
 popd
 echo "Done cloning certifications repository!"

--- a/scripts/build/jekyll.sh
+++ b/scripts/build/jekyll.sh
@@ -69,5 +69,5 @@ if [ "$PROD_SITE" = true ]
     jekyll build --source src/main/content --config src/main/content/_config.yml,src/main/content/_google_analytics.yml --destination target/jekyll-webapp 
   else
     # Set the --future flag to show blogs with date timestamps in the future
-    jekyll build --future --source src/main/content --destination target/jekyll-webapp 
+    jekyll build --future --source src/main/content --destination target/jekyll-webapp --verbose
 fi

--- a/scripts/build/ruby_install.sh
+++ b/scripts/build/ruby_install.sh
@@ -18,7 +18,7 @@ echo `ruby -v`
 
 gem install jekyll -v 3.8.6
 gem install jekyll-assets -v 2.4.0
-gem install bundler jekyll-feed jekyll-asciidoc jekyll-include-cache coderay uglifier octokit
+gem install bundler jekyll-feed jekyll-asciidoc jekyll-include-cache coderay octokit
 
 timer_end=$(date +%s)
 echo "Total execution time for installing Ruby and required packages/gems: '$(date -u --date @$(( $timer_end - $timer_start )) +%H:%M:%S)'"

--- a/scripts/build/ruby_install.sh
+++ b/scripts/build/ruby_install.sh
@@ -18,7 +18,7 @@ echo `ruby -v`
 
 gem install jekyll -v 3.8.6
 gem install jekyll-assets -v 2.4.0
-gem install bundler jekyll-feed jekyll-asciidoc jekyll-include-cache coderay octokit
+gem install bundler jekyll-feed jekyll-asciidoc jekyll-include-cache coderay octopress-minify-html octokit
 
 timer_end=$(date +%s)
 echo "Total execution time for installing Ruby and required packages/gems: '$(date -u --date @$(( $timer_end - $timer_start )) +%H:%M:%S)'"

--- a/scripts/build/ruby_install.sh
+++ b/scripts/build/ruby_install.sh
@@ -16,10 +16,9 @@ rvm use 2.5.7 --default
 echo "Ruby version:"
 echo `ruby -v`
 
-
 gem install jekyll -v 3.8.6
 gem install jekyll-assets -v 2.4.0
-gem install bundler jekyll-feed jekyll-asciidoc jekyll-include-cache coderay uglifier octopress-minify-html octokit
+gem install bundler jekyll-feed jekyll-asciidoc jekyll-include-cache coderay uglifier octokit
 
 timer_end=$(date +%s)
 echo "Total execution time for installing Ruby and required packages/gems: '$(date -u --date @$(( $timer_end - $timer_start )) +%H:%M:%S)'"

--- a/scripts/build/ruby_install.sh
+++ b/scripts/build/ruby_install.sh
@@ -18,7 +18,7 @@ echo `ruby -v`
 
 gem install jekyll -v 3.8.6
 gem install jekyll-assets -v 2.4.0
-gem install bundler jekyll-feed jekyll-asciidoc jekyll-include-cache coderay octopress-minify-html octokit
+gem install bundler jekyll-feed jekyll-asciidoc jekyll-include-cache coderay octokit
 
 timer_end=$(date +%s)
 echo "Total execution time for installing Ruby and required packages/gems: '$(date -u --date @$(( $timer_end - $timer_start )) +%H:%M:%S)'"

--- a/src/main/content/_assets/css/openliberty.scss
+++ b/src/main/content/_assets/css/openliberty.scss
@@ -88,8 +88,8 @@ div.sectionbody div.ulist > ul, div.sectionbody > div.olist > ol {
     padding-left: 20px;
 }
 
-div.sectionbody div.ulist > ul > li p, div.sectionbody > div.olist > ol > li p {
-    font-size: 16px;
+div.sectionbody div.ulist > ul > li > p, div.sectionbody > div.olist > ol > li > p {
+    font-size: 14px;
     color: #24243B;
     letter-spacing: 0;
     margin-bottom: 13px;

--- a/src/main/content/_assets/css/openliberty.scss
+++ b/src/main/content/_assets/css/openliberty.scss
@@ -88,7 +88,7 @@ div.sectionbody div.ulist > ul, div.sectionbody > div.olist > ol {
     padding-left: 20px;
 }
 
-div.sectionbody div.ulist > ul > li > p, div.sectionbody > div.olist > ol > li > p {
+div.sectionbody div.ulist > ul > li p, div.sectionbody > div.olist > ol > li p {
     font-size: 14px;
     color: #24243B;
     letter-spacing: 0;

--- a/src/main/content/_assets/css/openliberty.scss
+++ b/src/main/content/_assets/css/openliberty.scss
@@ -89,11 +89,15 @@ div.sectionbody div.ulist > ul, div.sectionbody > div.olist > ol {
 }
 
 div.sectionbody div.ulist > ul > li p, div.sectionbody > div.olist > ol > li p {
-    font-size: 14px;
+    font-size: 16px;
     color: #24243B;
     letter-spacing: 0;
     margin-bottom: 13px;
-    margin-top: 13px;
+    margin-top: 13px;    
+}
+
+div.sectionbody div.ulist > ul ul > li p, div.sectionbody > div.olist > ol ol > li p {
+    font-size: 14px;
 }
 
 div.sectionbody > div.enableByList > ul > li > p {

--- a/src/main/content/_config.yml
+++ b/src/main/content/_config.yml
@@ -29,16 +29,12 @@ assets:
     css: true
     js: true
 
-env: production
-minify_html: true
-
 plugins:
   - jekyll-feed
   - jekyll-asciidoc
   - jekyll-assets
   - jekyll-include-cache
   - ol-target-blank
-  - octopress-minify-html
 exclude:
   - vendor # TravisCI bundles all gems in the vendor directory on its build servers, which Jekyll will mistakenly read and explode on.
   - docs

--- a/src/main/content/_config.yml
+++ b/src/main/content/_config.yml
@@ -46,3 +46,4 @@ exclude:
   - "*.gendoc"
   - "*.examples"
   - antora_ui
+  - certifications/TCKResults.adoc

--- a/src/main/content/_config.yml
+++ b/src/main/content/_config.yml
@@ -29,12 +29,16 @@ assets:
     css: true
     js: true
 
+env: production
+minify_html: true
+
 plugins:
   - jekyll-feed
   - jekyll-asciidoc
   - jekyll-assets
   - jekyll-include-cache
   - ol-target-blank
+  - octopress-minify-html
 exclude:
   - vendor # TravisCI bundles all gems in the vendor directory on its build servers, which Jekyll will mistakenly read and explode on.
   - docs

--- a/src/main/content/_dev_config.yml
+++ b/src/main/content/_dev_config.yml
@@ -14,8 +14,6 @@ assets:
     - guides/iguide-retry-timeout/js
     - guides/iguide-retry-timeout/css
 
-minify_html: false
-
 exclude:
   - docs
   - feature

--- a/src/main/content/_dev_config.yml
+++ b/src/main/content/_dev_config.yml
@@ -14,6 +14,8 @@ assets:
     - guides/iguide-retry-timeout/js
     - guides/iguide-retry-timeout/css
 
+minify_html: false
+
 exclude:
   - docs
   - feature

--- a/src/main/content/_layouts/certification.html
+++ b/src/main/content/_layouts/certification.html
@@ -4,6 +4,7 @@ css:
 - header
 - certification
 ---
+{% include noindex.html %}
 
 <div id="article_container" class="container-fluid">
     <article class="post" aria-label="article">

--- a/src/main/content/antora_ui/src/sass/openliberty.scss
+++ b/src/main/content/antora_ui/src/sass/openliberty.scss
@@ -87,12 +87,16 @@ div.sectionbody div.ulist > ul, div.sectionbody > div.olist > ol {
     padding-left: 20px;
 }
 
-div.sectionbody div.ulist > ul > li p, div.sectionbody > div.olist > ol > li p {
+div.sectionbody div.ulist > ul > li > p, div.sectionbody > div.olist > ol > li > p {
     font-size: 14px;
     color: #24243B;
     letter-spacing: 0;
     margin-bottom: 13px;
-    margin-top: 13px;
+    margin-top: 13px;    
+}
+
+div.sectionbody div.ulist > ul ul > li p, div.sectionbody > div.olist > ol ol > li p {
+    font-size: 14px;
 }
 
 div.sectionbody > div.enableByList > ul > li > p {

--- a/src/main/content/antora_ui/src/sass/openliberty.scss
+++ b/src/main/content/antora_ui/src/sass/openliberty.scss
@@ -87,7 +87,7 @@ div.sectionbody div.ulist > ul, div.sectionbody > div.olist > ol {
     padding-left: 20px;
 }
 
-div.sectionbody div.ulist > ul > li > p, div.sectionbody > div.olist > ol > li > p {
+div.sectionbody div.ulist > ul > li p, div.sectionbody > div.olist > ol > li p {
     font-size: 14px;
     color: #24243B;
     letter-spacing: 0;

--- a/src/main/java/io/openliberty/website/RedirectFilter.java
+++ b/src/main/java/io/openliberty/website/RedirectFilter.java
@@ -110,7 +110,7 @@ public class RedirectFilter implements Filter {
      * @throws IOException
      */
     public static void init(ServletContext ctx) throws IOException {
-        String[] files = { "/WEB-INF/ui-redirects.properties", "/WEB-INF/doc-redirects.properties", "/WEB-INF/blog-redirects.properties" };   
+        String[] files = { "/WEB-INF/ui-redirects.properties", "/WEB-INF/doc-redirects.properties", "/WEB-INF/blog-redirects.properties", "/WEB-INF/cert-redirects.properties"  };   
         try {
             Properties props = new Properties();
             for(String file : files){


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
We have to remove the octopress minification tool for html because it pulls in a lot of latest gem versions which break our website build, and that gem is no longer maintained since 2016.
The compressed staging home page html is 6.1 kB, being 20.4 kB uncompressed
The draft site uncompressed html is 6.7 kB / 26 kB

Pingdom shows a 71 score for both compressed/uncompressed 

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [x] Lighthouse (in Chrome dev tools)

