### PR TITLE
Combine Jakarta/Java EE Features; Add 'Updated' label for guides; Change references to /downloads to /start

### DIFF
--- a/scripts/build/parse_features_toc.py
+++ b/scripts/build/parse_features_toc.py
@@ -219,6 +219,13 @@ for version in versions:
     for toc in tocs:
         toc['class'] = 'nav-item'
 
+    # Sort features list alphabetically ignoring case
+    ul = featureDropdown.find(attrs={"class": "nav-list"})
+    features = [li.extract() for li in ul.find_all('li', {'class': 'nav-item'})]
+    features.sort(key=lambda e: e.find(attrs={"class": "nav-link"}).string.lower())
+    for linebreak, li in reversed(list(zip(ul.contents, features))):
+     linebreak.insert_after(li)
+
     # Write the new TOC to the feature-overview.html with version control in it
     with open(antora_path + 'feature/feature-overview.html', "w") as file:     
         file.write(str(featureIndex))

--- a/scripts/build/parse_features_toc.py
+++ b/scripts/build/parse_features_toc.py
@@ -129,7 +129,10 @@ for version in versions:
 
     # Make sure all Jakarta EE feature names in the mapping are in the list of commonTOC so they get combined later.
     for mapping in java_to_jakarta_feature_mapping:
+        java_feature_name = mapping[0]
         jakarta_feature_name = mapping[1]
+        if java_feature_name + '.html' in commonTOCKeys:
+            del commonTOCs[java_feature_name + '.html']
         if jakarta_feature_name + '.html' not in commonTOCKeys:
             commonTOCs[jakarta_feature_name + '.html'] = '^' + jakarta_feature_name + '-\\d+[.]?\\d*.html$'
 
@@ -151,6 +154,8 @@ for version in versions:
                 for java_toc in matching_java_tocs:
                   matchingTitleTOCs.append(java_toc)
                   TOCToDecompose.append(java_toc.parent)
+
+        # print(matchingTitleTOCs)
                 
         firstElement = True;
         # determine whether there are multiple versions            
@@ -183,8 +188,15 @@ for version in versions:
                         versionDiv.append(hrefTag)
                 else:
                     hrefTag = createVersionHref(featurePage, tocHref, matchingTOC.string)
-                    versionDiv.append(hrefTag)
-                    TOCToDecompose.append(matchingTOC.parent)
+                    versionDiv.append(hrefTag)    
+                    jakartaFeature = False             
+                    for mapping in java_to_jakarta_feature_mapping:
+                        jakarta_pattern = re.compile('^' + mapping[1] + '-\\d+[.]?\\d*.html$')
+                        if jakarta_pattern.match(matchingTOC.get('href')):
+                            jakartaFeature = True
+                            break
+                    if not jakartaFeature:
+                        TOCToDecompose.append(matchingTOC.parent)                        
         # Write the feature title and the versions to the page div
         pageTitle.append(titleDiv)
         pageTitle.append(versionDiv)

--- a/scripts/build/parse_features_toc.py
+++ b/scripts/build/parse_features_toc.py
@@ -163,9 +163,7 @@ for version in versions:
                     for java_toc in matching_java_tocs[::-1]:
                         if(java_toc.get('href') != "javaee-8.0.html"):
                             matchingTitleTOCs.insert(0, java_toc) # Prepend     
-                            TOCToDecompose.append(java_toc.parent)
-                        else:
-                            TOCToDecompose.append(java_toc.parent)
+                        TOCToDecompose.append(java_toc.parent)
                 
         firstElement = True;
         # determine whether there are multiple versions            

--- a/scripts/build/parse_features_toc.py
+++ b/scripts/build/parse_features_toc.py
@@ -147,9 +147,10 @@ for version in versions:
                 # Get the Java equivalent
                 java_name = mapping[0]
                 java_regex = '^' + java_name + '-\\d+[.]?\\d*.html$'
-                matchingJavaTOCs = featureIndex.find_all('a', {'class': 'nav-link'}, href=re.compile(java_regex))
-                for JavaTOC in matchingJavaTOCs:
-                  matchingTitleTOCs.append(JavaTOC)
+                matching_java_tocs = featureIndex.find_all('a', {'class': 'nav-link'}, href=re.compile(java_regex))
+                for java_toc in matching_java_tocs:
+                  matchingTitleTOCs.append(java_toc)
+                  TOCToDecompose.append(java_toc.parent)
                 
         firstElement = True;
         # determine whether there are multiple versions            
@@ -163,7 +164,7 @@ for version in versions:
         # in reverse descending order
         matchingTOCs = matchingTitleTOCs[::-1]
         for matchingTOC in matchingTOCs:
