### PR TITLE
Fix the cypress test to use the default url if no website_url env flag is set

### DIFF
--- a/src/test/cypressjs/cypress/integration/testRedirectURLs.js
+++ b/src/test/cypressjs/cypress/integration/testRedirectURLs.js
@@ -20,7 +20,7 @@ describe('Test Redirect URLs', () => {
         // Do not know how to handle urls that are not /docs
         return;
       } else {
-        cy.visit(Cypress.env('website_url') + tokens[0])
+        cy.visit(target_url + tokens[0])
       }
     })
   })

--- a/src/test/cypressjs/cypress/integration/testRedirectURLs.js
+++ b/src/test/cypressjs/cypress/integration/testRedirectURLs.js
@@ -20,7 +20,11 @@ describe('Test Redirect URLs', () => {
         // Do not know how to handle urls that are not /docs
         return;
       } else {
-        cy.visit(target_url + tokens[0])
+        if (tokens[0].endsWith('.html')){
+          cy.visit(target_url + tokens[0])
+        } else {
+          cy.request(target_url + tokens[0])
+        }
       }
     })
   })


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

