### PR TITLE
Update production

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,14 +66,6 @@
 			<scope>test</scope>
 		</dependency>
 
-		<!-- Enable Logging for MicroShed Testing-->
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.7.26</version>
-			<scope>test</scope>
-		</dependency>
-
 		<!-- Mock server for mock DHE server support -->
 		<dependency>
 			<groupId>org.testcontainers</groupId>

--- a/scripts/build/ruby_install.sh
+++ b/scripts/build/ruby_install.sh
@@ -2,6 +2,8 @@
 timer_start=$(date +%s)
 
 echo "Install Ruby & required packages/gems"
+sudo apt-get install gnupg build-essential
+
 cat $BUILD_SCRIPTS_DIR/../gpg/mpapis.asc | gpg --import -
 cat $BUILD_SCRIPTS_DIR/../gpg/pkuczynski.asc | gpg --import -
 

--- a/scripts/build/ruby_install.sh
+++ b/scripts/build/ruby_install.sh
@@ -2,6 +2,8 @@
 timer_start=$(date +%s)
 
 echo "Install Ruby & required packages/gems"
+sudo apt-get -y install gnupg build-essential
+
 cat $BUILD_SCRIPTS_DIR/../gpg/mpapis.asc | gpg --import -
 cat $BUILD_SCRIPTS_DIR/../gpg/pkuczynski.asc | gpg --import -
 

--- a/src/main/content/_assets/js/builds.js
+++ b/src/main/content/_assets/js/builds.js
@@ -82,7 +82,7 @@ function getAllowedBuilds(build_type, package_locations, liberty_version) {
         var zipKey = x.split('=')[0];
         var allowList =  liberty_version ? allowed_builds[build_type](liberty_version) 
             : allowed_builds[build_type];
-        if(allowList.indexOf(zipKey) > 0) {
+        if(allowList.indexOf(zipKey) > -1) {
             return x;
         }
     });


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

- PR #2410 
- Issue #2377 (PR https://github.com/OpenLiberty/openliberty.io/pull/2406)

### Tested
I compared the HTML from prod vs staging for the download zips.  For some reason, the openliberty.io /data endpoint on staging is omitting two nightly OL builds.  Since the code being merged is only JavaScript, I do not think the missing two builds are due to the changes in this PR.  

### Update
I opened issue https://github.com/OpenLiberty/openliberty.io/issues/2412 to address the difference between staging and prod

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)

#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

