### PR TITLE
TOC styling for current doc pages that also dropdowns

### DIFF
--- a/src/main/content/antora_ui/src/sass/nav.scss
+++ b/src/main/content/antora_ui/src/sass/nav.scss
@@ -229,7 +229,7 @@ html.is-clipped--nav {
     padding-left: calc(
       var(--TOC-indention-first-level) - var(--TOC-orange-border-width)
     );
-  }
+  }  
   &[data-depth="1"] {
     & > span,
     & > a {
@@ -240,6 +240,10 @@ html.is-clipped--nav {
         var(--TOC-indention-first-level) + var(--TOC-indention) -
           var(--TOC-orange-border-width)
       );
+    }
+    & > .nav-item-toggle ~ .nav-link {
+      display: inline-block;
+      width: calc(100% + (var(--TOC-indention-first-level) + var(--TOC-indention)));
     }
   }
   &[data-depth="2"] {
@@ -253,6 +257,10 @@ html.is-clipped--nav {
           var(--TOC-orange-border-width)
       );
     }
+    & > .nav-item-toggle ~ .nav-link {
+      display: inline-block;
+      width: calc(100% + 2 * (var(--TOC-indention-first-level) + var(--TOC-indention)));
+    }
   }
   &[data-depth="3"] {
     & > span,
@@ -264,6 +272,10 @@ html.is-clipped--nav {
         var(--TOC-indention-first-level) + 3 * var(--TOC-indention) -
           var(--TOC-orange-border-width)
       );
+    }
+    & > .nav-item-toggle ~ .nav-link {
+      display: inline-block;
+      width: calc(100% + 3 * (var(--TOC-indention-first-level) + var(--TOC-indention)));
     }
   }
   &[data-depth="4"] {
@@ -277,12 +289,16 @@ html.is-clipped--nav {
           var(--TOC-orange-border-width)
       );
     }
+    & > .nav-item-toggle ~ .nav-link {
+      display: inline-block;
+      width: calc(100% + 4 * (var(--TOC-indention-first-level) + var(--TOC-indention)));
+    }
   }
 }
 
 .is-current-page > .nav-link,
 .is-current-page > .nav-text {
-  font-weight: var(--body-font-weight-bold);
+  font-weight: var(--body-font-weight-bold);  
 }
 
 .nav-link:focus,


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Increase the styling for pages that are also dropdowns in the docs. This is the first time we have a page like so.

Fixes the toc at https://docs-draft-openlibertyio.mybluemix.net/docs/21.0.0.11/rest-microservices.html to look like:
![image](https://user-images.githubusercontent.com/6392944/137199987-531e2cb9-bf53-44bb-92ff-682a51a75394.png)

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

