### PR TITLE
Merging fix for code block missing in single column view; Allow for not copyable code blocks in docs

### DIFF
--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -448,6 +448,9 @@ $(document).ready(function () {
     });
 
     $(window).on("resize", function () {
+        if (!inSingleColumnView()){
+            $("#code_column").css("top", "0px");
+        }
         handleFloatingTableOfContent(); // Handle table of content view changes.
         handleFloatingTOCAccordion();
         resizeGuideSections();

--- a/src/main/content/_assets/js/guide-multipane-static.js
+++ b/src/main/content/_assets/js/guide-multipane-static.js
@@ -783,7 +783,7 @@ $(document).ready(function () {
             var bottom = scrollTo + window.innerHeight - hotspot_height - 5;
             var height = bottom - scrollTo;
             $("#code_column").css({
-                top: scrollTo + mobile_toc_height + hotspot_height + 5 + "px",
+                top: mobile_toc_height + hotspot_height + 5 + "px",
                 left: "0px",
                 height: height,
             });

--- a/src/main/content/_assets/js/openliberty.js
+++ b/src/main/content/_assets/js/openliberty.js
@@ -116,7 +116,7 @@ var openliberty = (function() {
             $("#toc_inner").css("margin-top", "0px");
         }
         $("#toc_indicator").css("margin-top", "0px");
-        $("#code_column").css({"position":"fixed", "top":"0px"})
+        $("#code_column").css({"position":"fixed"})
 
         // reset body margin-top
         $('body').css("margin-top", "0px");

--- a/src/main/content/_assets/js/openliberty.js
+++ b/src/main/content/_assets/js/openliberty.js
@@ -116,7 +116,15 @@ var openliberty = (function() {
             $("#toc_inner").css("margin-top", "0px");
         }
         $("#toc_indicator").css("margin-top", "0px");
-        $("#code_column").css({"position":"fixed"})
+
+        //handles where the top of the code column should be
+        if (!inSingleColumnView()) {
+            //below the hotspot in single column view
+            $("#code_column").css({"position":"fixed", "top":"0px"})
+        } else {
+            //at the top of the browser window in multi-column view
+            $("#code_column").css("position", "fixed");
+        }
 
         // reset body margin-top
         $('body').css("margin-top", "0px");

--- a/src/main/content/_assets/js/openliberty.js
+++ b/src/main/content/_assets/js/openliberty.js
@@ -119,10 +119,10 @@ var openliberty = (function() {
 
         //handles where the top of the code column should be
         if (!inSingleColumnView()) {
-            //below the hotspot in single column view
+            //at the top of the browser window in multi-column view
             $("#code_column").css({"position":"fixed", "top":"0px"})
         } else {
-            //at the top of the browser window in multi-column view
+            //below the hotspot in single column view
             $("#code_column").css("position", "fixed");
         }
 

--- a/src/main/content/antora_ui/src/js/11-copy-to-clipboard.js
+++ b/src/main/content/antora_ui/src/js/11-copy-to-clipboard.js
@@ -9,9 +9,10 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
+ var code_blocks_with_copy_to_clipboard = 'pre:not(.no_copy pre)'; // CSS Selector
 $(document).ready(function () {
-    // Show copy to clipboard button when mouse enters code block
-    $('pre').on('mouseenter', function(event) {
+    // Show copy to clipboard button when mouse enters code block only if block lacks .no_copy class
+    $(code_blocks_with_copy_to_clipboard).on('mouseenter', function(event) {
         target = $(event.currentTarget);
         $('main').append('<div id="copied_confirmation">Copied to clipboard</div><img id="copy_to_clipboard" src="../../../../_/img/guides_copy_button.svg" alt="Copy code block" title="Copy code block">');
         $('#copy_to_clipboard').css({


### PR DESCRIPTION
#### What was fixed?  #2307 
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [x] Dymanic Accessability Plugin (DAP) -- now IBM Equal Access Accessibility Checker
- [ ] Lighthouse (in Chrome dev tools)

