### PR TITLE
Fix scrolling to older doc versions features in the toc

### DIFF
--- a/src/main/content/antora_ui/src/js/05-features.js
+++ b/src/main/content/antora_ui/src/js/05-features.js
@@ -75,11 +75,11 @@ function selectTOC() {
   }
   // Look for toc under the features dropdown
   var featureDropdown = $("li > span").filter(function() {
-    return this.text == "Features";
+    return this.innerText == "Features";
   });
   if (featureDropdown.length === 0) {
     featureDropdown = $("li > a.nav-link").filter(function() {
-      return this.text == "Features";
+      return this.innerText == "Features";
     });
   }
   featureDropdown = featureDropdown.parent();

--- a/src/main/content/antora_ui/src/sass/nav.scss
+++ b/src/main/content/antora_ui/src/sass/nav.scss
@@ -193,7 +193,8 @@ html.is-clipped--nav {
     height: var(--TOC-toggle-icon-size);
     width: var(--TOC-toggle-icon-size);
     margin-left: -23px;
-    margin-top: -3px;
+    position: absolute;
+    margin-top: 5px;
   }
   & > span,
   & > a {


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

