### PR TITLE
Check if inSingleColumnView is a function before calling it 

### DIFF
--- a/src/main/content/_assets/js/openliberty.js
+++ b/src/main/content/_assets/js/openliberty.js
@@ -118,13 +118,15 @@ var openliberty = (function() {
         $("#toc_indicator").css("margin-top", "0px");
 
         //handles where the top of the code column should be
-        if (!inSingleColumnView()) {
+        if(typeof(inSingleColumnView) === 'function'){
+            if (!inSingleColumnView()) {
             //at the top of the browser window in multi-column view
             $("#code_column").css({"position":"fixed", "top":"0px"})
-        } else {
-            //below the hotspot in single column view
-            $("#code_column").css("position", "fixed");
-        }
+            } else {
+                //below the hotspot in single column view
+                $("#code_column").css("position", "fixed");
+            } 
+        }        
 
         // reset body margin-top
         $('body').css("margin-top", "0px");


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
This is due to a bug recently where we fixed guides' single column view resizing to full width browsers. This caused the nav to disappear when scrolling any page other than guides.

We should really move this code into a guides specific javascript. I will link to the issue.
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

