### PR TITLE
Remove start/end whitespace on `og:image`; Remove `twitter:image`

### DIFF
--- a/src/main/content/_includes/head.html
+++ b/src/main/content/_includes/head.html
@@ -7,6 +7,8 @@
   {% assign description = site.description | strip_html | normalize_whitespace | truncate: 160 | escape %}
 {% endif %}
 
+{% assign default_image = 'https://openliberty.io/img/twitter_card.jpg' %}
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -46,10 +48,9 @@
   <meta name="twitter:site" content="@OpenLibertyIO" />
   <meta name="twitter:title" content="{% if page.seo-title %}{{ page.seo-title }}{% else %}{{site.title}}{% endif %}" />
   <meta name="twitter:description" content="{{ description }}" />
-  <meta name="twitter:image" content="https://openliberty.io/img/twitter_card.jpg" />
 
   <meta property='og:title' content="{% if page.seo-title %}{{ page.seo-title }}{% else %}{{site.title}}{% endif %}" />
-  <meta property='og:image' content="{% if page.open-graph-image %}{{page.open-graph-image}}{% else %}https://openliberty.io/img/twitter_card.jpg{% endif %}" />
+  <meta property='og:image' content="{% if page.open-graph-image %}{{page.open-graph-image}}{% else %}{{default_image}}{% endif %}" />
   <meta property='og:description' content="{{ description }}" />
   <meta property='og:url' content="{{ page.url | replace:'index.html','' | absolute_url }}" />
   <meta property='og:type' content="website" />

--- a/src/main/content/_includes/head.html
+++ b/src/main/content/_includes/head.html
@@ -49,7 +49,7 @@
   <meta name="twitter:image" content="https://openliberty.io/img/twitter_card.jpg" />
 
   <meta property='og:title' content="{% if page.seo-title %}{{ page.seo-title }}{% else %}{{site.title}}{% endif %}" />
-  <meta property='og:image' content="{% if page.open-graph-image %} {{page.open-graph-image}} {% else %}https://openliberty.io/img/twitter_card.jpg{% endif %}" />
+  <meta property='og:image' content="{% if page.open-graph-image %}{{page.open-graph-image}}{% else %}https://openliberty.io/img/twitter_card.jpg{% endif %}" />
   <meta property='og:description' content="{{ description }}" />
   <meta property='og:url' content="{{ page.url | replace:'index.html','' | absolute_url }}" />
   <meta property='og:type' content="website" />


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

For https://github.com/openliberty/openliberty.io/issues/2720

Per Twitter's [documentation](https://developer.twitter.com/en/docs/twitter-for-websites/cards/guides/getting-started#opengraph), Twitter will fallback to using `og:image` if we remove the `twitter:image` property. I am in favor of removing `twitter:image` rather than keeping it in sync with `og:image`. The reason is that the blog post Asciidoc front matter clearly says `open-graph-image` and has no mention of Twitter properties.

> Twitter card tags look similar to Open Graph tags, and are based on the same conventions as the Open Graph protocol. When using Open Graph protocol to describe data on a page, it is easy to generate a Twitter card without duplicating tags and data. When the Twitter card processor looks for tags on a page, it first checks for the Twitter-specific property, and if not present, falls back to the supported Open Graph property. This allows for both to be defined on the page independently, and minimizes the amount of duplicate markup required to describe content and experience.

Tested with commit in `draft` https://github.com/OpenLiberty/openliberty.io/commit/6f711b98975bd87a22644027950ae76d622405b1

Tested default image with blog post
https://draft-openlibertyio.mybluemix.net/blog/2021/09/14/open-liberty-stack-gradle.html

Tested Open Graph image with blog post
https://draft-openlibertyio.mybluemix.net/blog/2021/09/14/open-liberty-stack-gradle.html

Problem with testing...
I could not get the `og:image` to show up when creating a tweet. I suspect it is due to CORS issues when the URL is domain `draft-openlibertyio.mybluemix.net` and the `og:image` is domain `openliberty.io`

# Example of trying to preview tweet with draft site
<img width="590" alt="image" src="https://user-images.githubusercontent.com/31117513/175398619-4fda2c8c-af61-4372-93d0-538dc5558f62.png">

# Example of using an openliberty.io URL
<img width="579" alt="image" src="https://user-images.githubusercontent.com/31117513/175398680-256c317d-dcff-4de7-8b2e-b4a9cf9560d2.png">

I think we have no choice but to test this minor change in production to bypass possible CORS issues.

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] IBM Equal Access Accessibility Checker (https://www.ibm.com/able/toolkit/verify/automated)
- [ ] Lighthouse (in Chrome dev tools)

