### PR TITLE
Support doc feature pages being dropdowns and an actual page

### DIFF
--- a/scripts/build/parse_features_toc.py
+++ b/scripts/build/parse_features_toc.py
@@ -79,119 +79,128 @@ for version in versions:
     toc = featureIndex.find('nav', {'class': 'nav-menu'})
     if toc.find('span', text='Features') is not None:
         featureDropdown = toc.find('span', text='Features').parent
-        for featureTOC in featureDropdown.find_all('a', {'class': 'nav-link'}, href=True):
-            toc = featureTOC.get('href')
-            pattern = re.compile('^(?P<preString>[\s\D]*)-(?P<version>\d+[.]?\d*)(?P<postString>[\s\D]*)')
-            matches = pattern.match(toc)
-            if matches is None:
-                # take care of title with J2EE ...
-                pattern = re.compile('^(?P<preString>J2EE[\s\D]+)-(?P<version>\d+[.]?\d*)(?P<postString>[\s\D]*)')
-                matches = pattern.match(toc)
-            if matches is not None and matches.group('version') is not None:
-                tocCompileString = '^' + matches.group('preString') + '-\d+[.]?\d*' + matches.group('postString') + "$"
-                tocCommonString = matches.group('preString') + matches.group('postString')
-                if tocCommonString not in commonTOCs:
-                    commonTOCs[tocCommonString] = tocCompileString
-            
-        # process each TOC with version in the title
-        commonTOCKeys = commonTOCs.keys()
-        commonTOCKeys = list(commonTOCKeys)
+    elif toc.find('a', text='Features') is not None:
+        featureDropdown = toc.find('a', text='Features').parent
 
