### PR TITLE
Move noindex copy to *before* the doc build

### DIFF
--- a/scripts/build/antora_build_docs.sh
+++ b/scripts/build/antora_build_docs.sh
@@ -7,11 +7,11 @@ if [ "$PROD_SITE" = true ]
     # use local copy of antora. Once antora is upgraded to 3.0 the line below should be removed and replaced with the above commented out line above
     antora/node_modules/.bin/antora --fetch --stacktrace --google-analytics-key=GTM-TKP3KJ7 src/main/content/docs/antora-playbook.yml
   else
-    # antora --fetch --stacktrace src/main/content/docs/antora-playbook.yml
-    
-    # use local copy of antora. Once antora is upgraded to 3.0 the line below should be removed and replaced with the above commented out line above
-    antora/node_modules/.bin/antora --fetch --stacktrace src/main/content/docs/antora-playbook.yml
-
     # add noindex metdata for non prod sites
     cp src/main/content/_includes/noindex.html src/main/content/antora_ui/src/partials/noindex.hbs
+
+    # antora --fetch --stacktrace src/main/content/docs/antora-playbook.yml
+
+    # use local copy of antora. Once antora is upgraded to 3.0 the line below should be removed and replaced with the above commented out line above
+    antora/node_modules/.bin/antora --fetch --stacktrace src/main/content/docs/antora-playbook.yml
 fi

--- a/scripts/build_antora_dev.sh
+++ b/scripts/build_antora_dev.sh
@@ -7,6 +7,9 @@ npm i -g http-server
 
 ./scripts/build/antora_install.sh
 
+# add noindex metdata for non prod sites
+cp src/main/content/_includes/noindex.html src/main/content/antora_ui/src/partials/noindex.hbs
+
 # Run with the --update flag to fetch the latest doc changes
 if [[ $* == *--update* ]]; then
     ./scripts/build/antora_clone_playbook.sh

--- a/src/main/content/antora_ui/src/js/04-configs.js
+++ b/src/main/content/antora_ui/src/js/04-configs.js
@@ -692,7 +692,12 @@ function createClickableBreadcrumb(breadcrumbText, highlightLastItem) {
                 breadcrumbWidth = $(".contentStickyBreadcrumbHeader .stickyBreadcrumb").width() + paddingWidth;
                 fontSize = fontSize - 2;
             }
-            $(".contentStickyBreadcrumbHeader .stickyBreadcrumb").show();
+            if(window.location.href.includes("server-configuration-overview.html")){
+                $(".contentStickyBreadcrumbHeader").hide();
+            }
+            else{
+                $(".contentStickyBreadcrumbHeader .stickyBreadcrumb").show();
+            }
 
             addContentBreadcrumbClick();
         }


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
I moved the cp of noindex into the docs to *before* the docs are built. It must have got misconfigured during hardcoding the Antora version or while moving build scripts around, because it used to add it to non-prod sites correctly.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

