### PR TITLE
Parse blogs json during build time and add it to blog front matter

### DIFF
--- a/scripts/build/jekyll.sh
+++ b/scripts/build/jekyll.sh
@@ -58,6 +58,9 @@ $BUILD_SCRIPTS_DIR/clone_certifications.sh
 # Clone draft and published blogs
 $BUILD_SCRIPTS_DIR/clone_blogs.sh
 
+# Read in the blog tags file and add the tag to each blog so jekyll knows how to process them.
+python3 ./script/build/parse_blog_tags.py
+
 # Jekyll build all the cloned content
 echo "Building with jekyll..."
 echo `jekyll -version`

--- a/scripts/build/parse_blog_tags.py
+++ b/scripts/build/parse_blog_tags.py
@@ -7,9 +7,9 @@ tags = content['blog_tags']
 for tag in tags:
     tag_name = tag['name']
     posts = tag['posts']
-    for post in posts:
+    for post_name in posts:
         for file_name in os.listdir("src/main/content/_posts/"):            
-            if os.path.isfile("src/main/content/_posts/" + file_name) and file_name.endswith(post + '.adoc'):
+            if os.path.isfile("src/main/content/_posts/" + file_name) and file_name.endswith(post_name + '.adoc'):
                 f_post = open("src/main/content/_posts/" + file_name)
                 data = f_post.readlines()
                 
@@ -31,4 +31,4 @@ for tag in tags:
                 with open("src/main/content/_posts/" + file_name, 'w') as f_write:
                     f_write.writelines(data)
                     f_write.close()
-        
+f.close()

--- a/scripts/build/parse_blog_tags.py
+++ b/scripts/build/parse_blog_tags.py
@@ -9,7 +9,7 @@ for tag in tags:
     posts = tag['posts']
     for post in posts:
         for file_name in os.listdir("src/main/content/_posts/"):            
-            if os.path.isfile("src/main/content/_posts/" + file_name) and post in file_name:
+            if os.path.isfile("src/main/content/_posts/" + file_name) and file_name.endswith(post + '.adoc'):
                 f_post = open("src/main/content/_posts/" + file_name)
                 data = f_post.readlines()
                 

--- a/scripts/build/parse_blog_tags.py
+++ b/scripts/build/parse_blog_tags.py
@@ -1,0 +1,34 @@
+import json
+import os
+
+f = open("src/main/content/blog_tags.json", "r")
+content = json.loads(f.read())
+tags = content['blog_tags']
+for tag in tags:
+    tag_name = tag['name']
+    posts = tag['posts']
+    for post in posts:
+        for file_name in os.listdir("src/main/content/_posts/"):            
+            if os.path.isfile("src/main/content/_posts/" + file_name) and post in file_name:
+                f_post = open("src/main/content/_posts/" + file_name)
+                data = f_post.readlines()
+                
+                # Check if there is already a tags front-matter from a previous tag
+                line_num = 0
+                tags_line = -1
+                for line in data:
+                    if line.startswith('tags: '):
+                        tags_line = line_num
+                        break
+                    line_num += 1
+                if tags_line != -1:
+                    data[tags_line] = data[tags_line].rstrip('\n') # Remove initial newline
+                    data[tags_line] = data[tags_line] + ' ' + tag_name + '\n'
+                else:
+                    # Otherwise, add the tags after the first line of front-matter
+                    data[2] = 'tags: ' + tag_name + '\n' + data[2]
+
+                with open("src/main/content/_posts/" + file_name, 'w') as f_write:
+                    f_write.writelines(data)
+                    f_write.close()
+        

--- a/scripts/build/parse_blog_tags.py
+++ b/scripts/build/parse_blog_tags.py
@@ -22,11 +22,11 @@ for tag in tags:
                         break
                     line_num += 1
                 if tags_line != -1:
-                    data[tags_line] = data[tags_line].rstrip('\n') # Remove initial newline
-                    data[tags_line] = data[tags_line] + ' ' + tag_name + '\n'
+                    data[tags_line] = data[tags_line].replace(']', '').rstrip('\n') # Remove end bracket and initial newline
+                    data[tags_line] = data[tags_line] + ', "' + tag_name + '"]\n'
                 else:
                     # Otherwise, add the tags after the first line of front-matter
-                    data[2] = 'tags: ' + tag_name + '\n' + data[2]
+                    data[2] = 'tags: ["' + tag_name + '"]\n' + data[2] 
 
                 with open("src/main/content/_posts/" + file_name, 'w') as f_write:
                     f_write.writelines(data)

--- a/src/main/content/jakartaee.xml
+++ b/src/main/content/jakartaee.xml
@@ -13,7 +13,7 @@ permalink: /jakartaee.xml
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>
 
-    {% for post in site.tags["JakartaEE"] %}
+    {% for post in site.tags["Jakarta EE"] %}
       <item>
         <title>{{ post.title | xml_escape }}</title>
         <description>{{ post.content | xml_escape }}</description>        


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Since we removed tags from individual blog posts, a temporary fix was put in to add "JakartaEE" tags to those blog files individually. Since our tags are stored in a central file, https://github.com/OpenLiberty/blogs/blob/prod/blog_tags.json, we should use those instead and read in those tags during build time and place them back in the blogs so Jekyll is aware of the tags when processing things like feeds, and using site.tags.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

