### PR TITLE
New front matter attribute to configure noindex

### DIFF
--- a/src/main/content/_includes/head.html
+++ b/src/main/content/_includes/head.html
@@ -56,7 +56,7 @@
   
   <meta name="google-site-verification" content="h2P030H9b66CyL1nEmWfrZB8Fr14h9LmVMG7Ur0caBs" />
 
-  {% if jekyll.environment != 'production' or page.permalink == '/blog/redirected.html' %}
+  {% if jekyll.environment != 'production' or page.permalink == '/blog/redirected.html' or page.noindex == true %}
       {% include_cached noindex.html %}
   {% endif %}
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

Related to https://github.com/openliberty/openliberty.io/issues/2663

Cannot reliability test this change until it is in production, so what I did was test it locally by changing

https://github.com/OpenLiberty/openliberty.io/blob/b5e163d239d1ed87a788ea28729f33a96ecf1537/src/main/content/_includes/head.html#L59

to 

`{% if page.noindex == true %}`

I added `noindex: true` to a blog post (e.g. `*.adoc`) under `_posts`.  One post had no `noindex` and another had `noindex: true`.  I saw `<meta name="robots" content="noindex">` only get added to the blog pages with `noindex: true` front matter.

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] IBM Equal Access Accessibility Checker (https://www.ibm.com/able/toolkit/verify/automated)
- [ ] Lighthouse (in Chrome dev tools)