-            tocHref = matchingTOC.get('href')
+            tocHref = matchingTOC.get('href')            
             if not str.startswith(tocHref, ".."):
                 if firstElement:
                     firstElement = False

--- a/scripts/build/parse_features_toc.py
+++ b/scripts/build/parse_features_toc.py
@@ -152,10 +152,8 @@ for version in versions:
                 java_regex = '^' + java_name + '-\\d+[.]?\\d*.html$'
                 matching_java_tocs = featureIndex.find_all('a', {'class': 'nav-link'}, href=re.compile(java_regex))
                 for java_toc in matching_java_tocs:
-                  matchingTitleTOCs.append(java_toc)
-                  TOCToDecompose.append(java_toc.parent)
-
-        # print(matchingTitleTOCs)
+                    matchingTitleTOCs.insert(0, java_toc) # Prepend         
+                    TOCToDecompose.append(java_toc.parent)
                 
         firstElement = True;
         # determine whether there are multiple versions            
@@ -188,15 +186,8 @@ for version in versions:
                         versionDiv.append(hrefTag)
                 else:
                     hrefTag = createVersionHref(featurePage, tocHref, matchingTOC.string)
-                    versionDiv.append(hrefTag)    
-                    jakartaFeature = False             
-                    for mapping in java_to_jakarta_feature_mapping:
-                        jakarta_pattern = re.compile('^' + mapping[1] + '-\\d+[.]?\\d*.html$')
-                        if jakarta_pattern.match(matchingTOC.get('href')):
-                            jakartaFeature = True
-                            break
-                    if not jakartaFeature:
-                        TOCToDecompose.append(matchingTOC.parent)                        
+                    versionDiv.append(hrefTag) 
+                    TOCToDecompose.append(matchingTOC.parent)                        
         # Write the feature title and the versions to the page div
         pageTitle.append(titleDiv)
         pageTitle.append(versionDiv)

--- a/scripts/build/parse_features_toc.py
+++ b/scripts/build/parse_features_toc.py
@@ -112,7 +112,6 @@ for version in versions:
         ("ejbRemote", "enterpriseBeansRemote"),
         ("el", "expressionLanguage"),
         ("jacc", "appAuthorization"),
-        ("javaee", "jakartaee"),
         ("javaeeClient", "jakartaeeClient"),
         ("jaspic", "appAuthentication"),
         ("javaMail", "mail"),
@@ -161,8 +160,7 @@ for version in versions:
                     matching_java_tocs = featureIndex.find_all('a', {'class': 'nav-link'}, href=re.compile(java_regex))
                     # Add in reversed order to the list of Jakarta feature versions
                     for java_toc in matching_java_tocs[::-1]:
-                        if(java_toc.get('href') != "javaee-8.0.html"):
-                            matchingTitleTOCs.insert(0, java_toc) # Prepend     
+                        matchingTitleTOCs.insert(0, java_toc) # Prepend     
                         TOCToDecompose.append(java_toc.parent)
                 
         firstElement = True;

--- a/scripts/build/parse_features_toc.py
+++ b/scripts/build/parse_features_toc.py
@@ -100,10 +100,57 @@ for version in versions:
     commonTOCKeys = commonTOCs.keys()
     commonTOCKeys = list(commonTOCKeys)
 
+    java_to_jakarta_feature_mapping = [("ejb","enterpriseBeans"),
+        ("ejbHome", "enterpriseBeansHome"),
+        ("ejbLite", "enterpriseBeansLite"),
+        ("ejbPersistentTimer", "enterpriseBeansPersistentTimer"),
+        ("ejbRemote", "enterpriseBeansRemote"),
+        ("el", "expressionLanguage"),
+        ("jacc", "appAuthorization"),
+        ("javaee", "jakartaee"),
+        ("javaeeClient", "jakartaeeClient"),
+        ("jaspic", "appAuthentication"),
+        ("javaMail", "mail"),
+        ("jaxb", "xmlBinding"),
+        ("jaxrs", "restfulWS"),
+        ("jaxrsClient", "restfulWSClient"),
+        ("jaxws", "xmlWS"),
+        ("jca", "connectors"),
+        ("jcaInboundSecurity", "connectorsInboundSecurity"),
+        ("jms", "messaging"),
+        ("jpa", "persistence"),
+        ("jpaContainer", "persistenceContainer"),
+        ("jsf", "faces"),
+        ("jsfContainer", "facesContainer"),
+        ("jsp", "pages"),
+        ("wasJmsClient", "messagingClient"),
+        ("wasJmsSecurity", "messagingSecurity"),
+        ("wasJmsServer", "messagingServer")]
+
+    # Make sure all Jakarta EE feature names in the mapping are in the list of commonTOC so they get combined later.
+    for mapping in java_to_jakarta_feature_mapping:
+        jakarta_feature_name = mapping[1]
+        if jakarta_feature_name + '.html' not in commonTOCKeys:
+            commonTOCs[jakarta_feature_name + '.html'] = '^' + jakarta_feature_name + '-\\d+[.]?\\d*.html$'
+
+    commonTOCKeys = commonTOCs.keys()
+    commonTOCKeys = list(commonTOCKeys)
+
     TOCToDecompose = []
     for commonTOC in commonTOCKeys:
         commonTOCMatchString = commonTOCs[commonTOC]
         matchingTitleTOCs = featureIndex.find_all('a', {'class': 'nav-link'}, href=re.compile(commonTOCMatchString))
