### PR TITLE
Fix generating skills network button if guide has new url structure

### DIFF
--- a/src/main/content/_assets/js/guide-static.js
+++ b/src/main/content/_assets/js/guide-static.js
@@ -84,7 +84,7 @@ $(document).ready(function () {
                     host === "openliberty.io"
                         ? data.skillNetworkDomain
                         : data.stagingSkillNetworkDomain;
-                skills_network_url += data.courses.guide_name;
+                skills_network_url += data.courses[guide_name];
             } else {
                 // This guide is not in the list of courses in the new skills network url schema yet. This is the old deprecated url structure that only exists until all guide's urls have been in the cloud-hosted-guides.json file under the courses field.
                 skills_network_url =
@@ -97,7 +97,10 @@ $(document).ready(function () {
                 );
             }
 
-            if (data.guides.indexOf(guide_name) > -1) {
+            if (
+                data.guides.indexOf(guide_name) > -1 ||
+                (data.courses && data.courses[guide_name])
+            ) {
                 $(".skills_network_description").text(data.buttonLabel);
                 var skills_network_button = $(
                     '<a class="skills_network_button" target="_blank" rel="noopener"></a>'


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

