### PR TITLE
Set height/width for embedded Twitter timeline

### DIFF
--- a/src/main/content/_assets/css/home.scss
+++ b/src/main/content/_assets/css/home.scss
@@ -517,6 +517,10 @@ body {
 
 #news_container {
   padding-top: 84px;
+  #news_row {
+    // value is based on the data-height found on HTML element with class="twitter-timeline"
+    min-height: 650px;
+  }
 }
 
 #cloud_images_div {

--- a/src/main/content/index.html
+++ b/src/main/content/index.html
@@ -202,7 +202,7 @@ css:
     </div>
     <h2 id="news_title">Open Liberty News</h2>
     <p id="news_text">Check out the latest news on our blog and follow us on Twitter.</p>
-    <div class="row">
+    <div id="news_row" class="row">
         <div class="col-xs-12 col-lg-6">
             <div id="blog_post">
                 {% for post in site.posts limit:1 %}
@@ -262,7 +262,13 @@ css:
                 <a id="twitter_link" href="https://twitter.com/OpenLibertyIO" target="_blank" rel="noopener">Follow</a>
             </div>
             <div id="twitter_iframe_div">
-                <a class="twitter-timeline" href="https://twitter.com/OpenLibertyIO?ref_src=twsrc%5Etfw" rel="noopener" data-tweet-limit="3" data-chrome="noheader nofooter"></a>
+                <a class="twitter-timeline"
+                    href="https://twitter.com/OpenLibertyIO?ref_src=twsrc%5Etfw"
+                    rel="noopener" data-tweet-limit="3"
+                    data-chrome="noheader nofooter"
+                    data-width="520"
+                    data-height="650" >
+                </a>
                 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
             </div>
         </div>


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

Tested on draft with commit a399dcdef6516601370cdb8d98866aec470e25e2

Related to #2600

- Set the width to the max value based on Twitter's documentation

https://developer.twitter.com/en/docs/twitter-for-websites/timelines/overview
"""
An embedded timeline automatically adjusts to the width of its parent
element with a minimum width of 180 pixels and a maximum
width of 520 pixels.
"""

- Use min-height in case the Twitter timeline needs more height, though
unlikely since data-height is set to 650.

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] IBM Equal Access Accessibility Checker (https://www.ibm.com/able/toolkit/verify/automated)
- [ ] Lighthouse (in Chrome dev tools)