+        # Check for old Java features here and concat them to the list of Jakarta matches
+        for mapping in java_to_jakarta_feature_mapping:
+            jakarta_feature_name = mapping[1]            
+            if jakarta_feature_name + '.html' == commonTOC:
+                # Get the Java equivalent
+                java_name = mapping[0]
+                java_regex = '^' + java_name + '-\\d+[.]?\\d*.html$'
+                matchingJavaTOCs = featureIndex.find_all('a', {'class': 'nav-link'}, href=re.compile(java_regex))
+                for JavaTOC in matchingJavaTOCs:
+                  matchingTitleTOCs.append(JavaTOC)
+                
         firstElement = True;
         # determine whether there are multiple versions            
         firstHref = matchingTitleTOCs[0].get('href')

--- a/scripts/build/parse_features_toc.py
+++ b/scripts/build/parse_features_toc.py
@@ -151,8 +151,15 @@ for version in versions:
             # Open page and rewrite the version part
             versionHref = antora_path + 'feature/' + matchingTOC.get('href')
             versionPage = BeautifulSoup(open(versionHref), "lxml")
-            versionTitle = versionPage.find('h1', {'class': 'page'})
-            versionTitle.replace_with(pageTitle)
+            versionTitle = versionPage.find('h1', {'class': 'page'})  
+            # Get the matchingTOC's string and write it over the shared title of this feature version            
+            if versionTitle is not None:   
+                versionTitle.replace_with(pageTitle)       
+            displayTitle = versionPage.find('div', {'id': 'feature_name_string'})
+            if displayTitle is not None and len(displayTitle) > 0:
+                displayTitle.string = matchingTOC.string
+                displayTitle['full_title'] = "{}".format(matchingTOC.string)
+                displayTitle['aria-label'] = "{}".format(matchingTOC.string)
             with open(versionHref, "w") as file:
                 file.write(str(versionPage))
 

--- a/src/main/content/_assets/css/guide-card.css
+++ b/src/main/content/_assets/css/guide-card.css
@@ -64,7 +64,7 @@
     line-height: 21px;
 }
 
-.guide_interactive_container, .new_guide_container, .guide_run_in_cloud_container {
+.guide_interactive_container, .new_guide_container, .updated_guide_container, .guide_run_in_cloud_container {
     border: 1px solid #CC4D19;
     border-radius: 100px;
     float: right;
@@ -84,7 +84,7 @@
     letter-spacing: 0;
 }
 
-.guide_interactive, .guide_new, .guide_run_in_cloud {
+.guide_interactive, .guide_new, .guide_updated, .guide_run_in_cloud {
     font-family: BunueloBold, Arial Narrow, Helvetica, Arial;
     font-size: 13px;
     color: #CC4D19;

--- a/src/main/content/_assets/js/guides.js
+++ b/src/main/content/_assets/js/guides.js
@@ -546,6 +546,19 @@ $(document).ready(function () {
     });
   }
 
+  // Turn the "Updated" flag into an actual searchable tag
+  function createUpdatedTag() {
+    $(".updated_guide_container").each(function (i, j) {
+      if ($(this).parent().data("tags")) {
+        $(this)
+          .parent()
+          .data("tags", $(this).data("tags") + " updated");
+      } else {
+        $(this).parent().data("tags", "updated");
+      }
+    });
+  }
+
   // Move guide cards to correct subcategories
   function sortGuides(subcategory, guideList) {
     // iterate over array of guides from JSON file
@@ -1033,4 +1046,5 @@ $(document).ready(function () {
   });
 
   createNewTag();
+  createUpdatedTag();
   });

--- a/src/main/content/_includes/end-of-guide.html
+++ b/src/main/content/_includes/end-of-guide.html
@@ -126,7 +126,17 @@
                                         </div>
                                     {% endif %}
                                 {% endif %}
-
+                                <!-- Add Updated flag to guides if the last major update is within last 12 weeks. -->
+                                <!-- Count number of guides from past last 12 weeks that is 84 days-->
+                                <!-- 7257600 is 84 days in seconds (84 days * 24 hours * 60 minutes * 60 seconds) -->
+                                {% if related-guide-metadata.majorupdateddate %}
+                                {% assign date_updated = related-guide-metadata.majorupdateddate | date:'%s' %}
+                                {% assign date_now = 'now' | date:'%s' %} {% assign date_difference =
+                                date_now | minus: date_updated %} {% if date_difference < 7257600 %}
+                                <div class="updated_guide_container">
+                                    <span class="guide_updated">Updated</span>
+                                </div>
+                                {% endif %}{% endif %}
                                 {% if related-guide-metadata.layout == 'iguide-multipane' %}
                                     <div class="guide_interactive_container">
                                         <img class="interactive_bolt_icon" src="/img/guide_lightning_bolt.svg" alt="Interactive">

--- a/src/main/content/_layouts/guide-multipane.html
+++ b/src/main/content/_layouts/guide-multipane.html
@@ -105,6 +105,17 @@ plus: 1 %} {% endif %} {% endfor %}
             <span class="guide_new">New</span>
           </div>
           {% endif %} {% endif %}
