### PR TITLE
Code column wasn't always at top of browser window in multi-column view

### DIFF
--- a/src/main/content/_assets/js/openliberty.js
+++ b/src/main/content/_assets/js/openliberty.js
@@ -116,7 +116,15 @@ var openliberty = (function() {
             $("#toc_inner").css("margin-top", "0px");
         }
         $("#toc_indicator").css("margin-top", "0px");
-        $("#code_column").css({"position":"fixed"})
+
+        //handles where the top of the code column should be
+        if (!inSingleColumnView()) {
+            //below the hotspot in single column view
+            $("#code_column").css({"position":"fixed", "top":"0px"})
+        } else {
+            //at the top of the browser window in multi-column view
+            $("#code_column").css("position", "fixed");
+        }
 
         // reset body margin-top
         $('body').css("margin-top", "0px");

--- a/src/main/content/_assets/js/openliberty.js
+++ b/src/main/content/_assets/js/openliberty.js
@@ -119,10 +119,10 @@ var openliberty = (function() {
 
         //handles where the top of the code column should be
         if (!inSingleColumnView()) {
-            //below the hotspot in single column view
+            //at the top of the browser window in multi-column view
             $("#code_column").css({"position":"fixed", "top":"0px"})
         } else {
-            //at the top of the browser window in multi-column view
+            //below the hotspot in single column view
             $("#code_column").css("position", "fixed");
         }
 


### PR DESCRIPTION
#### What was fixed?  Incomplete fix for #2307 went into draft under #2353 
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [x] Dymanic Accessability Plugin (DAP) -- now IBM Equal Access Accessibility Checker
- [ ] Lighthouse (in Chrome dev tools)

