### PR TITLE
Revert "Make `og:image` and `twitter:image` the same"

### DIFF
--- a/src/main/content/_includes/head.html
+++ b/src/main/content/_includes/head.html
@@ -48,7 +48,6 @@
   <meta name="twitter:site" content="@OpenLibertyIO" />
   <meta name="twitter:title" content="{% if page.seo-title %}{{ page.seo-title }}{% else %}{{site.title}}{% endif %}" />
   <meta name="twitter:description" content="{{ description }}" />
-  <meta name="twitter:image" content="{% if page.open-graph-image %}{{page.open-graph-image}}{% else %}{{default_image}}{% endif %}" />
 
   <meta property='og:title' content="{% if page.seo-title %}{{ page.seo-title }}{% else %}{{site.title}}{% endif %}" />
   <meta property='og:image' content="{% if page.open-graph-image %}{{page.open-graph-image}}{% else %}{{default_image}}{% endif %}" />


### PR DESCRIPTION
For https://github.com/openliberty/openliberty.io/issues/2720
Reverts OpenLiberty/openliberty.io#2726

Also reverted in `draft` branch with https://github.com/OpenLiberty/openliberty.io/commit/daa0015f3e796e926bb32e5dbb2ffddecf86234a

See https://github.com/OpenLiberty/openliberty.io/issues/2720#issuecomment-1170224417 on why this PR is no longer needed
