### PR TITLE
Downgrade nokogiri gem to the last version that supports Ruby 2.5

### DIFF
--- a/gems/ol-target-blank/ol-target-blank.gemspec
+++ b/gems/ol-target-blank/ol-target-blank.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.3.0"
 
   s.add_dependency "jekyll", ">= 3.0", "<5.0"
-  s.add_dependency "nokogiri", "~> 1.10"
+  s.add_dependency "nokogiri", "~> 1.12.0"
 
   s.add_development_dependency "bundler", "~> 2.0"
   s.add_development_dependency "rake", "~> 12.0"


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

`nokogiri` ended support for Ruby 2.5 with version 1.13.0.  Use the last Ruby 2.5 supported `nokogiri` version.
https://github.com/sparklemotion/nokogiri/releases/tag/v1.13.0

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] Dymanic Accessability Plugin (DAP)
- [ ] Lighthouse (in Chrome dev tools)

