### PR TITLE
changed to hash - when /latest is added will be replaced with ?

### DIFF
--- a/src/main/content/_assets/js/javadoc-redirect.js
+++ b/src/main/content/_assets/js/javadoc-redirect.js
@@ -17,7 +17,7 @@ $(function () {
       port +
       '/docs/latest/reference/javadoc/microprofile-' +
       version +
-      '-javadoc.html?package=' +
+      '-javadoc.html#package=' +
       pack +
       '/package-frame.html&class=' +
       jd;
@@ -39,7 +39,7 @@ $(function () {
       port +
       '/docs/latest/reference/javadoc/liberty-javaee' +
       version +
-      '-javadoc.html?package=' +
+      '-javadoc.html#package=' +
       pack +
       '/package-frame.html&class=' +
       jd;
@@ -60,7 +60,7 @@ $(function () {
       port +
       '/docs/latest/reference/javadoc/liberty-jakartaee' +
       version +
-      '-javadoc.html?package=' +
+      '-javadoc.html#package=' +
       pack +
       '/package-frame.html&class=' +
       jd;


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] IBM Equal Access Accessibility Checker (https://www.ibm.com/able/toolkit/verify/automated)
- [ ] Lighthouse (in Chrome dev tools)

