### PR TITLE
Revert "2259 blogtag cutoff"

### DIFF
--- a/src/main/content/_assets/css/blog.scss
+++ b/src/main/content/_assets/css/blog.scss
@@ -445,7 +445,7 @@ html {
 }
 
 .blog_tag {
-    display: inline;
+    display: inline-block;
     font-size: 14px;
     color: #5E6B8D;
     


### PR DESCRIPTION
Reverts OpenLiberty/openliberty.io#2758
New formatting caused publish date and read more button to overlap when viewing blog post feed on mobile, overlap occurs on blog posts with no tags