### PR TITLE
Disable submit starter until field data is retrieved

### DIFF
--- a/src/main/content/downloads.html
+++ b/src/main/content/downloads.html
@@ -83,7 +83,7 @@ permalink: /downloads/
     <div class="row">
         <div class="col">
             <div id="starter_warnings"></div>
-            <a id="starter_submit" class="light_green_link_light_background" tabindex="0">Generate Project</a>
+            <a id="starter_submit" class="light_green_link_light_background disabled" tabindex="0">Generate Project</a>
         </div>        
     </div>
 </div>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