+          <!-- Add Updated flag to guides if the last major update is within last 12 weeks. -->
+          <!-- Count number of guides from past last 12 weeks that is 84 days-->
+          <!-- 7257600 is 84 days in seconds (84 days * 24 hours * 60 minutes * 60 seconds) -->
+          {% if page.majorupdateddate %}
+          {% assign date_updated = page.majorupdateddate | date:'%s' %}
+          {% assign date_now = 'now' | date:'%s' %} {% assign date_difference =
+          date_now | minus: date_updated %} {% if date_difference < 7257600 %}
+          <div class="updated_guide_container">
+            <span class="guide_updated">Updated</span>
+          </div>
+          {% endif %}{% endif %}
         </div>
         <div id="mobile_prereqs_section">
           <p id="mobile_prereqs_title">Prerequisites:</p>

--- a/src/main/content/_layouts/guide.html
+++ b/src/main/content/_layouts/guide.html
@@ -106,6 +106,17 @@ plus: 1 %} {% endif %} {% endfor %}
               <span class="guide_new">New</span>
             </div>
             {% endif %} {% endif %}
+            <!-- Add Updated flag to guides if the last major update is within last 12 weeks. -->
+            <!-- Count number of guides from past last 12 weeks that is 84 days-->
+            <!-- 7257600 is 84 days in seconds (84 days * 24 hours * 60 minutes * 60 seconds) -->
+            {% if page.majorupdateddate %}
+            {% assign date_updated = page.majorupdateddate | date:'%s' %}
+            {% assign date_now = 'now' | date:'%s' %} {% assign date_difference =
+            date_now | minus: date_updated %} {% if date_difference < 7257600 %}
+            <div class="updated_guide_container">
+              <span class="guide_updated">Updated</span>
+            </div>
+            {% endif %}{% endif %}
           </div>
           <div id="mobile_prereqs_section">
             <p id="mobile_prereqs_title">Prerequisites:</p>

--- a/src/main/content/_layouts/iguide-multipane.html
+++ b/src/main/content/_layouts/iguide-multipane.html
@@ -102,7 +102,17 @@ plus: 1 %} {% endif %} {% endfor %}
             <span class="guide_new">New</span>
           </div>
           {% endif %} {% endif %}
-
+          <!-- Add Updated flag to guides if the last major update is within last 12 weeks. -->
+          <!-- Count number of guides from past last 12 weeks that is 84 days-->
+          <!-- 7257600 is 84 days in seconds (84 days * 24 hours * 60 minutes * 60 seconds) -->
+          {% if page.majorupdateddate %}
+          {% assign date_updated = page.majorupdateddate | date:'%s' %}
+          {% assign date_now = 'now' | date:'%s' %} {% assign date_difference =
+          date_now | minus: date_updated %} {% if date_difference < 7257600 %}
+          <div class="updated_guide_container">
+            <span class="guide_updated">Updated</span>
+          </div>
+          {% endif %}{% endif %}
           <div class="guide_interactive_container">
             <img
               class="interactive_bolt_icon"

