### PR TITLE
Skip class cache creation

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -6,6 +6,7 @@ defaults: &defaults
   timeout: 180
   env:
     JBP_CONFIG_LIBERTY: 'app_archive: {features: ["jaxrs-2.1","cdi-2.0","concurrent-1.0","jsonb-1.0","webCache-1.0","mpRestClient-1.3"]}'
+    LIBERTY_SKIP_POPULATE_CLASSCACHE: true
 
 applications:
 # US South


### PR DESCRIPTION
We intermittently hit timeout issues during deployment.  Skipping the class cache creation should help shorten the time it takes to stage the app.

