### PR TITLE
Change curl command to point at rvm installer instead of rvm.io

### DIFF
--- a/scripts/build/ruby_install.sh
+++ b/scripts/build/ruby_install.sh
@@ -7,7 +7,7 @@ echo "Install Ruby & required packages/gems"
 cat $BUILD_SCRIPTS_DIR/../gpg/mpapis.asc | gpg --import -
 cat $BUILD_SCRIPTS_DIR/../gpg/pkuczynski.asc | gpg --import -
 
-curl -v -k -sSL https://get.rvm.io | bash -s stable
+curl -v -k -sSL https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer | bash -s stable
 set +e
 source /usr/local/rvm/scripts/rvm || true
 set -e

--- a/scripts/build/ruby_install.sh
+++ b/scripts/build/ruby_install.sh
@@ -7,7 +7,7 @@ echo "Install Ruby & required packages/gems"
 cat $BUILD_SCRIPTS_DIR/../gpg/mpapis.asc | gpg --import -
 cat $BUILD_SCRIPTS_DIR/../gpg/pkuczynski.asc | gpg --import -
 
-curl -v -k -sSL https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer | bash -s stable
+curl -v -k -sSL https://get.rvm.io -v | bash -s stable
 set +e
 source /usr/local/rvm/scripts/rvm || true
 set -e

--- a/scripts/build/ruby_install.sh
+++ b/scripts/build/ruby_install.sh
@@ -7,7 +7,7 @@ echo "Install Ruby & required packages/gems"
 cat $BUILD_SCRIPTS_DIR/../gpg/mpapis.asc | gpg --import -
 cat $BUILD_SCRIPTS_DIR/../gpg/pkuczynski.asc | gpg --import -
 
-curl -v -k -sSL https://get.rvm.io -v | bash -s stable
+curl -sSL https://get.rvm.io -v | bash -s stable
 set +e
 source /usr/local/rvm/scripts/rvm || true
 set -e


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

