### PR TITLE
Docs: Allow for removal of the "copy to clipboard" button 

### DIFF
--- a/src/main/content/antora_ui/src/js/11-copy-to-clipboard.js
+++ b/src/main/content/antora_ui/src/js/11-copy-to-clipboard.js
@@ -9,9 +9,10 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
+ var code_blocks_with_copy_to_clipboard = 'pre:not(.no_copy pre)'; // CSS Selector
 $(document).ready(function () {
-    // Show copy to clipboard button when mouse enters code block
-    $('pre').on('mouseenter', function(event) {
+    // Show copy to clipboard button when mouse enters code block only if block lacks .no_copy class
+    $(code_blocks_with_copy_to_clipboard).on('mouseenter', function(event) {
         target = $(event.currentTarget);
         $('main').append('<div id="copied_confirmation">Copied to clipboard</div><img id="copy_to_clipboard" src="../../../../_/img/guides_copy_button.svg" alt="Copy code block" title="Copy code block">');
         $('#copy_to_clipboard').css({


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

Related to https://github.com/OpenLiberty/openliberty.io/issues/2263

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

