### PR TITLE
No copy to clipboard option for docs pages

### DIFF
--- a/src/main/content/_assets/css/guide-card.css
+++ b/src/main/content/_assets/css/guide-card.css
@@ -64,7 +64,7 @@
     line-height: 21px;
 }
 
-.guide_interactive_container, .new_guide_container {
+.guide_interactive_container, .new_guide_container, .guide_run_in_cloud_container {
     border: 1px solid #CC4D19;
     border-radius: 100px;
     float: right;
@@ -84,7 +84,7 @@
     letter-spacing: 0;
 }
 
-.guide_interactive, .guide_new {
+.guide_interactive, .guide_new, .guide_run_in_cloud {
     font-family: BunueloBold, Arial Narrow, Helvetica, Arial;
     font-size: 13px;
     color: #CC4D19;

--- a/src/main/content/_assets/css/toc-multipane-static.scss
+++ b/src/main/content/_assets/css/toc-multipane-static.scss
@@ -365,6 +365,7 @@
     line-height: 30px;
     overflow-wrap: break-word;
     word-wrap: break-word;
+    white-space: nowrap;
 }
 
 #tags_container a:hover {

--- a/src/main/content/_assets/css/toc.scss
+++ b/src/main/content/_assets/css/toc.scss
@@ -361,6 +361,7 @@
     line-height: 30px;
     overflow-wrap: break-word;
     word-wrap: break-word;
+    white-space: nowrap;
 }
 
 #tags_container a:hover {

--- a/src/main/content/_assets/js/guides.js
+++ b/src/main/content/_assets/js/guides.js
@@ -515,6 +515,17 @@ $(document).ready(function () {
             } else {
               $(this).data("tags", tag_name.toLowerCase());
             }
+
+            //add "RUN IN CLOUD" orange pill to applicable guides
+            if (tag_name.toLowerCase() == "run in cloud") {
+              //add to last child element in .guide_item element
+              if ($(this).children().last().hasClass("new_guide_container")) {
+                //add before "NEW" orange pill so "NEW" pill shows first because float: right; reverses element order
+                $('<div class="guide_run_in_cloud_container"><span class="guide_run_in_cloud">Run in cloud</span></div>').insertBefore($(this).children().last());
+              } else {
+                $('<div class="guide_run_in_cloud_container"><span class="guide_run_in_cloud">Run in cloud</span></div>').insertAfter($(this).children().last());
+              }
+            }
           }
         });
       });
@@ -1022,4 +1033,4 @@ $(document).ready(function () {
   });
 
   createNewTag();
-});
+  });

--- a/src/main/content/antora_ui/src/js/11-copy-to-clipboard.js
+++ b/src/main/content/antora_ui/src/js/11-copy-to-clipboard.js
@@ -9,9 +9,10 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
+ var code_blocks_with_copy_to_clipboard = 'pre:not(.no_copy pre)'; // CSS Selector
 $(document).ready(function () {
-    // Show copy to clipboard button when mouse enters code block
-    $('pre').on('mouseenter', function(event) {
+    // Show copy to clipboard button when mouse enters code block only if block lacks .no_copy class
+    $(code_blocks_with_copy_to_clipboard).on('mouseenter', function(event) {
         target = $(event.currentTarget);
         $('main').append('<div id="copied_confirmation">Copied to clipboard</div><img id="copy_to_clipboard" src="../../../../_/img/guides_copy_button.svg" alt="Copy code block" title="Copy code block">');
         $('#copy_to_clipboard').css({

--- a/src/main/content/guides.html
+++ b/src/main/content/guides.html
@@ -69,6 +69,7 @@ plus: 1 %} {% endif %} {% endfor %}
         <button type="button" class="tag_button">new</button>
         <button type="button" class="tag_button">microprofile</button>
         <button type="button" class="tag_button">jakarta ee</button>
+        <button type="button" class="tag_button">run in cloud</button>
         <button type="button" class="tag_button">interactive</button>
       </div>
     </div>
@@ -163,7 +164,7 @@ plus: 1 %} {% endif %} {% endfor %}
           />
           <span class="guide_interactive">Interactive</span>
         </div>
-        {% endif %}
+        {% endif %} 
       </a>
     </div>
     {% endfor %}


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

Support the optional removal of "copy to clipboard" for code snippets in the docs pages.
Depends on https://github.com/OpenLiberty/docs/pull/4926

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

