### PR TITLE
Do not gzip index.html to handle paths ending in /

### DIFF
--- a/scripts/build/gzip.sh
+++ b/scripts/build/gzip.sh
@@ -2,7 +2,7 @@ timer_start=$(date +%s)
 
 pushd target/jekyll-webapp/docs/
 echo "Runing gzip on all of the docs html."
-find . \( -name '*.html' \) -exec gzip "{}" \;
+find . \( -name '*.html' -not -name "*index.html" \) -exec gzip "{}" \;
 popd
 
 timer_end=$(date +%s)

--- a/src/main/java/io/openliberty/website/TLSFilter.java
+++ b/src/main/java/io/openliberty/website/TLSFilter.java
@@ -106,7 +106,7 @@ public class TLSFilter implements Filter {
             if (uri.startsWith("/img/")) {
                 response.setHeader("Cache-Control", "max-age=604800");
                 // if requesting the JAX-RS api set cache control to not cache
-            } else if (uri.startsWith("/docs") && uri.endsWith(".html")) {
+            } else if (uri.startsWith("/docs") && uri.endsWith(".html") && !uri.endsWith("index.html")) {
                 boolean doGzip = true;
                 // Check if the servlet context contains a redirect rule for this url
                 Map<String, ?> map = cfg.getServletContext().getContext(uri).getFilterRegistrations();


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
This is so any path ending in / for the docs that has an index.html will still work, such as:
https://staging-openlibertyio.mybluemix.net/docs/ref/config/
https://staging-openlibertyio.mybluemix.net/docs/ref/general/
https://staging-openlibertyio.mybluemix.net/docs/ref/feature/
https://staging-openlibertyio.mybluemix.net/docs/ref/command/
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

