### PR TITLE
Remove slf4j log4j12 and install GPG

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,14 +66,6 @@
 			<scope>test</scope>
 		</dependency>
 
-		<!-- Enable Logging for MicroShed Testing-->
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.7.26</version>
-			<scope>test</scope>
-		</dependency>
-
 		<!-- Mock server for mock DHE server support -->
 		<dependency>
 			<groupId>org.testcontainers</groupId>

--- a/scripts/build/ruby_install.sh
+++ b/scripts/build/ruby_install.sh
@@ -2,6 +2,8 @@
 timer_start=$(date +%s)
 
 echo "Install Ruby & required packages/gems"
+sudo apt-get install gnupg build-essential
+
 cat $BUILD_SCRIPTS_DIR/../gpg/mpapis.asc | gpg --import -
 cat $BUILD_SCRIPTS_DIR/../gpg/pkuczynski.asc | gpg --import -
 

--- a/scripts/build/ruby_install.sh
+++ b/scripts/build/ruby_install.sh
@@ -2,6 +2,8 @@
 timer_start=$(date +%s)
 
 echo "Install Ruby & required packages/gems"
+sudo apt-get -y install gnupg build-essential
+
 cat $BUILD_SCRIPTS_DIR/../gpg/mpapis.asc | gpg --import -
 cat $BUILD_SCRIPTS_DIR/../gpg/pkuczynski.asc | gpg --import -
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

- Remove `slf4j-log4j12`
- Ensure the build environment has GPG installed (PR #2407).

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

