### PR TITLE
Add https://docs.oracle.com/ to list of content that can load

### DIFF
--- a/src/main/content/_assets/css/guide-card.css
+++ b/src/main/content/_assets/css/guide-card.css
@@ -64,7 +64,7 @@
     line-height: 21px;
 }
 
-.guide_interactive_container, .new_guide_container {
+.guide_interactive_container, .new_guide_container, .guide_run_in_cloud_container {
     border: 1px solid #CC4D19;
     border-radius: 100px;
     float: right;
@@ -84,7 +84,7 @@
     letter-spacing: 0;
 }
 
-.guide_interactive, .guide_new {
+.guide_interactive, .guide_new, .guide_run_in_cloud {
     font-family: BunueloBold, Arial Narrow, Helvetica, Arial;
     font-size: 13px;
     color: #CC4D19;

--- a/src/main/content/_assets/css/guide-card.css
+++ b/src/main/content/_assets/css/guide-card.css
@@ -64,7 +64,7 @@
     line-height: 21px;
 }
 
-.guide_interactive_container, .new_guide_container, .guide_run_in_cloud_container {
+.guide_interactive_container, .new_guide_container {
     border: 1px solid #CC4D19;
     border-radius: 100px;
     float: right;
@@ -84,7 +84,7 @@
     letter-spacing: 0;
 }
 
-.guide_interactive, .guide_new, .guide_run_in_cloud {
+.guide_interactive, .guide_new {
     font-family: BunueloBold, Arial Narrow, Helvetica, Arial;
     font-size: 13px;
     color: #CC4D19;

--- a/src/main/content/_assets/css/toc-multipane-static.scss
+++ b/src/main/content/_assets/css/toc-multipane-static.scss
@@ -365,7 +365,6 @@
     line-height: 30px;
     overflow-wrap: break-word;
     word-wrap: break-word;
-    white-space: nowrap;
 }
 
 #tags_container a:hover {

--- a/src/main/content/_assets/css/toc-multipane-static.scss
+++ b/src/main/content/_assets/css/toc-multipane-static.scss
@@ -365,6 +365,7 @@
     line-height: 30px;
     overflow-wrap: break-word;
     word-wrap: break-word;
+    white-space: nowrap;
 }
 
 #tags_container a:hover {

--- a/src/main/content/_assets/css/toc.scss
+++ b/src/main/content/_assets/css/toc.scss
@@ -361,7 +361,6 @@
     line-height: 30px;
     overflow-wrap: break-word;
     word-wrap: break-word;
-    white-space: nowrap;
 }
 
 #tags_container a:hover {

--- a/src/main/content/_assets/css/toc.scss
+++ b/src/main/content/_assets/css/toc.scss
@@ -361,6 +361,7 @@
     line-height: 30px;
     overflow-wrap: break-word;
     word-wrap: break-word;
+    white-space: nowrap;
 }
 
 #tags_container a:hover {

--- a/src/main/content/_assets/js/guides.js
+++ b/src/main/content/_assets/js/guides.js
@@ -515,17 +515,6 @@ $(document).ready(function () {
             } else {
               $(this).data("tags", tag_name.toLowerCase());
             }
-
-            //add "RUN IN CLOUD" orange pill to applicable guides
-            if (tag_name.toLowerCase() == "run in cloud") {
-              //add to last child element in .guide_item element
-              if ($(this).children().last().hasClass("new_guide_container")) {
-                //add before "NEW" orange pill so "NEW" pill shows first because float: right; reverses element order
-                $('<div class="guide_run_in_cloud_container"><span class="guide_run_in_cloud">Run in cloud</span></div>').insertBefore($(this).children().last());
-              } else {
-                $('<div class="guide_run_in_cloud_container"><span class="guide_run_in_cloud">Run in cloud</span></div>').insertAfter($(this).children().last());
-              }
-            }
           }
         });
       });
@@ -1033,4 +1022,4 @@ $(document).ready(function () {
   });
 
   createNewTag();
-  });
+});

