### PR TITLE
Add logic for new skills network urls

### DIFF
--- a/src/main/content/_assets/js/guide-static.js
+++ b/src/main/content/_assets/js/guide-static.js
@@ -76,14 +76,26 @@ $(document).ready(function () {
                 .replace(".html", "")
                 .replace("/guides/", "");
             var host = window.location.hostname;
-            var skills_network_url =
-                host === "openliberty.io"
-                    ? data.skillNetworkUrl
-                    : data.stagingSkillNetworkUrl;
-            skills_network_url = skills_network_url.replace(
-                "{projectid}",
-                guide_name
-            );
+            var skills_network_url;
+
+            if (data.courses && data.courses.guide_name) {
+                skills_network_url =
+                    host === "openliberty.io"
+                        ? data.skillNetworkDomain
+                        : data.stagingSkillNetworkDomain;
+                skills_network_url += "/" + data.courses.guide_name;
+            } else {
+                // Guide is not in the list of courses
+                skills_network_url =
+                    host === "openliberty.io"
+                        ? data.skillNetworkUrl
+                        : data.stagingSkillNetworkUrl;
+                skills_network_url = skills_network_url.replace(
+                    "{projectid}",
+                    guide_name
+                );
+            }
+
             if (data.guides.indexOf(guide_name) > -1) {
                 $(".skills_network_description").text(data.buttonLabel);
                 var skills_network_button = $(

--- a/src/main/content/_assets/js/guide-static.js
+++ b/src/main/content/_assets/js/guide-static.js
@@ -79,13 +79,14 @@ $(document).ready(function () {
             var skills_network_url;
 
             if (data.courses && data.courses.guide_name) {
+                // The new url format supported by the skills network. The domain host is known ahead of time, and each guide's specific url path is specified in the cloud-hosted-guides.json file.
                 skills_network_url =
                     host === "openliberty.io"
                         ? data.skillNetworkDomain
                         : data.stagingSkillNetworkDomain;
                 skills_network_url += "/" + data.courses.guide_name;
             } else {
-                // Guide is not in the list of courses
+                // This guide is not in the list of courses in the new skills network url schema yet. This is the old deprecated url structure that only exists until all guide's urls have been in the cloud-hosted-guides.json file under the courses field.
                 skills_network_url =
                     host === "openliberty.io"
                         ? data.skillNetworkUrl


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
If the guide is found in the new "courses" data in the json from the guides team, we will use that url for the skills network button. Otherwise, just use the old format.

There is a new url format for skills network guides mentioned in the attached issue.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

