### PR TITLE
change in wordings for Unzip instructions and background moving to left when popup opens issue fix

### DIFF
--- a/src/main/content/_assets/css/start.scss
+++ b/src/main/content/_assets/css/start.scss
@@ -727,6 +727,9 @@ html, body {
     }
 }
 
+.modal-open { // class belongs to bootstrap css, seems like in few bootstrap versions when modal popup open it shifts the background to left since it add style dynamically
+    padding-right:0 !important;
+}
 
 @media (max-width: 991.98px) {
 

--- a/src/main/content/start.html
+++ b/src/main/content/start.html
@@ -106,7 +106,7 @@ permalink: /start/
         </div>
         <div class="modal-body">
             <h3>Your zip file has been beamed to your computer!</h3>
-            <p>Unzip it and follow the README instructions or run this command.</p>
+            <p>Unzip it and run this command, or refer to the included README.</p>
             <div id="cmd_to_run" class="cmd_to_run"></div>
             <p class="guide-link">For more help visit our <a href="/blog/2021/08/20/open-liberty-starter.html" class="orange_link_light_background" tabindex="0">helpful guides.</a></p>    
         </div>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [x] Firefox (Desktop)
- [x] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] IBM Equal Access Accessibility Checker (https://www.ibm.com/able/toolkit/verify/automated)
- [ ] Lighthouse (in Chrome dev tools)

