### PR TITLE
Remove octopress html minification gem and uglifier

### DIFF
--- a/scripts/build/jekyll.sh
+++ b/scripts/build/jekyll.sh
@@ -69,5 +69,5 @@ if [ "$PROD_SITE" = true ]
     jekyll build --source src/main/content --config src/main/content/_config.yml,src/main/content/_google_analytics.yml --destination target/jekyll-webapp 
   else
     # Set the --future flag to show blogs with date timestamps in the future
-    jekyll build --future --source src/main/content --destination target/jekyll-webapp 
+    jekyll build --future --source src/main/content --destination target/jekyll-webapp --verbose
 fi

--- a/scripts/build/ruby_install.sh
+++ b/scripts/build/ruby_install.sh
@@ -18,7 +18,7 @@ echo `ruby -v`
 
 gem install jekyll -v 3.8.6
 gem install jekyll-assets -v 2.4.0
-gem install bundler jekyll-feed jekyll-asciidoc jekyll-include-cache coderay uglifier octokit
+gem install bundler jekyll-feed jekyll-asciidoc jekyll-include-cache coderay octokit
 
 timer_end=$(date +%s)
 echo "Total execution time for installing Ruby and required packages/gems: '$(date -u --date @$(( $timer_end - $timer_start )) +%H:%M:%S)'"

--- a/scripts/build/ruby_install.sh
+++ b/scripts/build/ruby_install.sh
@@ -18,7 +18,7 @@ echo `ruby -v`
 
 gem install jekyll -v 3.8.6
 gem install jekyll-assets -v 2.4.0
-gem install bundler jekyll-feed jekyll-asciidoc jekyll-include-cache coderay octokit
+gem install bundler jekyll-feed jekyll-asciidoc jekyll-include-cache coderay octopress-minify-html octokit
 
 timer_end=$(date +%s)
 echo "Total execution time for installing Ruby and required packages/gems: '$(date -u --date @$(( $timer_end - $timer_start )) +%H:%M:%S)'"

--- a/scripts/build/ruby_install.sh
+++ b/scripts/build/ruby_install.sh
@@ -16,10 +16,9 @@ rvm use 2.5.7 --default
 echo "Ruby version:"
 echo `ruby -v`
 
-
 gem install jekyll -v 3.8.6
 gem install jekyll-assets -v 2.4.0
-gem install bundler jekyll-feed jekyll-asciidoc jekyll-include-cache coderay uglifier octopress-minify-html octokit
+gem install bundler jekyll-feed jekyll-asciidoc jekyll-include-cache coderay uglifier octokit
 
 timer_end=$(date +%s)
 echo "Total execution time for installing Ruby and required packages/gems: '$(date -u --date @$(( $timer_end - $timer_start )) +%H:%M:%S)'"

--- a/scripts/build/ruby_install.sh
+++ b/scripts/build/ruby_install.sh
@@ -18,7 +18,7 @@ echo `ruby -v`
 
 gem install jekyll -v 3.8.6
 gem install jekyll-assets -v 2.4.0
-gem install bundler jekyll-feed jekyll-asciidoc jekyll-include-cache coderay octopress-minify-html octokit
+gem install bundler jekyll-feed jekyll-asciidoc jekyll-include-cache coderay octokit
 
 timer_end=$(date +%s)
 echo "Total execution time for installing Ruby and required packages/gems: '$(date -u --date @$(( $timer_end - $timer_start )) +%H:%M:%S)'"

--- a/src/main/content/_config.yml
+++ b/src/main/content/_config.yml
@@ -29,16 +29,12 @@ assets:
     css: true
     js: true
 
-env: production
-minify_html: true
-
 plugins:
   - jekyll-feed
   - jekyll-asciidoc
   - jekyll-assets
   - jekyll-include-cache
   - ol-target-blank
-  - octopress-minify-html
 exclude:
   - vendor # TravisCI bundles all gems in the vendor directory on its build servers, which Jekyll will mistakenly read and explode on.
   - docs

--- a/src/main/content/_config.yml
+++ b/src/main/content/_config.yml
@@ -29,12 +29,16 @@ assets:
     css: true
     js: true
 
+env: production
+minify_html: true
+
 plugins:
   - jekyll-feed
   - jekyll-asciidoc
   - jekyll-assets
   - jekyll-include-cache
   - ol-target-blank
+  - octopress-minify-html
 exclude:
   - vendor # TravisCI bundles all gems in the vendor directory on its build servers, which Jekyll will mistakenly read and explode on.
   - docs

--- a/src/main/content/_dev_config.yml
+++ b/src/main/content/_dev_config.yml
@@ -14,8 +14,6 @@ assets:
     - guides/iguide-retry-timeout/js
     - guides/iguide-retry-timeout/css
 
-minify_html: false
-
 exclude:
   - docs
   - feature

--- a/src/main/content/_dev_config.yml
+++ b/src/main/content/_dev_config.yml
@@ -14,6 +14,8 @@ assets:
     - guides/iguide-retry-timeout/js
     - guides/iguide-retry-timeout/css
 
+minify_html: false
+
 exclude:
   - docs
   - feature


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
We have to remove the octopress minification tool for html because it pulls in a lot of latest gem versions which break our website build, and that gem is no longer maintained since 2016.

We found out none of our other gems need uglifier, so we removed it.

The compressed staging home page html is 6.1 kB, being 20.4 kB uncompressed
The draft site uncompressed html is 6.7 kB / 26 kB

Pingdom shows a 71 score for both compressed/uncompressed
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

