### PR TITLE
show guide tags only when visible attr set to true

### DIFF
--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -416,7 +416,7 @@ function getTags(callback) {
     $.getJSON("../../guides/guides-common/guide_tags.json", function (data) {
         $.each(data.guide_tags, function (i, tag) {
             // Check if tag is visible before adding it
-            if (tag.visible) {
+            if (tag.visible == "true") {
                 project_id = window.location.pathname
                     .replace("/guides/", "")
                     .replace(".html", "");


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

