### PR TITLE
Add production flag to node install in Antora

### DIFF
--- a/scripts/build/antora_install.sh
+++ b/scripts/build/antora_install.sh
@@ -26,7 +26,7 @@ echo "Installing Antora dependencies"
 # npm install -g @antora/site-generator-default@2.3.3 # add back this line when upgrading antora to 3.0
 npm install gulp -g
 npm install node-sass gulp-sass --save-dev
-npm install
+npm install --production
 gulp sass:convert
 SOURCEMAPS=true gulp build
 gulp bundle:pack


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Test running production flag during npm install to use a smaller dependency list.
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

