### PR TITLE
Update the URL to the open-liberty README.md

### DIFF
--- a/src/main/content/contribute.html
+++ b/src/main/content/contribute.html
@@ -131,7 +131,7 @@ permalink: /contribute/
                 Testing is an essential step to having a robust, helpful release. The more high quality tests we run before a release, the more headaches we
                 save our users in the future. 
             </p>
-            <a id="tools_and_tests_link_3" href="https://github.com/OpenLiberty/open-liberty/blob/release/README.md#contribute-to-open-liberty" target="_blank" rel="noopener" class="regular_link orange_link_light_background line_link">
+            <a id="tools_and_tests_link_3" href="https://github.com/OpenLiberty/open-liberty/blob/release/README.md#contributing" target="_blank" rel="noopener" class="regular_link orange_link_light_background line_link">
                 <span class="line"></span> Learn the ins and outs of testing for Open Liberty
             </a>
         </div>


### PR DESCRIPTION
The URL was changed with commit
https://github.com/OpenLiberty/open-liberty/commit/bedf03789d3b47c30d40c324a13753694667d0f7

#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] IBM Equal Access Accessibility Checker (https://www.ibm.com/able/toolkit/verify/automated)
- [ ] Lighthouse (in Chrome dev tools)

