### PR TITLE
javadoc url with parameters cannot be switched correctly

### DIFF
--- a/src/main/java/io/openliberty/website/RedirectFilter.java
+++ b/src/main/java/io/openliberty/website/RedirectFilter.java
@@ -62,6 +62,10 @@ public class RedirectFilter implements Filter {
         // url, it won't be a direct from and to.
         if (startsWithMatch) {
             String uri = ((HttpServletRequest) req).getRequestURI();
+            String queryString = ((HttpServletRequest) req).getQueryString();
+            if (queryString != null) {
+                uri = uri +"?"+ queryString;
+            }
             // Do not redirect if the uri doesn't contain anything more than the 'from'
             // redirect rule during a wildcard match.
             if (!uri.endsWith(from)) {


### PR DESCRIPTION
#### What was fixed?  (Issue #2614  or description of fix)

using this url 
https://staging-openlibertyio.mybluemix.net/docs/22.0.0.4/reference/javadoc/microprofile-5.0-javadoc.html?package=jakarta/activation/package-frame.html&class=overview-summary.html

or latest or any previous version like 22.0.0.3, 22.0.0.2, etc it will not remove query params

https://staging-openlibertyio.mybluemix.net/docs/latest/reference/javadoc/microprofile-5.0-javadoc.html?package=jakarta/activation/package-frame.html&class=overview-summary.html

but when you type the actual latest numerical version 22.0.0.5 it will convert to latest but it removes query params

https://staging-openlibertyio.mybluemix.net/docs/22.0.0.5/reference/javadoc/microprofile-5.0-javadoc.html?package=jakarta/activation/package-frame.html&class=overview-summary.html

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] IBM Equal Access Accessibility Checker (https://www.ibm.com/able/toolkit/verify/automated)
- [ ] Lighthouse (in Chrome dev tools)

