### PR TITLE
Prevent search engines from crawling third party blog post permalink

### DIFF
--- a/src/main/content/_includes/head.html
+++ b/src/main/content/_includes/head.html
@@ -56,7 +56,7 @@
   
   <meta name="google-site-verification" content="h2P030H9b66CyL1nEmWfrZB8Fr14h9LmVMG7Ur0caBs" />
 
-  {% if jekyll.environment != 'production' %}
+  {% if jekyll.environment != 'production' or page.permalink == '/blog/redirected.html' %}
       {% include_cached noindex.html %}
   {% endif %}
 

--- a/src/main/content/_includes/noindex.html
+++ b/src/main/content/_includes/noindex.html
@@ -1,1 +1,1 @@
-<meta name="robots" content="noindex">
+<meta name="robots" content="noindex" />


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Fixes #1884
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

