### PR TITLE
Increate App Timeout

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,7 +3,7 @@ defaults: &defaults
   instances: 1
   disk_quota: 1512M
   path: target/openliberty.war
-  timeout: 180
+  timeout: 300
   env:
     JBP_CONFIG_LIBERTY: 'app_archive: {features: ["jaxrs-2.1","cdi-2.0","concurrent-1.0","jsonb-1.0","webCache-1.0","mpRestClient-1.3"]}'
     LIBERTY_SKIP_POPULATE_CLASSCACHE: true


### PR DESCRIPTION
Likely will have no affect since the default max CF timeout is 180, but it's possible IBM Cloud raised that so it's worth checking (doesn't seem to be documented in IBM Docs)

#### What was fixed?  (Issue # or description of fix)

Related to #2497

Test: Draft toolchain built without issues

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] IBM Equal Access Accessibility Checker (https://www.ibm.com/able/toolkit/verify/automated)
- [ ] Lighthouse (in Chrome dev tools)

