### PR TITLE
Move noindex before the antora ui build

### DIFF
--- a/scripts/build/antora_build_docs.sh
+++ b/scripts/build/antora_build_docs.sh
@@ -7,11 +7,8 @@ if [ "$PROD_SITE" = true ]
     # use local copy of antora. Once antora is upgraded to 3.0 the line below should be removed and replaced with the above commented out line above
     antora/node_modules/.bin/antora --fetch --stacktrace --google-analytics-key=GTM-TKP3KJ7 src/main/content/docs/antora-playbook.yml
   else
-    # add noindex metdata for non prod sites
-    cp src/main/content/_includes/noindex.html src/main/content/antora_ui/src/partials/noindex.hbs
-
     # antora --fetch --stacktrace src/main/content/docs/antora-playbook.yml
-
+    
     # use local copy of antora. Once antora is upgraded to 3.0 the line below should be removed and replaced with the above commented out line above
     antora/node_modules/.bin/antora --fetch --stacktrace src/main/content/docs/antora-playbook.yml
 fi

--- a/scripts/build/antora_install.sh
+++ b/scripts/build/antora_install.sh
@@ -16,6 +16,11 @@ cd ..
 mv -f src/main/content/_assets/js/custom-include-processor.js antora/node_modules/@antora/asciidoc-loader/lib/include/include-processor.js 
 # Remove the section above when upgrading antora to 3.0
 
+if [ "$PROD_SITE" != "true" ]; then
+    # add noindex metdata for non prod sites
+    cp src/main/content/_includes/noindex.html src/main/content/antora_ui/src/partials/noindex.hbs
+fi
+
 pushd src/main/content/antora_ui
 echo "Installing Antora dependencies"
 # npm install -g @antora/site-generator-default@2.3.3 # add back this line when upgrading antora to 3.0

--- a/scripts/build_antora_dev.sh
+++ b/scripts/build_antora_dev.sh
@@ -5,10 +5,10 @@
 # Install http-server for local site viewing
 npm i -g http-server
 
-./scripts/build/antora_install.sh
-
 # add noindex metdata for non prod sites
 cp src/main/content/_includes/noindex.html src/main/content/antora_ui/src/partials/noindex.hbs
+
+./scripts/build/antora_install.sh
 
 # Run with the --update flag to fetch the latest doc changes
 if [[ $* == *--update* ]]; then


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
I had to move the noindex file again to before the `Antora UI` bundle gets created. It didn't work just moving it right before Antora generates the doc files.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

