### PR TITLE
PR2452 - update highlights.js to 10.7.3

### DIFF
--- a/src/main/content/antora_ui/package-lock.json
+++ b/src/main/content/antora_ui/package-lock.json
@@ -26,7 +26,7 @@
         "gulp-uglify": "~3.0",
         "gulp-vinyl-zip": "~2.1 >=2.1.2",
         "handlebars": "^4.7.7",
-        "highlight.js": "9.18.3",
+        "highlight.js": "~10.7",
         "js-yaml": "~3.13",
         "merge-stream": "~2.0",
         "node-sass": "^7.0.0",
@@ -7314,9 +7314,9 @@
       "dev": true
     },
     "node_modules/highlight.js": {
-      "version": "9.18.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.3.tgz",
-      "integrity": "sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ==",
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
       "deprecated": "Version no longer supported. Upgrade to @latest",
       "dev": true,
       "engines": {
@@ -22033,9 +22033,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "9.18.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.3.tgz",
-      "integrity": "sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ==",
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
       "dev": true
     },
     "hmac-drbg": {

--- a/src/main/content/antora_ui/package-lock.json
+++ b/src/main/content/antora_ui/package-lock.json
@@ -26,7 +26,7 @@
         "gulp-uglify": "~3.0",
         "gulp-vinyl-zip": "~2.1 >=2.1.2",
         "handlebars": "^4.7.7",
-        "highlight.js": "~9.15",
+        "highlight.js": "9.18.3",
         "js-yaml": "~3.13",
         "merge-stream": "~2.0",
         "node-sass": "^7.0.0",
@@ -7314,9 +7314,9 @@
       "dev": true
     },
     "node_modules/highlight.js": {
-      "version": "9.15.10",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz",
-      "integrity": "sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==",
+      "version": "9.18.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.3.tgz",
+      "integrity": "sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ==",
       "deprecated": "Version no longer supported. Upgrade to @latest",
       "dev": true,
       "engines": {
@@ -22033,9 +22033,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "9.15.10",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz",
-      "integrity": "sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==",
+      "version": "9.18.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.3.tgz",
+      "integrity": "sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ==",
       "dev": true
     },
     "hmac-drbg": {

--- a/src/main/content/antora_ui/package.json
+++ b/src/main/content/antora_ui/package.json
@@ -29,7 +29,7 @@
     "gulp-uglify": "~3.0",
     "gulp-vinyl-zip": "~2.1 >=2.1.2",
     "handlebars": "^4.7.7",
-    "highlight.js": "9.18.3",
+    "highlight.js": "~10.7",
     "js-yaml": "~3.13",
     "merge-stream": "~2.0",
     "node-sass": "^7.0.0",

--- a/src/main/content/antora_ui/package.json
+++ b/src/main/content/antora_ui/package.json
@@ -29,7 +29,7 @@
     "gulp-uglify": "~3.0",
     "gulp-vinyl-zip": "~2.1 >=2.1.2",
     "handlebars": "^4.7.7",
-    "highlight.js": "~9.15",
+    "highlight.js": "9.18.3",
     "js-yaml": "~3.13",
     "merge-stream": "~2.0",
     "node-sass": "^7.0.0",

--- a/src/main/content/antora_ui/src/js/vendor/highlight.bundle.js
+++ b/src/main/content/antora_ui/src/js/vendor/highlight.bundle.js
@@ -1,13 +1,13 @@
 (function () {
   'use strict'
 
-  var hljs = require('highlight.js/lib/highlight')
+  var hljs = require('highlight.js/lib/core')
   hljs.registerLanguage('apache', require('highlight.js/lib/languages/apache'))
   hljs.registerLanguage('asciidoc', require('highlight.js/lib/languages/asciidoc'))
   hljs.registerLanguage('bash', require('highlight.js/lib/languages/bash'))
   hljs.registerLanguage('clojure', require('highlight.js/lib/languages/clojure'))
-  hljs.registerLanguage('cpp', require('highlight.js/lib/languages/cpp'))
-  hljs.registerLanguage('cs', require('highlight.js/lib/languages/cs'))
+  hljs.registerLanguage('cpp', require('highlight.js/lib/languages/c-like'))
+  hljs.registerLanguage('cs', require('highlight.js/lib/languages/csharp'))
   hljs.registerLanguage('css', require('highlight.js/lib/languages/css'))
   hljs.registerLanguage('diff', require('highlight.js/lib/languages/diff'))
   hljs.registerLanguage('dockerfile', require('highlight.js/lib/languages/dockerfile'))
@@ -36,5 +36,5 @@
   hljs.registerLanguage('swift', require('highlight.js/lib/languages/swift'))
   hljs.registerLanguage('xml', require('highlight.js/lib/languages/xml'))
   hljs.registerLanguage('yaml', require('highlight.js/lib/languages/yaml'))
-  hljs.initHighlighting()
+  hljs.highlightAll()
 })()

--- a/src/main/content/antora_ui/src/partials/head-scripts.hbs
+++ b/src/main/content/antora_ui/src/partials/head-scripts.hbs
@@ -1,6 +1,6 @@
     {{#if site.keys.googleAnalytics }}
         {{> google_tag_manager_head }}
     {{/if}}
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.10/highlight.min.js"></script>
+    <script async src="{{uiRootPath}}/js/vendor/highlight.js "></script>
     <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>

--- a/src/main/content/antora_ui/src/partials/head-styles.hbs
+++ b/src/main/content/antora_ui/src/partials/head-styles.hbs
@@ -1,4 +1,4 @@
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
 <link href="https://fonts.googleapis.com/css?family=Asap:400,500" rel="stylesheet">
-<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/styles/default.min.css">
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.3/styles/default.min.css">
 <link rel="stylesheet" href="{{uiRootPath}}/css/site.css">

--- a/src/main/content/antora_ui/src/partials/head-styles.hbs
+++ b/src/main/content/antora_ui/src/partials/head-styles.hbs
@@ -1,4 +1,4 @@
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
 <link href="https://fonts.googleapis.com/css?family=Asap:400,500" rel="stylesheet">
-<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.10/styles/default.min.css">
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/styles/default.min.css">
 <link rel="stylesheet" href="{{uiRootPath}}/css/site.css">


### PR DESCRIPTION
#### What was fixed?  (Issue #2452 )

ReDOS vulnerabities: multiple grammars
https://github.com/advisories/GHSA-7wwv-vh3v-89cq

Update highlight.bundle.js per the v10 highlight.js breaking changes https://github.com/highlightjs/highlight.js/blob/main/VERSION_10_BREAKING_CHANGES.md

- Change cs to csharp, cpp to c-like, 
-   Use highlightAll() since initHighlighting() is deprecating
-   Use lib/core since lib/highligh no longer there

Test: visual compare openliberty.io docs site with draft
For the most part the highlight works

openliberty.io
![image](https://user-images.githubusercontent.com/30509453/157541822-1302cb5f-bb53-4afe-83f5-763d82c1a1e9.png)

![image](https://user-images.githubusercontent.com/30509453/157542135-6b3bfd63-50b8-4d29-a6b0-71470d9c0084.png)

draft:
![image](https://user-images.githubusercontent.com/30509453/157541893-c1cf9a80-3030-46b1-95c7-4939d2c29708.png)

![image](https://user-images.githubusercontent.com/30509453/157542170-9538ae39-c530-4391-a836-6fe737f915a2.png)

subtle changes to the colors below:

openliberty.io
![image](https://user-images.githubusercontent.com/30509453/157542303-39f7dd69-6b07-4e39-b9e3-dbe4af539013.png)

draft:
![image](https://user-images.githubusercontent.com/30509453/157542342-63a8d367-0976-4cef-826f-b31692aaf271.png)


#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] IBM Equal Access Accessibility Checker (https://www.ibm.com/able/toolkit/verify/automated)
- [ ] Lighthouse (in Chrome dev tools)

