### PR TITLE
Only list one beta build based on driver_location (staging branch)

### DIFF
--- a/src/main/content/_assets/js/builds.js
+++ b/src/main/content/_assets/js/builds.js
@@ -203,10 +203,15 @@ function render_builds(builds, parent) {
             // beta releases table only
             else if (parent.parent().data('builds-id') == 'runtime_betas') {
                 var package_locations = build.package_locations;
-                if (
-                    package_locations !== null &&
-                    package_locations !== undefined
-                ) {
+                if (package_locations !== null && package_locations !== undefined) {
+                    package_locations = package_locations.filter(function (x) {
+                        // The assumption is there is only one zip for the beta build.  If 
+                        // there are any other zips returned from DHE, ignore them.
+                        var url = x.split('=')[1];
+                        if(url === build.driver_location) {
+                            return x;
+                        }
+                    });
                     var num_packages = package_locations.length;
                     var version_column = $(
                         '<td headers="' +


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

Tested using `draft` branch. https://draft-openlibertyio.mybluemix.net/start/#runtime_betas

- The assumption is that the `driver_location` for the `runtime_betas`
JSON key from the DHE API https://openliberty.io/api/builds/data points
to the only downloadable zip for each beta version. This is unlike the
`runtime_releases` where there can be multiple zips containing
different content (e.g. kernal, webProfile).

Fixes #2377

Example of JSON from DHE API https://openliberty.io/api/builds/data
![image](https://user-images.githubusercontent.com/31117513/145088559-3e8b9eea-b063-46bc-a0c5-a3a5dcca6eeb.png)

Before
![image](https://user-images.githubusercontent.com/31117513/145097319-0d29b3eb-de11-405d-adc8-d45c3381e12d.png)

After
![image](https://user-images.githubusercontent.com/31117513/145097283-22345c39-7510-457f-b7fc-cf9ab340b1a3.png)


#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

