### PR TITLE
Update paragraph for the feature section

### DIFF
--- a/src/main/content/_i18n/en.yml
+++ b/src/main/content/_i18n/en.yml
@@ -24,7 +24,7 @@ global:
   microprofile_small_case: microprofile
   jakartaee: Jakarta EE
   jakartaee_small_case: jakarta ee
-  zero_migration: Zero migration
+  zero_migration: zero migration
   jenkins: Jenkins
   spring: Spring
   docker: Docker
@@ -38,6 +38,7 @@ global:
   elastic_search: Elastic Search
   follow: Follow
   and: and
+  and_with: And with
   or: or
   trans_yes: Yes`
   websphere_application_server: WebSphere Application Server
@@ -73,8 +74,8 @@ home:
   intro_paragraph3: developers in this solar system.
   get_openliberty: Get Open Liberty
   cloud_native_develop_title: Develop cloud-native Java microservices
-  cloud_native_develop_text1: Open Liberty is fast to start up with a low memory footprint and live reload for quick iteration. Simple to add and remove features from the latest versions of
-  cloud_native_develop_text2: lets you focus on what's important, not the APIs changing under you.
+  cloud_native_develop_text1: Open Liberty starts up fast, with a low memory footprint and live reload for quick iteration. Adding and removing features from the latest versions of
+  cloud_native_develop_text2: you focus on what's important, not the APIs changing under you.
   fast_iteration_develop_title: Dev mode for fast iteration
   fast_iteration_develop_text: Launch into dev mode and get coding. No more manual compiling, packaging, and deploying—we handle that for you. 
                     Get automated testing, debugger support, and a fast turn-around time in any editor.

--- a/src/main/content/index.html
+++ b/src/main/content/index.html
@@ -83,12 +83,13 @@ css:
                     {% else %}
                     <a class="blue_link_light_background_external" href="/{{site.lang}}/docs/latest/jakarta-ee.html">{% t global.jakartaee %}</a>.
                     {% endif %}
+                    {% t global.and_with %}
                     {% if site.lang == 'en' %}
-                    <a class="blue_link_light_background_external" href="/docs/latest/zero-migration-architecture.html">{% t global.zero_migration %}</a>
+                    <a class="blue_link_light_background_external" href="/docs/latest/zero-migration-architecture.html">{% t global.zero_migration %}</a>,
                     {% else %}
-                    <a class="blue_link_light_background_external" href="/{{site.lang}}/docs/latest/zero-migration-architecture.html">{% t global.zero_migration %}</a>
+                    <a class="blue_link_light_background_external" href="/{{site.lang}}/docs/latest/zero-migration-architecture.html">{% t global.zero_migration %}</a>,
                     {% endif %}
-                    {% t home.cloud_native_develop_text2 %}
+                    {% t home.cloud_native_develop_text2%}
                 </p>
                 <div class="learn_more_container">
                     {% if site.lang == 'en' %}


### PR DESCRIPTION
#### What was fixed?  (Issue #2709)

- The problem being solved is to eliminate the two unique links in
 "Jakarta EE. Zero migration" from looking like one link. The fix is
to add more plaintext words between the "Jakarta EE" link and
"Zero migration" link.

![image](https://user-images.githubusercontent.com/31117513/179606592-7d696f70-acbb-4815-976f-c9f45572e1f0.png)


#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] IBM Equal Access Accessibility Checker (https://www.ibm.com/able/toolkit/verify/automated)
- [ ] Lighthouse (in Chrome dev tools)

