### PR TITLE
Use an allow list for determining which builds show on the website (staging)

### DIFF
--- a/src/main/content/_assets/js/builds.js
+++ b/src/main/content/_assets/js/builds.js
@@ -82,7 +82,7 @@ function getAllowedBuilds(build_type, package_locations, liberty_version) {
         var zipKey = x.split('=')[0];
         var allowList =  liberty_version ? allowed_builds[build_type](liberty_version) 
             : allowed_builds[build_type];
-        if(allowList.indexOf(zipKey) > 0) {
+        if(allowList.indexOf(zipKey) > -1) {
             return x;
         }
     });


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

For #2377 

- Move away from blindly showing all zips found on DHE. Use a hardcoded
list of zips that we expect to be listed on the website.

- It is tricky to construct the allowed list for the Betas zips because
beta zips are labeled by the liberty version. This is handled by a
function to construct the allow list on the fly.

- There can be more than one zip per beta version. Replace the previous
fix from c0f13d4b55a62fb55833aaa0a884966ff04ae78a with the new allow
list logic.

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)