### PR TITLE
2688 logo links

### DIFF
--- a/src/main/content/index.html
+++ b/src/main/content/index.html
@@ -163,29 +163,51 @@ css:
                 <div id="logo_image_row" class="row justify-content-center">
                     <div class="col-sm-12 col-md">
                         <a href="https://microprofile.io/">
-                        <img id="microprofile_logo"  src="/img/home_logo_microprofile.png" alt="MicroProfile Logo">
+                            <img id="microprofile_logo"  src="/img/home_logo_microprofile.png" alt="MicroProfile Logo">
                         </a>
                     </div>
                     <div class="col-sm-12 col-md">
                         <a href="https://jakarta.ee/">
-                        <img id="jakarta_ee_logo"  src="/img/home_logo_jakartaee.png" alt="Jakarta EE logo">
+                            <img id="jakarta_ee_logo"  src="/img/home_logo_jakartaee.png" alt="Jakarta EE logo">
                         </a>
                     </div>
                 </div>
                 <div class="logos_row row justify-content-center">
-                    <p>Jenkins</p>
-                    <p>Spring</p>
-                    <p>Docker</p>
-                    <p>Grafana</p>
-                    <p>Gradle</p>
-                    <p>Logstash</p>
+                    <a href="https://www.jenkins.io/">
+                        <p>Jenkins</p>
+                    </a>
+                    <a href="https://spring.io/">
+                        <p>Spring</p>
+                    </a>
+                    <a href="https://www.docker.com/">
+                        <p>Docker</p>
+                    </a>
+                    <a href="https://grafana.com/">
+                        <p>Grafana</p>
+                    </a>
+                    <a href="https://gradle.org/">
+                        <p>Gradle</p>
+                    </a>
+                    <a href="https://www.elastic.co/logstash/">
+                        <p>Logstash</p>
+                    </a>
                 </div>
                 <div class="logos_row row justify-content-center">
-                    <p>Prometheus</p>
-                    <p>Maven</p>
-                    <p>Kubernetes</p>
-                    <p>Kibana</p>
-                    <p>Elastic Search</p>
+                    <a href="https://prometheus.io/">
+                        <p>Prometheus</p>
+                    </a>
+                    <a href=" https://maven.apache.org/">
+                        <p>Maven</p>
+                    </a>
+                    <a href="https://kubernetes.io/">
+                        <p>Kubernetes</p>
+                    </a>
+                    <a href=" https://www.elastic.co/kibana/">
+                        <p>Kibana</p>
+                    </a>
+                    <a href="https://www.elastic.co/elasticsearch/">
+                        <p>Elastic Search</p>
+                    </a>
                 </div>
             </div>
         </div>

--- a/src/main/content/index.html
+++ b/src/main/content/index.html
@@ -162,10 +162,14 @@ css:
                 <h3 id="logos_title">Open Liberty integrates with the Open Source community</h3>
                 <div id="logo_image_row" class="row justify-content-center">
                     <div class="col-sm-12 col-md">
+                        <a href="https://microprofile.io/">
                         <img id="microprofile_logo"  src="/img/home_logo_microprofile.png" alt="MicroProfile Logo">
+                        </a>
                     </div>
                     <div class="col-sm-12 col-md">
+                        <a href="https://jakarta.ee/">
                         <img id="jakarta_ee_logo"  src="/img/home_logo_jakartaee.png" alt="Jakarta EE logo">
+                        </a>
                     </div>
                 </div>
                 <div class="logos_row row justify-content-center">

--- a/src/main/content/index.html
+++ b/src/main/content/index.html
@@ -196,13 +196,13 @@ css:
                     <a href="https://prometheus.io/">
                         <p>Prometheus</p>
                     </a>
-                    <a href=" https://maven.apache.org/">
+                    <a href="https://maven.apache.org/">
                         <p>Maven</p>
                     </a>
                     <a href="https://kubernetes.io/">
                         <p>Kubernetes</p>
                     </a>
-                    <a href=" https://www.elastic.co/kibana/">
+                    <a href="https://www.elastic.co/kibana/">
                         <p>Kibana</p>
                     </a>
                     <a href="https://www.elastic.co/elasticsearch/">


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Related to https://github.com/OpenLiberty/openliberty.io/pull/2694
Related to https://github.com/OpenLiberty/openliberty.io/pull/2688

Tested on draft
https://draft-openlibertyio.mybluemix.net/#logos_title
<img width="1209" alt="image" src="https://user-images.githubusercontent.com/31117513/172424143-655da1e1-ec4a-4711-94a1-7fd68a606f03.png">


#### Were the changes tested on
- [x] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] IBM Equal Access Accessibility Checker (https://www.ibm.com/able/toolkit/verify/automated)
- [ ] Lighthouse (in Chrome dev tools)

