### PR TITLE
Change TLS check to startsWith

### DIFF
--- a/src/main/java/io/openliberty/website/TLSFilter.java
+++ b/src/main/java/io/openliberty/website/TLSFilter.java
@@ -106,7 +106,7 @@ public class TLSFilter implements Filter {
             if (uri.startsWith("/img/")) {
                 response.setHeader("Cache-Control", "max-age=604800");
                 // if requesting the JAX-RS api set cache control to not cache
-            } else if (uri.contains("/docs") && uri.endsWith(".html")) {
+            } else if (uri.startsWith("/docs") && uri.endsWith(".html")) {
                 boolean doGzip = true;
                 // Check if the servlet context contains a redirect rule for this url
                 Map<String, ?> map = cfg.getServletContext().getContext(uri).getFilterRegistrations();


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Change to startsWith so it doesn't accidentally try to return gzipped html in the future for a random page that contains /docs in it. I think the analytics show right now there isn't any urls with that but just to be sure for the future.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