-        TOCToDecompose = []
-        for commonTOC in commonTOCKeys:
-            commonTOCMatchString = commonTOCs[commonTOC]
-            matchingTitleTOCs = featureIndex.find_all('a', {'class': 'nav-link'}, href=re.compile(commonTOCMatchString))
-            firstElement = True;
-            # determine whether there are multiple versions            
-            firstHref = matchingTitleTOCs[0].get('href')
-            featurePage  = BeautifulSoup(open(antora_path + '/feature/' + firstHref), "lxml")
-            pageTitle = featurePage.find('h1', {'class': 'page'})
-            titleDiv = featurePage.new_tag('div', id='feature_name')
-            versionDiv = featurePage.new_tag('div', id='feature_versions')
-            pageTitle.string = ''
-            newTOCHref = ''
-            # in reverse descending order
-            matchingTOCs = matchingTitleTOCs[::-1]
-            for matchingTOC in matchingTOCs:
-                tocHref = matchingTOC.get('href')
-                if not str.startswith(tocHref, ".."):
-                    if firstElement:
-                        firstElement = False
-                        hrefSplits = tocHref.split('/')
-                        lastHrefSplit = hrefSplits[-1]
-                        htmlSplits = lastHrefSplit.split('-')
-                        lastMatch = re.search(r'\d*.html$', htmlSplits[-1])
-                        if lastMatch:
-                            del htmlSplits[-1]
-                            combineHtml = "-".join(htmlSplits) + '.html'
-                            del hrefSplits[-1]
-                            newTOCHref = '/'.join(hrefSplits) + '/' + combineHtml
-                            title = createTitle(featurePage, tocHref, matchingTOC.string)
-                            titleDiv.append(title)
-                            hrefTag = createVersionHref(featurePage, tocHref, matchingTOC.string)
-                            versionDiv.append(hrefTag)
-                    else:
+    for featureTOC in featureDropdown.find_all('a', {'class': 'nav-link'}, href=True):
+        toc = featureTOC.get('href')
+        pattern = re.compile('^(?P<preString>[\s\D]*)-(?P<version>\d+[.]?\d*)(?P<postString>[\s\D]*)')
+        matches = pattern.match(toc)
+        if matches is None:
+            # take care of title with J2EE ...
+            pattern = re.compile('^(?P<preString>J2EE[\s\D]+)-(?P<version>\d+[.]?\d*)(?P<postString>[\s\D]*)')
+            matches = pattern.match(toc)
+        if matches is not None and matches.group('version') is not None:
+            tocCompileString = '^' + matches.group('preString') + '-\d+[.]?\d*' + matches.group('postString') + "$"
+            tocCommonString = matches.group('preString') + matches.group('postString')
+            if tocCommonString not in commonTOCs:
+                commonTOCs[tocCommonString] = tocCompileString
+        
+    # process each TOC with version in the title
+    commonTOCKeys = commonTOCs.keys()
+    commonTOCKeys = list(commonTOCKeys)
+
+    TOCToDecompose = []
+    for commonTOC in commonTOCKeys:
+        commonTOCMatchString = commonTOCs[commonTOC]
+        matchingTitleTOCs = featureIndex.find_all('a', {'class': 'nav-link'}, href=re.compile(commonTOCMatchString))
+        firstElement = True;
+        # determine whether there are multiple versions            
+        firstHref = matchingTitleTOCs[0].get('href')
+        featurePage  = BeautifulSoup(open(antora_path + '/feature/' + firstHref), "lxml")
+        pageTitle = featurePage.find('h1', {'class': 'page'})
+        titleDiv = featurePage.new_tag('div', id='feature_name')
+        versionDiv = featurePage.new_tag('div', id='feature_versions')
+        pageTitle.string = ''
+        newTOCHref = ''
+        # in reverse descending order
+        matchingTOCs = matchingTitleTOCs[::-1]
+        for matchingTOC in matchingTOCs:
+            tocHref = matchingTOC.get('href')
+            if not str.startswith(tocHref, ".."):
+                if firstElement:
+                    firstElement = False
+                    hrefSplits = tocHref.split('/')
+                    lastHrefSplit = hrefSplits[-1]
+                    htmlSplits = lastHrefSplit.split('-')
+                    lastMatch = re.search(r'\d*.html$', htmlSplits[-1])
+                    if lastMatch:
+                        del htmlSplits[-1]
+                        combineHtml = "-".join(htmlSplits) + '.html'
+                        del hrefSplits[-1]
+                        newTOCHref = '/'.join(hrefSplits) + '/' + combineHtml
+                        title = createTitle(featurePage, tocHref, matchingTOC.string)
+                        titleDiv.append(title)
                         hrefTag = createVersionHref(featurePage, tocHref, matchingTOC.string)
                         versionDiv.append(hrefTag)
-                        TOCToDecompose.append(matchingTOC.parent)
-            # Write the feature title and the versions to the page div
-            pageTitle.append(titleDiv)
-            pageTitle.append(versionDiv)
+                else:
+                    hrefTag = createVersionHref(featurePage, tocHref, matchingTOC.string)
+                    versionDiv.append(hrefTag)
+                    TOCToDecompose.append(matchingTOC.parent)
+        # Write the feature title and the versions to the page div
+        pageTitle.append(titleDiv)
+        pageTitle.append(versionDiv)
 
-            # write to the common version doc with the highest versioned content
-            if newTOCHref is not "":
-                with open(antora_path + 'feature' +  newTOCHref, "w") as file:
-                    file.write(str(featurePage))
-            
-            # Go through the matching TOC pages and write the version switcher to the top of the page
-            for matchingTOC in matchingTOCs:
-                # Open page and rewrite the version part
-                versionHref = antora_path + 'feature/' + matchingTOC.get('href')
-                versionPage = BeautifulSoup(open(versionHref), "lxml")
-                versionTitle = versionPage.find('h1', {'class': 'page'})
-                versionTitle.replace_with(pageTitle)
-                with open(versionHref, "w") as file:
-                    file.write(str(versionPage))
-
-        for TOC in TOCToDecompose:
-            TOC.decompose()
+        # write to the common version doc with the highest versioned content
+        if newTOCHref is not "":
+            with open(antora_path + 'feature' +  newTOCHref, "w") as file:
+                file.write(str(featurePage))
         
