### PR TITLE
Increase app size limit

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,6 +4,7 @@ defaults: &defaults
   disk_quota: 1512M
   path: target/openliberty.war
   timeout: 180
+  cc.packages.max_package_size: 1512M
   env:
     JBP_CONFIG_LIBERTY: 'app_archive: {features: ["jaxrs-2.1","cdi-2.0","concurrent-1.0","jsonb-1.0","webCache-1.0","mpRestClient-1.3","concurrent-1.0"]}'
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Increasing the max app size mentioned in https://docs.cloudfoundry.org/devguide/deploy-apps/large-app-deploy.html due to our deployment failing because of too large of an app.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

