### PR TITLE
Remove extra slash that will be provided in the json instead

### DIFF
--- a/src/main/content/_assets/js/guide-static.js
+++ b/src/main/content/_assets/js/guide-static.js
@@ -84,7 +84,7 @@ $(document).ready(function () {
                     host === "openliberty.io"
                         ? data.skillNetworkDomain
                         : data.stagingSkillNetworkDomain;
-                skills_network_url += "/" + data.courses.guide_name;
+                skills_network_url += data.courses.guide_name;
             } else {
                 // This guide is not in the list of courses in the new skills network url schema yet. This is the old deprecated url structure that only exists until all guide's urls have been in the cloud-hosted-guides.json file under the courses field.
                 skills_network_url =


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
There is no need to construct the joining slash, because it is specified here: https://github.com/OpenLiberty/guides-common/blob/dev/cloud-hosted-guides.json.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