-        # Remove .is-current-page so they don't show up as highlighted in other types of docs
-        tocs = featureIndex.find_all('li', {'class':'is-current-page'})
-        for toc in tocs:
-            toc['class'] = 'nav-item'
+        # Go through the matching TOC pages and write the version switcher to the top of the page
+        for matchingTOC in matchingTOCs:
+            # Open page and rewrite the version part
+            versionHref = antora_path + 'feature/' + matchingTOC.get('href')
+            versionPage = BeautifulSoup(open(versionHref), "lxml")
+            versionTitle = versionPage.find('h1', {'class': 'page'})
+            versionTitle.replace_with(pageTitle)
+            with open(versionHref, "w") as file:
+                file.write(str(versionPage))
 
-        # Write the new TOC to the feature-overview.html with version control in it
-        with open(antora_path + 'feature/feature-overview.html', "w") as file:     
-            file.write(str(featureIndex))
+    for TOC in TOCToDecompose:
+        TOC.decompose()
+    
+    # Remove .is-current-page so they don't show up as highlighted in other types of docs
+    tocs = featureIndex.find_all('li', {'class':'is-current-page'})
+    for toc in tocs:
+        toc['class'] = 'nav-item'
 
-        # Record the toc in the featureIndex to write over the other pages
-        featureIndex = BeautifulSoup(open(antora_path + 'feature/feature-overview.html'), "lxml")
-        toc = featureIndex.find_all('ul', {'class': 'nav-list'})[0]
+    # Write the new TOC to the feature-overview.html with version control in it
+    with open(antora_path + 'feature/feature-overview.html', "w") as file:     
+        file.write(str(featureIndex))
+
+    # Record the toc in the featureIndex to write over the other pages
+    featureIndex = BeautifulSoup(open(antora_path + 'feature/feature-overview.html'), "lxml")
+    toc = featureIndex.find_all('ul', {'class': 'nav-list'})[0]
+    if toc.find('span', text='Features') is not None:
         featureTOC = toc.find('span', text='Features').parent
+    elif toc.find('a', text='Features') is not None:
+        featureTOC = toc.find('a', text='Features').parent
 
-        # Change hrefs to full path so the links work from other doc pages
-        for feature in featureTOC.find_all('a', {'class': 'nav-link'}, href=True):
-            fullHref = '/docs/' + version + '/reference/feature/' + feature.get('href')
-            feature['href'] = fullHref
+    # Change hrefs to full path so the links work from other doc pages
+    for feature in featureTOC.find_all('a', {'class': 'nav-link'}, href=True):
+        fullHref = '/docs/' + version + '/reference/feature/' + feature.get('href')
+        feature['href'] = fullHref
 
-        # Write the reduced feature TOC of all of the Antora doc pages in this version
-        print("Modifying the docs TOCs of version " + version + " to remove the duplicate feature versions.")
-        path = featurePath + version
-        for root, dirs, files in os.walk(path):
-            for basename in files:
-                if fnmatch.fnmatch(basename, "*.html"):
-                    if(basename != "index.html"):
-                        href = os.path.join(root, basename)
-                        page = BeautifulSoup(open(href), "lxml")
+    # Write the reduced feature TOC of all of the Antora doc pages in this version
+    print("Modifying the docs TOCs of version " + version + " to remove the duplicate feature versions.")
+    path = featurePath + version
+    for root, dirs, files in os.walk(path):
+        for basename in files:
+            if fnmatch.fnmatch(basename, "*.html"):
+                if(basename != "index.html"):
+                    href = os.path.join(root, basename)
+                    page = BeautifulSoup(open(href), "lxml")
 
-                        # Find the toc and replace it with the modified toc
-                        page_toc = page.find_all('ul', {'class': 'nav-list'})[0]
+                    # Find the toc and replace it with the modified toc
+                    page_toc = page.find_all('ul', {'class': 'nav-list'})[0]
+                    if page_toc.find('span', text='Features') is not None:
                         toc_to_replace = page_toc.find('span', text='Features').parent
