### PR TITLE
Use flag `--ignore-scripts` when installing `gulp`

### DIFF
--- a/scripts/build/antora_install.sh
+++ b/scripts/build/antora_install.sh
@@ -13,7 +13,7 @@ cp src/main/content/_includes/noindex.html src/main/content/antora_ui/src/partia
 pushd src/main/content/antora_ui
 echo "Installing Antora dependencies"
 npm install -g @antora/site-generator@3.0.1
-npm install gulp -g
+npm install gulp -g --ignore-scripts
 npm install node-sass gulp-sass --save-dev
 npm install --production
 gulp sass:convert


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] IBM Equal Access Accessibility Checker (https://www.ibm.com/able/toolkit/verify/automated)
- [ ] Lighthouse (in Chrome dev tools)