--- a/src/main/content/antora_ui/src/partials/header-content.hbs
+++ b/src/main/content/antora_ui/src/partials/header-content.hbs
@@ -11,7 +11,7 @@
         <div id="hamburger_menu">
             <ul class="nav_list">
                 <li class="nav_link">
-                    <a href="/downloads">Get Started</a>
+                    <a href="/start">Get Started</a>
                 </li>
                 <li class="nav_link">
                     <a href="/guides">Guides</a>

--- a/src/main/content/guides.html
+++ b/src/main/content/guides.html
@@ -67,7 +67,6 @@ plus: 1 %} {% endif %} {% endfor %}
       <div id="popover_content" class="hide" style="display: none">
         <p class="tags_title">Suggested tags</p>
         <button type="button" class="tag_button">new</button>
-        <button type="button" class="tag_button">updated</button>
         <button type="button" class="tag_button">microprofile</button>
         <button type="button" class="tag_button">jakarta ee</button>
         <button type="button" class="tag_button">run in cloud</button>

--- a/src/main/content/guides.html
+++ b/src/main/content/guides.html
@@ -67,6 +67,7 @@ plus: 1 %} {% endif %} {% endfor %}
       <div id="popover_content" class="hide" style="display: none">
         <p class="tags_title">Suggested tags</p>
         <button type="button" class="tag_button">new</button>
+        <button type="button" class="tag_button">updated</button>
         <button type="button" class="tag_button">microprofile</button>
         <button type="button" class="tag_button">jakarta ee</button>
         <button type="button" class="tag_button">run in cloud</button>
@@ -155,7 +156,19 @@ plus: 1 %} {% endif %} {% endfor %}
         <div class="new_guide_container">
           <span class="guide_new">New</span>
         </div>
-        {% endif %} {% endif %} {% if guide.layout == 'iguide-multipane' %}
+        {% endif %} {% endif %} 
+        <!-- Add Updated flag to guides if the last major update is within last 12 weeks. -->
+        <!-- Count number of guides from past last 12 weeks that is 84 days-->
+        <!-- 7257600 is 84 days in seconds (84 days * 24 hours * 60 minutes * 60 seconds) -->
+        {% if guide.majorupdateddate %}
+        {% assign date_updated = guide.majorupdateddate | date:'%s' %}
+        {% assign date_now = 'now' | date:'%s' %} {% assign date_difference =
+        date_now | minus: date_updated %} {% if date_difference < 7257600 %}
+        <div class="updated_guide_container">
+          <span class="guide_updated">Updated</span>
+        </div>
+        {% endif %}{% endif %}
+        {% if guide.layout == 'iguide-multipane' %}
         <div class="guide_interactive_container">
           <img
             class="interactive_bolt_icon"

--- a/src/main/content/index.html
+++ b/src/main/content/index.html
@@ -28,7 +28,7 @@ css:
                         Open Liberty<sup>TM</sup> is the most flexible server runtime available to Java<sup>TM</sup> developers in this solar system.
                     </p>
                     <div id="download_links_container">
-                        <a id="download_link" href="/downloads">Get Open Liberty</a>
+                        <a id="download_link" href="/start">Get Open Liberty</a>
                     </div>
                 </div>
             </div>

--- a/src/main/content/sitemap.xml
+++ b/src/main/content/sitemap.xml
@@ -16,7 +16,7 @@
         <changefreq>weekly</changefreq>
     </url>
     <url>
-        <loc>https://openliberty.io/downloads/</loc>
+        <loc>https://openliberty.io/start/</loc>
         <changefreq>monthly</changefreq>
     </url>
     <url>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Link to combined Jakarta/Java EE on staging: https://staging-openlibertyio.mybluemix.net/docs/21.0.0.12/reference/feature/appSecurity-4.0.html
And old doc versions still look the same: https://staging-openlibertyio.mybluemix.net/docs/21.0.0.11/reference/feature/appSecurity-3.0.html

Guide updated label on staging:
https://staging-openlibertyio.mybluemix.net/guides/#build
![image](https://user-images.githubusercontent.com/6392944/144489359-2ca34b89-e173-4eab-959b-ecd2dcefb77c.png)

https://staging-openlibertyio.mybluemix.net/guides/maven-multimodules.html
![image](https://user-images.githubusercontent.com/6392944/144489395-f5336b50-5292-4bf7-a861-3f7a21c9abd0.png)

https://staging-openlibertyio.mybluemix.net/guides/maven-intro.html
![image](https://user-images.githubusercontent.com/6392944/144489442-05e8ac33-2f22-44cc-9875-befecdad0a0c.png)

#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

