### PR TITLE
Update cypress.env.json website_url to the field the test uses

### DIFF
--- a/src/test/cypressjs/cypress.env.json
+++ b/src/test/cypressjs/cypress.env.json
@@ -1,4 +1,4 @@
 {
-  "default_website_url": "https://demo1-openlibertyio.mybluemix.net",
+  "website_url": "https://demo1-openlibertyio.mybluemix.net",
   "redirects_url": "https://raw.githubusercontent.com/OpenLiberty/docs-playbook/prod/doc-redirects.properties"
 }


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Our cypress test uses website_url rather than default_website_url so there's no point in having it named that unless we change the test to use that.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

