### PR TITLE
Reduce 302 redirects from header links

### DIFF
--- a/src/main/content/_includes/header.html
+++ b/src/main/content/_includes/header.html
@@ -11,19 +11,19 @@
         <div id="hamburger_menu">
             <ul class="nav_list">
                 <li class="nav_link">
-                    <a href="/downloads">Get Started</a>
+                    <a href="/start/">Get Started</a>
                 </li>
                 <li class="nav_link">
-                    <a href="/guides">Guides</a>
+                    <a href="/guides/">Guides</a>
                 </li>
                 <li class="nav_link">
-                    <a href="/docs">Docs</a>
+                    <a href="/docs/">Docs</a>
                 </li>
                 <li class="nav_link">
-                    <a href="/support">Support</a>
+                    <a href="/support/">Support</a>
                 </li>
                 <li class="nav_link">
-                    <a href="/blog">Blog</a>
+                    <a href="/blog/">Blog</a>
                 </li>
             </ul>
             <div id="header_round_links_container"> 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

Related to #2282

Reduce 302 redirects from header links

- Add trailing slash to all links to avoid unnecessary 302 HTTP redirect

- Update the Get Started link

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

