### PR TITLE
Increate app timeout

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,7 +3,7 @@ defaults: &defaults
   instances: 1
   disk_quota: 1512M
   path: target/openliberty.war
-  timeout: 180
+  timeout: 300
   env:
     JBP_CONFIG_LIBERTY: 'app_archive: {features: ["jaxrs-2.1","cdi-2.0","concurrent-1.0","jsonb-1.0","webCache-1.0","mpRestClient-1.3"]}'
     LIBERTY_SKIP_POPULATE_CLASSCACHE: true


### PR DESCRIPTION
Likely will have no affect since the default max CF timeout is 180, but it's possible IBM Cloud raised that so it's worth checking (doesn't seem to be documented in IBM Docs)