### PR TITLE
Make `og:image` and `twitter:image` the same

### DIFF
--- a/src/main/content/_includes/head.html
+++ b/src/main/content/_includes/head.html
@@ -7,6 +7,8 @@
   {% assign description = site.description | strip_html | normalize_whitespace | truncate: 160 | escape %}
 {% endif %}
 
+{% assign default_image = 'https://openliberty.io/img/twitter_card.jpg' %}
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -46,10 +48,10 @@
   <meta name="twitter:site" content="@OpenLibertyIO" />
   <meta name="twitter:title" content="{% if page.seo-title %}{{ page.seo-title }}{% else %}{{site.title}}{% endif %}" />
   <meta name="twitter:description" content="{{ description }}" />
-  <meta name="twitter:image" content="https://openliberty.io/img/twitter_card.jpg" />
+  <meta name="twitter:image" content="{% if page.open-graph-image %}{{page.open-graph-image}}{% else %}{{default_image}}{% endif %}" />
 
   <meta property='og:title' content="{% if page.seo-title %}{{ page.seo-title }}{% else %}{{site.title}}{% endif %}" />
-  <meta property='og:image' content="{% if page.open-graph-image %}{{page.open-graph-image}}{% else %}https://openliberty.io/img/twitter_card.jpg{% endif %}" />
+  <meta property='og:image' content="{% if page.open-graph-image %}{{page.open-graph-image}}{% else %}{{default_image}}{% endif %}" />
   <meta property='og:description' content="{{ description }}" />
   <meta property='og:url' content="{{ page.url | replace:'index.html','' | absolute_url }}" />
   <meta property='og:type' content="website" />


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

For #2720

See comment https://github.com/OpenLiberty/openliberty.io/issues/2720#issuecomment-1169102578 on why we are restoring `twitter:image`.

- Testing with draft a tweet has shown inconsistency with the image
showing up in the tweet when relying only on `og:image`. Use Twitter's
image metadata.

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] IBM Equal Access Accessibility Checker (https://www.ibm.com/able/toolkit/verify/automated)
- [ ] Lighthouse (in Chrome dev tools)

