### PR TITLE
Revert "Upgrade to highlight.js v10"

### DIFF
--- a/src/main/content/antora_ui/package-lock.json
+++ b/src/main/content/antora_ui/package-lock.json
@@ -7147,9 +7147,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "version": "9.15.10",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz",
+      "integrity": "sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==",
       "dev": true
     },
     "hmac-drbg": {

--- a/src/main/content/antora_ui/package.json
+++ b/src/main/content/antora_ui/package.json
@@ -37,7 +37,7 @@
     "gulp-uglify": "~3.0",
     "gulp-vinyl-zip": "~2.1 >=2.1.2",
     "handlebars": "^4.7.7",
-    "highlight.js": "^10.0",
+    "highlight.js": "~9.15",
     "js-yaml": "~3.13",
     "merge-stream": "~2.0",
     "node-sass": "^4.14.1",

--- a/src/main/content/antora_ui/src/js/vendor/highlight.bundle.js
+++ b/src/main/content/antora_ui/src/js/vendor/highlight.bundle.js
@@ -7,7 +7,7 @@
   hljs.registerLanguage('bash', require('highlight.js/lib/languages/bash'))
   hljs.registerLanguage('clojure', require('highlight.js/lib/languages/clojure'))
   hljs.registerLanguage('cpp', require('highlight.js/lib/languages/cpp'))
-  hljs.registerLanguage('csharp', require('highlight.js/lib/languages/csharp'))
+  hljs.registerLanguage('cs', require('highlight.js/lib/languages/cs'))
   hljs.registerLanguage('css', require('highlight.js/lib/languages/css'))
   hljs.registerLanguage('diff', require('highlight.js/lib/languages/diff'))
   hljs.registerLanguage('dockerfile', require('highlight.js/lib/languages/dockerfile'))


### PR DESCRIPTION
Reverts OpenLiberty/openliberty.io#2433

This upgrade regressed the syntax highlighting on our doc pages.

# Good
![image](https://user-images.githubusercontent.com/31117513/150017510-e5fd0f31-7094-43bb-9c1d-0d813a6285e6.png)


# Regression
![image](https://user-images.githubusercontent.com/31117513/150017494-e65dde63-3af1-415d-b85e-0e0f0eefe296.png)