-                        toc_to_replace.clear()
-                        toc_to_replace.append(featureTOC)
-                        with open(href, "w") as file:           
-                            file.write(str(page))
+                    elif page_toc.find('a', text='Features') is not None:
+                        toc_to_replace = page_toc.find('a', text='Features').parent
+                    toc_to_replace.clear()
+                    toc_to_replace.append(featureTOC)
+                    with open(href, "w") as file:           
+                        file.write(str(page))
 
 timerEnd = time.time()
 print('Total execution time for parsing ToC Features: ', timerEnd - timerStart)

--- a/src/main/content/antora_ui/src/js/05-features.js
+++ b/src/main/content/antora_ui/src/js/05-features.js
@@ -10,83 +10,95 @@
  *******************************************************************************/
 
 // Setup and listen to version clicks if there is more than one version of a feature on the version picker.
-function addVersionClick(){
-    if($('.feature_version').length ===  1){
-        // If there's just one version, then disable the hover/click behavior for the version.
-        $('.feature_version').css('cursor', 'default');
-        return;
-    }
-    var onclick = function(event) {
-        var resource = $(event.currentTarget);
-        var href = resource.attr("href");
-        var url = window.location.href;
-        var newUrl = url.substring(0,url.lastIndexOf('/')) + '/' + href;
-        window.location.href = newUrl;
-    };
-    $(".feature_version").on("click", onclick);       
-}
-
-function acivateNavMenu(){
-    // Add active class to the nav-menu
-    $('.nav-panel-menu').addClass('is-active');
-}
-
-function highlightSelectedVersion(){
+function addVersionClick() {
+  if ($(".feature_version").length === 1) {
+    // If there's just one version, then disable the hover/click behavior for the version.
+    $(".feature_version").css("cursor", "default");
+    return;
+  }
+  var onclick = function(event) {
+    var resource = $(event.currentTarget);
+    var href = resource.attr("href");
     var url = window.location.href;
-    var version = url.substring(url.lastIndexOf('/') + 1);
-    var versionHref = $('.feature_version[href="' + version + '"]');
-    if(versionHref.length === 1){
-        versionHref.addClass('feature_version_selected');
-        var ariaLabel = versionHref.attr('aria-label');
-        versionHref.attr('aria-label', ariaLabel + ' selected');
-    }
+    var newUrl = url.substring(0, url.lastIndexOf("/")) + "/" + href;
+    window.location.href = newUrl;
+  };
+  $(".feature_version").on("click", onclick);
+}
+
+function acivateNavMenu() {
+  // Add active class to the nav-menu
+  $(".nav-panel-menu").addClass("is-active");
+}
+
+function highlightSelectedVersion() {
+  var url = window.location.href;
+  var version = url.substring(url.lastIndexOf("/") + 1);
+  var versionHref = $('.feature_version[href="' + version + '"]');
+  if (versionHref.length === 1) {
+    versionHref.addClass("feature_version_selected");
+    var ariaLabel = versionHref.attr("aria-label");
+    versionHref.attr("aria-label", ariaLabel + " selected");
+  }
 }
 
 // Versioned features have a non-versioned page to support linking to the latest version of a feature without having to supply the version. E.g. link:docs/ref/feature/appSecurity.adoc will create appSecurity.html which redirects to the highest version of that feature (at the time), appSecurity-3.0.html. If there are versions for the current page but the current href doesn't match any of them, then we're on a versionless page that should be versioned, so we should redirect to the highest version of this feature.
-function checkForNonVersionedPage(){
-    if($('.feature_version').length > 0){
-        var url = window.location.href;
-        var urlWithoutHash = url;
-        if(url.indexOf('#') > -1){
-            urlWithoutHash = url.substring(0, url.indexOf('#'));
-        }        
-        var href = urlWithoutHash.substring(urlWithoutHash.indexOf('/reference/feature/') + 19);
-        if($('.feature_version[href="' + href + '"]').length === 0){
-            // Redirect to the highest version
-            var href = $('.feature_version').first().attr('href');
-            var newUrl = url.substring(0,url.lastIndexOf('/')) + '/' + href;
-            window.location.href = newUrl;
-        }
+function checkForNonVersionedPage() {
+  if ($(".feature_version").length > 0) {
+    var url = window.location.href;
+    var urlWithoutHash = url;
+    if (url.indexOf("#") > -1) {
+      urlWithoutHash = url.substring(0, url.indexOf("#"));
     }
+    var href = urlWithoutHash.substring(
+      urlWithoutHash.indexOf("/reference/feature/") + 19
+    );
+    if ($('.feature_version[href="' + href + '"]').length === 0) {
+      // Redirect to the highest version
+      var href = $(".feature_version")
+        .first()
+        .attr("href");
+      var newUrl = url.substring(0, url.lastIndexOf("/")) + "/" + href;
+      window.location.href = newUrl;
+    }
+  }
 }
 
 // When loading the page, if the page from the url isn't selected in the TOC we need to look for its version in the TOC and highlight it since the multiple feature versions only have one TOC entry.
-function selectTOC(){
-    var first_version = $('.feature_version').first();
-    var href = first_version.attr('href');
-    if(!href){
-        // If the feature is a single version it won't have a version switcher at the top. Get the href from the url.
-        href = window.location.href;
-        href = href.substring(href.lastIndexOf('/') + 1);
-    }
-    // Look for toc under the features dropdown
-    var featureDropdown = $('li > span:contains(Features)').parent();
-    var toc = featureDropdown.find('.nav-item a').filter(function(){
-        var tocHref = $(this).attr('href');
-        tocHref = tocHref.substring(tocHref.lastIndexOf('/') + 1);
-        return href === tocHref;
+function selectTOC() {
+  var first_version = $(".feature_version").first();
+  var href = first_version.attr("href");
+  if (!href) {
+    // If the feature is a single version it won't have a version switcher at the top. Get the href from the url.
+    href = window.location.href;
+    href = href.substring(href.lastIndexOf("/") + 1);
+  }
+  // Look for toc under the features dropdown
+  var featureDropdown = $("li > span").filter(function() {
+    return this.text == "Features";
+  });
+  if (featureDropdown.length === 0) {
+    featureDropdown = $("li > a.nav-link").filter(function() {
+      return this.text == "Features";
     });
-    if(toc.length > 0){        
-        var li = toc.parent()[0];
-        navigation.activateCurrentPath(li);
-        navigation.scrollItemToMidpoint(li);
-    }
+  }
+  featureDropdown = featureDropdown.parent();
+  var featureToc = featureDropdown.find("a.nav-link").filter(function() {
+    var tocHref = $(this).attr("href");
+    tocHref = tocHref.substring(tocHref.lastIndexOf("/") + 1);
+    return href === tocHref;
+  });
+  if (featureToc.length > 0) {
+    var li = featureToc.parent()[0];
+    navigation.activateCurrentPath(li);
+    navigation.scrollItemToMidpoint(li);
+  }
 }
 
-$(document).ready(function () {  
-    checkForNonVersionedPage();
-    addVersionClick();
-    acivateNavMenu();
-    highlightSelectedVersion();
-    selectTOC();
+$(document).ready(function() {
+  checkForNonVersionedPage();
+  addVersionClick();
+  acivateNavMenu();
+  highlightSelectedVersion();
+  selectTOC();
 });

--- a/src/main/content/antora_ui/src/js/05-features.js
+++ b/src/main/content/antora_ui/src/js/05-features.js
@@ -75,11 +75,11 @@ function selectTOC() {
   }
   // Look for toc under the features dropdown
   var featureDropdown = $("li > span").filter(function() {
-    return this.text == "Features";
+    return this.innerText == "Features";
   });
   if (featureDropdown.length === 0) {
     featureDropdown = $("li > a.nav-link").filter(function() {
-      return this.text == "Features";
+      return this.innerText == "Features";
     });
   }
   featureDropdown = featureDropdown.parent();

--- a/src/main/content/antora_ui/src/js/05-features.js
+++ b/src/main/content/antora_ui/src/js/05-features.js
@@ -90,8 +90,9 @@ function selectTOC() {
   });
   if (featureToc.length > 0) {
     var li = featureToc.parent()[0];
+    var anchor = li.querySelector(".nav-link");
     navigation.activateCurrentPath(li);
-    navigation.scrollItemToMidpoint(li);
+    navigation.scrollItemToMidpoint(anchor);
   }
 }
 

--- a/src/main/content/antora_ui/src/sass/nav.scss
+++ b/src/main/content/antora_ui/src/sass/nav.scss
@@ -193,7 +193,8 @@ html.is-clipped--nav {
     height: var(--TOC-toggle-icon-size);
     width: var(--TOC-toggle-icon-size);
     margin-left: -23px;
-    margin-top: -3px;
+    position: absolute;
+    margin-top: 5px;
   }
   & > span,
   & > a {

--- a/src/main/content/antora_ui/src/sass/nav.scss
+++ b/src/main/content/antora_ui/src/sass/nav.scss
@@ -229,7 +229,7 @@ html.is-clipped--nav {
     padding-left: calc(
       var(--TOC-indention-first-level) - var(--TOC-orange-border-width)
     );
-  }
+  }  
   &[data-depth="1"] {
     & > span,
     & > a {
@@ -240,6 +240,10 @@ html.is-clipped--nav {
         var(--TOC-indention-first-level) + var(--TOC-indention) -
           var(--TOC-orange-border-width)
       );
+    }
+    & > .nav-item-toggle ~ .nav-link {
+      display: inline-block;
+      width: calc(100% + (var(--TOC-indention-first-level) + var(--TOC-indention)));
     }
   }
   &[data-depth="2"] {
@@ -253,6 +257,10 @@ html.is-clipped--nav {
           var(--TOC-orange-border-width)
       );
     }
+    & > .nav-item-toggle ~ .nav-link {
+      display: inline-block;
+      width: calc(100% + 2 * (var(--TOC-indention-first-level) + var(--TOC-indention)));
+    }
   }
   &[data-depth="3"] {
     & > span,
@@ -264,6 +272,10 @@ html.is-clipped--nav {
         var(--TOC-indention-first-level) + 3 * var(--TOC-indention) -
           var(--TOC-orange-border-width)
       );
+    }
+    & > .nav-item-toggle ~ .nav-link {
+      display: inline-block;
+      width: calc(100% + 3 * (var(--TOC-indention-first-level) + var(--TOC-indention)));
     }
   }
   &[data-depth="4"] {
@@ -277,12 +289,16 @@ html.is-clipped--nav {
           var(--TOC-orange-border-width)
       );
     }
+    & > .nav-item-toggle ~ .nav-link {
+      display: inline-block;
+      width: calc(100% + 4 * (var(--TOC-indention-first-level) + var(--TOC-indention)));
+    }
   }
 }
 
 .is-current-page > .nav-link,
 .is-current-page > .nav-text {
-  font-weight: var(--body-font-weight-bold);
+  font-weight: var(--body-font-weight-bold);  
 }
 
 .nav-link:focus,


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
This is to fix the issue in https://draft-openlibertyio.mybluemix.net/docs/21.0.0.11/reference/feature/feature-overview.html where the features aren't getting combined because previously the python script was looking to combine features underneath the `span` with the word 'Features' and now this will support both the span for older doc version TOC's as well as the new `anchor` dropdowns where the Feature overview dropdown is a clickable page itself.
Fixes this issue with the features not getting combined:
![image](https://user-images.githubusercontent.com/6392944/138509297-cb8e6286-2e63-40f7-bb06-7505daf1ca4a.png)

Also fix scrolling to the right spot in the toc when features load.
Also change the styling of the nav so these dropdown pages are on the same line as their arrows:
![image](https://user-images.githubusercontent.com/6392944/138509374-7f705b27-6abb-4909-a7ef-026dc423f271.png)

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

