### PR TITLE
Adjust blog tag container margins

### DIFF
--- a/src/main/content/_assets/css/blog.scss
+++ b/src/main/content/_assets/css/blog.scss
@@ -438,8 +438,10 @@ html {
 
     &:empty {
         margin-bottom: 20px;
-        & + .read_more_link_container {
-            margin-top: -50px;
+        @media (min-width: 767.98px) {
+            & + .read_more_link_container {
+                margin-top: -50px;
+            }
         }
     }
 }


### PR DESCRIPTION
Only modify blog tag container margins when window is larger than mobile

#### What was fixed?  (Issue # or description of fix)
Issue #2259 
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [X] Safari (Desktop and Developer Tools Responsive View)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] IBM Equal Access Accessibility Checker (https://www.ibm.com/able/toolkit/verify/automated)
- [ ] Lighthouse (in Chrome dev tools)

