### PR TITLE
changed link path downloads to start

### DIFF
--- a/src/main/content/antora_ui/src/partials/header-content.hbs
+++ b/src/main/content/antora_ui/src/partials/header-content.hbs
@@ -11,7 +11,7 @@
         <div id="hamburger_menu">
             <ul class="nav_list">
                 <li class="nav_link">
-                    <a href="/downloads">Get Started</a>
+                    <a href="/start">Get Started</a>
                 </li>
                 <li class="nav_link">
                     <a href="/guides">Guides</a>

--- a/src/main/content/index.html
+++ b/src/main/content/index.html
@@ -28,7 +28,7 @@ css:
                         Open Liberty<sup>TM</sup> is the most flexible server runtime available to Java<sup>TM</sup> developers in this solar system.
                     </p>
                     <div id="download_links_container">
-                        <a id="download_link" href="/downloads">Get Open Liberty</a>
+                        <a id="download_link" href="/start">Get Open Liberty</a>
                     </div>
                 </div>
             </div>

--- a/src/main/content/sitemap.xml
+++ b/src/main/content/sitemap.xml
@@ -16,7 +16,7 @@
         <changefreq>weekly</changefreq>
     </url>
     <url>
-        <loc>https://openliberty.io/downloads/</loc>
+        <loc>https://openliberty.io/start/</loc>
         <changefreq>monthly</changefreq>
     </url>
     <url>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

