### PR TITLE
Check that blog_tags.json exists before parsing

### DIFF
--- a/scripts/build/jekyll.sh
+++ b/scripts/build/jekyll.sh
@@ -59,7 +59,11 @@ $BUILD_SCRIPTS_DIR/clone_certifications.sh
 $BUILD_SCRIPTS_DIR/clone_blogs.sh
 
 # Read in the blog tags file and add the tag to each blog so jekyll knows how to process them.
-python3 $BUILD_SCRIPTS_DIR/parse_blog_tags.py
+if [ -f src/main/content/blog_tags.json ]; then
+   echo "Parsing the blog tags"
+   python3 $BUILD_SCRIPTS_DIR/parse_blog_tags.py
+fi
+
 
 # Jekyll build all the cloned content
 echo "Building with jekyll..."


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

