### PR TITLE
New CODEOWNERS GitHub configuration file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@OpenLiberty/openliberty-io-maintainers


### PR DESCRIPTION
This new CODEOWNERS file is a GitHub configuration file that can be used as a requirement before commits are merged into branches. The intention here is to add more approval steps for the `prod` branch.

The CODEOWNERS will be this team https://github.com/orgs/OpenLiberty/teams/openliberty-io-maintainers

CODEOWNERS documentation
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners