### PR TITLE
Add more instructions for running Cypress tests

### DIFF
--- a/src/test/cypressjs/README.md
+++ b/src/test/cypressjs/README.md
@@ -1,4 +1,17 @@
 # How to run [Cypress.io](https://www.cypress.io/) automated UI tests
-- `npm install`
-- Update `cypress.env.json` with target URL
-- `npx cypress open`
+
+## Step 1: First time setting up local environment with Cypress
+- Run `npm install` in the directory containing this `README.md`
+- `node_modules` is created containing Cypress and its dependencies.
+
+## Step 2: Setup URL you want the to test (2 options)
+  - **Choose one of the options: 1 or 2** 
+  - **Option 1:** Update the value for `default_website_url` in `cypress.env.json` with target URL
+  - **Option 2**: Supply a command line variable when launching cypress instead of changing `cypress.env.json`.  Option 2 is preferred to avoid changing a file tracked by `git`.
+
+## Step 3:  Launch the Cypress test runner
+- `cd cypress`
+- **Option 1 from step 2** using `cypress.env.json`
+  - `npx cypress open`
+- **Option 2 from step 2** using CLI variable instead of `cypress.env.json`
+  - `npx cypress open --env website_url=https://openliberty.io`

--- a/src/test/cypressjs/cypress.env.json
+++ b/src/test/cypressjs/cypress.env.json
@@ -1,4 +1,4 @@
 {
-  "website_url": "https://demo1-openlibertyio.mybluemix.net",
+  "default_website_url": "https://demo1-openlibertyio.mybluemix.net",
   "redirects_url": "https://raw.githubusercontent.com/OpenLiberty/docs-playbook/prod/doc-redirects.properties"
 }

--- a/src/test/cypressjs/cypress/integration/testRedirectURLs.js
+++ b/src/test/cypressjs/cypress/integration/testRedirectURLs.js
@@ -1,5 +1,9 @@
 describe('Test Redirect URLs', () => {
   let redirects = "";
+  // Allow users to specify URL via cypress environment variable
+  // For example:
+  //    npx cypress open --env website_url=https://openliberty.io
+  const target_url = Cypress.env('website_url') || Cypress.env('default_website_url');
 
   before(() => {
     cy.request(Cypress.env('redirects_url')).then((res) => {


### PR DESCRIPTION
Some feedback on the initial code drop for the Cypress tests
 1.  Not clear which directory to run the `npx cypress open`.  When in the wrong directory, Cypress will show the sample tests rather than the tests in this repo.
 2. Desire to pass in the target URL for the tests via command line.  I based my solution on https://docs.cypress.io/guides/guides/environment-variables#Option-4-env
