### PR TITLE
Blogs: Allow for authors to choose which code blocks have copy to clipboard functionality

### DIFF
--- a/src/main/content/_assets/js/openliberty.js
+++ b/src/main/content/_assets/js/openliberty.js
@@ -10,183 +10,181 @@
  *******************************************************************************/
 var openliberty = (function() {
     $(document).ready(function() {
-    var scrollAllowed = true;
-    var prevScrollTop = 0;
-	$(window).scroll(function() {
-        if(!scrollAllowed){
-            return;
-        }
-        var currScrollTop = $(this).scrollTop();
-        // if scrolled past nav bar, determine whether to hide or show nav bar
-        if (currScrollTop > $("#nav_bar").outerHeight()) {
+        var scrollAllowed = true;
+        var prevScrollTop = 0;
+        $(window).scroll(function() {
+            if(!scrollAllowed){
+                return;
+            }
+            var currScrollTop = $(this).scrollTop();
+            // if scrolled past nav bar, determine whether to hide or show nav bar
+            if (currScrollTop > $("#nav_bar").outerHeight()) {
             // make docs toolbar position sticky once you scroll past nav bar
-            $(".toolbar").css("position", "sticky");
+                $(".toolbar").css("position", "sticky");
 
-            // if scrolling down, hide nav bar
-            if (currScrollTop > prevScrollTop) {
-                hideNav();
+                // if scrolling down, hide nav bar
+                if (currScrollTop > prevScrollTop) {
+                    hideNav();
+                }
+                // if scrolling up, show nav bar
+                else {
+                    showNav();
+                }
             }
-            // if scrolling up, show nav bar
             else {
-                showNav();
+                $("#code_column").css({"position": "absolute", "top": ""});
+                $(".toolbar").css({"position": "static", "top": ""});
+                $(".nav").css("top", "");
             }
+
+            // When page scrolled back to top: Make nav bar no longer fixed, reset body margin-top
+            if (currScrollTop == 0) {
+                $("#nav_bar").removeClass("fixed_top");
+                $('body').css("margin-top", "0px");
+                $('#toc_column').css({'position': '', 'top': ''});
+            }
+
+            // make toc scroll off of screen at Nice Work section in guides
+            if (typeof isBackgroundBottomVisible === "function") {
+                if(isBackgroundBottomVisible()) {
+                    handleTOCScrolling();
+                }
+            }
+
+            prevScrollTop = currScrollTop;
+        });
+
+        $(window).on('resize', function() {
+            if ($(".toolbar").css("position") == "sticky" && $("#nav_bar").hasClass("fixed_top")) {
+                $(".toolbar").css("top", $("#nav_bar").outerHeight() + "px");
+            }
+        });
+    });
+
+    // slide nav bar into view, move down elements that are fixed to top of screen
+    function showNav() {
+        var nav_height = $("#nav_bar").outerHeight();
+
+        // fix nav bar to top of screen
+        $("#nav_bar").addClass("fixed_top");
+        $("#nav_bar").css("top", "0px");
+
+        // push toc column, toc indicator and code column down below nav bar
+        $("#toc_column").css("top", nav_height + "px");
+        if (window.innerWidth > 1440) {
+            $("#toc_inner").css("margin-top", nav_height + "px");
+        }
+        $("#toc_indicator").css("margin-top", nav_height + "px");
+        $("#code_column").css({"position": "fixed", "top": nav_height + "px"});
+
+        // add margin-top to body so page doesn't jump when nav slides into view
+        $('body').css("margin-top", nav_height + "px");
+
+        // in guides, if mobile toc accodion is fixed to top of screen, move toc accordion below fixed nav bar
+        if ($("#mobile_toc_accordion_container").hasClass("fixed_toc_accordion")) {
+            $("#mobile_toc_accordion_container").css("top", nav_height + "px");
+        }
+
+        // on /guides, if tablet toc accordion is fixed to top of screen, move toc accordion below fixed nav bar
+        if ($("#tablet_toc_accordion_container").css("position") === "fixed") {
+            $("#tablet_toc_accordion_container").css("top", nav_height + "px");
+        }
+
+        // adjust docs toolbar and nav position
+        $(".toolbar").css("top", nav_height + "px");
+        if (window.innerWidth < 1024) {
+            $(".nav-container").css("top", nav_height + $(".toolbar").outerHeight() + "px");
+            $(".nav").css("top", "");
         }
         else {
-            $("#code_column").css({"position": "absolute", "top": ""});
-            $(".toolbar").css({"position": "static", "top": ""});
+            $(".nav").css("top",  nav_height + "px");
+        }
+
+        // move config breadcrumb down when nav bar in view
+        $(".contentStickyBreadcrumbHeader").css("top", nav_height + $(".toolbar").outerHeight() + "px");
+    }
+
+    // slide nav bar back out of view, reset elements that were pushed down
+    function hideNav() {
+    // reset nav bar and move off screen
+        $("#nav_bar").removeClass("fixed_top");
+        $("#nav_bar").css({"top": "-60px"});
+
+        // reset toc column, toc indicator and code column position
+        $("#toc_column").css("top", "0px");
+        if (window.innerWidth > 1440) {
+            $("#toc_inner").css("margin-top", "0px");
+        }
+        $("#toc_indicator").css("margin-top", "0px");
+        $("#code_column").css({"position":"fixed", "top":"0px"})
+
+        // reset body margin-top
+        $('body').css("margin-top", "0px");
+
+        // fix mobile and tablet toc accordion to top of screen again
+        $("#mobile_toc_accordion_container").css("top", "0px");
+        $("#tablet_toc_accordion_container").css("top", "0px");
+
+        // adjust docs toolbar and nav position
+        $(".toolbar").css("top", "0px");
+        if (window.innerWidth < 1024) {
+            $(".nav-container").css("top", $(".toolbar").outerHeight() + "px");
+            $(".nav").css("top", "");
+        }
+        else {
+            $(".nav-container").css("top", "");
             $(".nav").css("top", "");
         }
 
-        // When page scrolled back to top: Make nav bar no longer fixed, reset body margin-top
-        if (currScrollTop == 0) {
-            $("#nav_bar").removeClass("fixed_top");
-            $('body').css("margin-top", "0px");
-            $('#toc_column').css({'position': '', 'top': ''});
-        }
-
-        // make toc scroll off of screen at Nice Work section in guides
-        if (typeof isBackgroundBottomVisible === "function") {
-            if(isBackgroundBottomVisible()) {
-                handleTOCScrolling();
-            }
-        }
-
-        prevScrollTop = currScrollTop;
-    });
-
-    $(window).on('resize', function() {
-        if ($(".toolbar").css("position") == "sticky" && $("#nav_bar").hasClass("fixed_top")) {
-            $(".toolbar").css("top", $("#nav_bar").outerHeight() + "px");
-        }
-    });
-});
-
-// slide nav bar into view, move down elements that are fixed to top of screen
-function showNav() {
-    var nav_height = $("#nav_bar").outerHeight();
-
-    // fix nav bar to top of screen
-    $("#nav_bar").addClass("fixed_top");
-    $("#nav_bar").css("top", "0px");
-
-    // push toc column, toc indicator and code column down below nav bar
-    $("#toc_column").css("top", nav_height + "px");
-    if (window.innerWidth > 1440) {
-        $("#toc_inner").css("margin-top", nav_height + "px");
-    }
-    $("#toc_indicator").css("margin-top", nav_height + "px");
-    $("#code_column").css({"position": "fixed", "top": nav_height + "px"});
-
-    // add margin-top to body so page doesn't jump when nav slides into view
-    $('body').css("margin-top", nav_height + "px");
-
-    // in guides, if mobile toc accodion is fixed to top of screen, move toc accordion below fixed nav bar
-    if ($("#mobile_toc_accordion_container").hasClass("fixed_toc_accordion")) {
-        $("#mobile_toc_accordion_container").css("top", nav_height + "px");
+        // move config breadcrumb back up when nav bar slides out of view
+        $(".contentStickyBreadcrumbHeader").css("top", $(".toolbar").outerHeight() + "px");
     }
 
-    // on /guides, if tablet toc accordion is fixed to top of screen, move toc accordion below fixed nav bar
-    if ($("#tablet_toc_accordion_container").css("position") === "fixed") {
-        $("#tablet_toc_accordion_container").css("top", nav_height + "px");
-    }
-
-    // adjust docs toolbar and nav position
-    $(".toolbar").css("top", nav_height + "px");
-    if (window.innerWidth < 1024) {
-        $(".nav-container").css("top", nav_height + $(".toolbar").outerHeight() + "px");
-        $(".nav").css("top", "");
-    }
-    else {
-        $(".nav").css("top",  nav_height + "px");
-    }
-
-    // move config breadcrumb down when nav bar in view
-    $(".contentStickyBreadcrumbHeader").css("top", nav_height + $(".toolbar").outerHeight() + "px");
-}
-
-// slide nav bar back out of view, reset elements that were pushed down
-function hideNav() {
-    // reset nav bar and move off screen
-    $("#nav_bar").removeClass("fixed_top");
-    $("#nav_bar").css({"top": "-60px"});
-
-    // reset toc column, toc indicator and code column position
-    $("#toc_column").css("top", "0px");
-    if (window.innerWidth > 1440) {
-        $("#toc_inner").css("margin-top", "0px");
-    }
-    $("#toc_indicator").css("margin-top", "0px");
-    $("#code_column").css({"position":"fixed", "top":"0px"})
-
-    // reset body margin-top
-    $('body').css("margin-top", "0px");
-
-    // fix mobile and tablet toc accordion to top of screen again
-    $("#mobile_toc_accordion_container").css("top", "0px");
-    $("#tablet_toc_accordion_container").css("top", "0px");
-
-    // adjust docs toolbar and nav position
-    $(".toolbar").css("top", "0px");
-    if (window.innerWidth < 1024) {
-        $(".nav-container").css("top", $(".toolbar").outerHeight() + "px");
-        $(".nav").css("top", "");
-    }
-    else {
-        $(".nav-container").css("top", "");
-        $(".nav").css("top", "");
-    }
-
-    // move config breadcrumb back up when nav bar slides out of view
-    $(".contentStickyBreadcrumbHeader").css("top", $(".toolbar").outerHeight() + "px");
-}
-
-/* Copy the target element to the clipboard
-target: element to copy
-callback: function to run if the copy is successful
-*/
-function copy_element_to_clipboard(target, callback){
+    // Copy the target element to the clipboard
+    // target: element to copy
+    // callback: function to run if the copy is successful
+    function copy_element_to_clipboard(target, callback){
     // IE
-    if(window.clipboardData){
-        window.clipboardData.setData("Text", target.innerText);
-    }
-    else{
-        var temp = $('<textarea>');
-        temp.css({
-            position: "absolute",
-            left:     "-1000px",
-            top:      "-1000px",
-        });
-
-        // Create a temporary element for copying the text.
-        // Prepend <br> with newlines because jQuery .text() strips the <br>'s and we use .text() because we don't want all of the html tags copied to the clipboard.
-        // Remove <b> tags that contain callouts
-        var text = $(target).clone().find('br').prepend('\r\n').end().find("b").remove().end().text().trim();
-        temp.text(text);
-        $("body").append(temp);
-        temp.trigger('select');
-
-        // Try to copy the selection and if it fails display a popup to copy manually.
-        if(document.execCommand('copy')) {
-            callback();
-        } else {
-            alert('Copy failed. Copy the command manually: ' + target.innerText);
+        if(window.clipboardData){
+            window.clipboardData.setData("Text", target.innerText);
         }
-        temp.remove(); // Remove temporary element.
+        else{
+            var temp = $('<textarea>');
+            temp.css({
+                position: "absolute",
+                left:     "-1000px",
+                top:      "-1000px",
+            });
+
+            // Create a temporary element for copying the text.
+            // Prepend <br> with newlines because jQuery .text() strips the <br>'s and we use .text() because we don't want all of the html tags copied to the clipboard.
+            // Remove <b> tags that contain callouts
+            var text = $(target).clone().find('br').prepend('\r\n').end().find("b").remove().end().text().trim();
+            temp.text(text);
+            $("body").append(temp);
+            temp.trigger('select');
+
+            // Try to copy the selection and if it fails display a popup to copy manually.
+            if(document.execCommand('copy')) {
+                callback();
+            } else {
+                alert('Copy failed. Copy the command manually: ' + target.innerText);
+            }
+            temp.remove(); // Remove temporary element.
+        }
     }
-}
 
-function preventScrolling(){
-    scrollAllowed = false;
-}
+    function preventScrolling(){
+        scrollAllowed = false;
+    }
 
-function allowScrolling(){
-    scrollAllowed = true;
-}
+    function allowScrolling(){
+        scrollAllowed = true;
+    }
 
-return {
-    preventScrolling: preventScrolling,
-    allowScrolling: allowScrolling,
-    copy_element_to_clipboard: copy_element_to_clipboard
-};
+    return {
+        preventScrolling: preventScrolling,
+        allowScrolling: allowScrolling,
+        copy_element_to_clipboard: copy_element_to_clipboard
+    };
 })();
-

--- a/src/main/content/_assets/js/post.js
+++ b/src/main/content/_assets/js/post.js
@@ -24,8 +24,10 @@ $.getJSON( "../../../../blog_tags.json", function(data) {
 
 });
 
-// Show copy to clipboard button when mouse enters code block
-$('pre').on('mouseenter', function(event) {
+var code_blocks_with_copy_to_clipboard = 'pre:not(.no_copy pre)'; // CSS Selector
+
+// Show copy to clipboard button when mouse enters code block lacking the .no_copy className
+$(code_blocks_with_copy_to_clipboard).on('mouseenter', function(event) {
     target = $(event.currentTarget);
     $('main').append('<div id="copied_confirmation">Copied to clipboard</div><img id="copy_to_clipboard" src="/img/guides_copy_button.svg" alt="Copy code block" title="Copy code block">');
     $('#copy_to_clipboard').css({

--- a/src/test/cypressjs/cypress/integration/testNoCopy.js
+++ b/src/test/cypressjs/cypress/integration/testNoCopy.js
@@ -1,0 +1,16 @@
+describe('Test No Copy attribute on code blocks', () => {  
+    before(() => {
+        cy.goToBlogs();
+        cy.url().then(foo => {
+            cy.visit(foo+"2021/09/03/microprofile-21009.html");
+        })
+    });
+  
+    it('Test code block with and without "no_copy" className', () => {
+        cy.get('.no_copy').first().trigger('mouseover');
+        cy.get('#copy_to_clipboard').should('not.exist');
+
+        cy.get('pre').first().trigger('mouseover');
+        cy.get('#copy_to_clipboard').should('be.visible');
+    })
+  });

--- a/src/test/cypressjs/cypress/support/commands.js
+++ b/src/test/cypressjs/cypress/support/commands.js
@@ -23,3 +23,9 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+
+var websiteUrl = Cypress.env('website_url') || Cypress.env('default_website_url');
+
+Cypress.Commands.add('goToBlogs', () => { 
+    cy.visit(websiteUrl + '/blog/');
+})


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Related to https://github.com/OpenLiberty/openliberty.io/issues/2263

- Added new test for `no_copy` on a blog post 
- Scope down the CSS selector for all blog post JavaScript when deciding to add the `copy_to_clipboard` functionality.
- Fix indention based on ESLint rules

#### Were the changes tested on
- [x] Chrome (Desktop)
- [x] Cypress Automation Tests
![image](https://user-images.githubusercontent.com/31117513/138504982-af32dde3-bdc5-4b9e-9ea3-12218d4d172d.png)

#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

