### PR TITLE
Add class to copy to clipboard icon for use in google analytics 

### DIFF
--- a/src/main/content/_assets/js/guide-static.js
+++ b/src/main/content/_assets/js/guide-static.js
@@ -113,8 +113,8 @@
         }
         $('#copy_to_clipboard').css({	
             top: target_position.top + 1,	
-            right: parseInt($('#guide_column').css('padding-right')) + right_position	
-        });
+            right: parseInt($('#guide_column').css('padding-right')) + right_position,	            
+        }).addClass('copy_to_clipboard_git_clone');
         $('#copy_to_clipboard').stop().fadeIn();	
      }).on('mouseleave', function(event) {	
         if(offset){
@@ -123,8 +123,9 @@
             if(!(x > target_position.left	
             && x < target_position.left + target_width	
             && y > target_position.top	
-            && y < target_position.top + target_height)) {	
+            && y < target_position.top + target_height)) {
                 $('#copy_to_clipboard').stop().fadeOut();	
+                $('#copy_to_clipboard').removeClass('copy_to_clipboard_git_clone');
                 $('#guide_section_copied_confirmation').stop().fadeOut();	
             }
         }          	


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Fixes #2008
This will be used in Google Tag Manager to track clones of guides
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