--- a/src/main/content/_assets/js/guides.js
+++ b/src/main/content/_assets/js/guides.js
@@ -515,6 +515,17 @@ $(document).ready(function () {
             } else {
               $(this).data("tags", tag_name.toLowerCase());
             }
+
+            //add "RUN IN CLOUD" orange pill to applicable guides
+            if (tag_name.toLowerCase() == "run in cloud") {
+              //add to last child element in .guide_item element
+              if ($(this).children().last().hasClass("new_guide_container")) {
+                //add before "NEW" orange pill so "NEW" pill shows first because float: right; reverses element order
+                $('<div class="guide_run_in_cloud_container"><span class="guide_run_in_cloud">Run in cloud</span></div>').insertBefore($(this).children().last());
+              } else {
+                $('<div class="guide_run_in_cloud_container"><span class="guide_run_in_cloud">Run in cloud</span></div>').insertAfter($(this).children().last());
+              }
+            }
           }
         });
       });
@@ -1022,4 +1033,4 @@ $(document).ready(function () {
   });
 
   createNewTag();
-});
+  });

--- a/src/main/content/guides.html
+++ b/src/main/content/guides.html
@@ -69,6 +69,7 @@ plus: 1 %} {% endif %} {% endfor %}
         <button type="button" class="tag_button">new</button>
         <button type="button" class="tag_button">microprofile</button>
         <button type="button" class="tag_button">jakarta ee</button>
+        <button type="button" class="tag_button">run in cloud</button>
         <button type="button" class="tag_button">interactive</button>
       </div>
     </div>
@@ -163,7 +164,7 @@ plus: 1 %} {% endif %} {% endfor %}
           />
           <span class="guide_interactive">Interactive</span>
         </div>
-        {% endif %}
+        {% endif %} 
       </a>
     </div>
     {% endfor %}

--- a/src/main/content/guides.html
+++ b/src/main/content/guides.html
@@ -69,7 +69,6 @@ plus: 1 %} {% endif %} {% endfor %}
         <button type="button" class="tag_button">new</button>
         <button type="button" class="tag_button">microprofile</button>
         <button type="button" class="tag_button">jakarta ee</button>
-        <button type="button" class="tag_button">run in cloud</button>
         <button type="button" class="tag_button">interactive</button>
       </div>
     </div>
@@ -164,7 +163,7 @@ plus: 1 %} {% endif %} {% endfor %}
           />
           <span class="guide_interactive">Interactive</span>
         </div>
-        {% endif %} 
+        {% endif %}
       </a>
     </div>
     {% endfor %}

--- a/src/main/java/io/openliberty/website/TLSFilter.java
+++ b/src/main/java/io/openliberty/website/TLSFilter.java
@@ -82,7 +82,7 @@ public class TLSFilter implements Filter {
             response.setHeader("X-Content-Type-Options", "nosniff"); // Stops a browser from trying to MIME-sniff the
                                                                      // content type.
             response.setHeader("Content-Security-Policy",
-                    "default-src 'self' 'unsafe-inline' 'unsafe-eval' maxcdn.bootstrapcdn.com fonts.googleapis.com ajax.googleapis.com code.jquery.com fonts.gstatic.com  *.githubusercontent.com api.github.com www.googletagmanager.com tagmanager.google.com www.google-analytics.com cdnjs.cloudflare.com data: buttons.github.io www.youtube.com *.twitter.com *.twimg.com video.ibm.com https://start.openliberty.io/"); // Mitigating
+                    "default-src 'self' 'unsafe-inline' 'unsafe-eval' maxcdn.bootstrapcdn.com fonts.googleapis.com ajax.googleapis.com code.jquery.com fonts.gstatic.com  *.githubusercontent.com api.github.com www.googletagmanager.com tagmanager.google.com www.google-analytics.com cdnjs.cloudflare.com data: buttons.github.io www.youtube.com *.twitter.com *.twimg.com video.ibm.com https://start.openliberty.io/ https://docs.oracle.com/"); // Mitigating
             // cross
             // site
             // scripting


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Add a new rule to the TLS filter Content Security Policy to allow javadocs from https://docs.oracle.com/ shown on the website.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

