### PR TITLE
Fix internal link colors on /start page

### DIFF
--- a/scripts/build/clone_blogs.sh
+++ b/scripts/build/clone_blogs.sh
@@ -3,6 +3,7 @@ pushd src/main/content
 # For development purposes, lets always delete previously created folders
 # so that you can run this script to refresh your blog files
 rm -rf _posts _drafts
+rm -rf _i18n/en/_posts _drafts
 rm -rf img/blog
 
 echo "Start cloning blogs repository..."
@@ -26,6 +27,7 @@ git clone https://github.com/OpenLiberty/blogs.git --branch $BRANCH_NAME blogs_t
 
 mv blogs_temp/posts/ .
 mv posts/ _posts
+cp -a _posts/. _i18n/en/_posts
 
 mv blogs_temp/img/blog img
 

--- a/scripts/build/gem_dependencies.sh
+++ b/scripts/build/gem_dependencies.sh
@@ -1,5 +1,6 @@
 echo "Installing ruby packages..."
 gem install jekyll -v 3.8.6
 gem install jekyll-assets -v 2.4.0
+gem install jekyll-multiple-languages-plugin
 gem install bundler jekyll-feed jekyll-asciidoc jekyll-include-cache coderay uglifier octopress-minify-html octokit
 gem uninstall -i /usr/local/rvm/gems/ruby-2.4.1@global rubygems-bundler

--- a/scripts/build/jekyll.sh
+++ b/scripts/build/jekyll.sh
@@ -83,5 +83,5 @@ if [ "$PROD_SITE" = true ]
     jekyll build --source src/main/content --config src/main/content/_config.yml,src/main/content/_google_analytics.yml --destination target/jekyll-webapp 
   else
     # Set the --future flag to show blogs with date timestamps in the future
-    jekyll build --future --source src/main/content --destination target/jekyll-webapp
+    jekyll build --future --source src/main/content --config src/main/content/_config.yml --destination target/jekyll-webapp
 fi

--- a/scripts/build/ruby_install.sh
+++ b/scripts/build/ruby_install.sh
@@ -26,6 +26,7 @@ echo `ruby -v`
 
 gem install jekyll -v 3.8.6
 gem install jekyll-assets -v 2.4.0
+gem install jekyll-multiple-languages-plugin
 gem install bundler jekyll-feed jekyll-asciidoc jekyll-include-cache coderay octokit
 
 timer_end=$(date +%s)

--- a/src/main/content/404.html
+++ b/src/main/content/404.html
@@ -8,7 +8,7 @@ permalink: /404.html
 ---
 
 <div id="page_container">
-    <h2 id="error_message">Oh no! You’ve reached an unexplored corner of the universe.</h2>
+    <h2 id="error_message">{% t global.404_error_message %}</h2>
     <div id="crashed_ship_container">
         <img id="crashed_ship" src="/img/404_crashed_ship.svg" alt="crashed ship">
         <img id="shiplight_top" src="/img/404_shiplight_top.svg" alt="">

--- a/src/main/content/_assets/css/blog.scss
+++ b/src/main/content/_assets/css/blog.scss
@@ -438,14 +438,16 @@ html {
 
     &:empty {
         margin-bottom: 20px;
-        & + .read_more_link_container {
-            margin-top: -50px;
+        @media (min-width: 767.98px) {
+            & + .read_more_link_container {
+                margin-top: -50px;
+            }
         }
     }
 }
 
 .blog_tag {
-    display: inline-block;
+    display: inline;
     font-size: 14px;
     color: #5E6B8D;
     

--- a/src/main/content/_assets/js/builds.js
+++ b/src/main/content/_assets/js/builds.js
@@ -184,13 +184,13 @@ function render_builds(builds, parent) {
                 var package_locations = build.package_locations;
                 var sorted_package_locations;
                 if (package_locations !== null && package_locations !== undefined) {
-                    sorted_package_locations = sortPackageLocations(package_locations);
+                    sorted_package_locations = sortRuntimeLocations(package_locations);
                     package_locations = sorted_package_locations;
                 }
                 var package_signature_locations = build.package_signature_locations || [];
                 var sorted_package_signature_locations;
                 if (package_signature_locations !== null && package_signature_locations !== undefined) {
-                    sorted_package_signature_locations = sortPackageLocations(package_signature_locations);
+                    sorted_package_signature_locations = sortRuntimeLocations(package_signature_locations);
                     package_signature_locations = sorted_package_signature_locations;
                 }
                 if (package_locations !== null && package_locations !== undefined) {
@@ -344,13 +344,13 @@ function render_builds(builds, parent) {
                 var beta_package_locations = build.package_locations;
                 var sorted_beta_package_locations;
                 if (beta_package_locations !== null && beta_package_locations !== undefined) {
-                    sorted_beta_package_locations = sortPackageLocations(beta_package_locations);
+                    sorted_beta_package_locations = sortBetaLocations(beta_package_locations);
                     beta_package_locations = sorted_beta_package_locations;
                 }
                 var beta_package_sig_locs= build.package_signature_locations || [];
                 var sorted_beta_package_sig_locs;
                 if (beta_package_sig_locs !== null && beta_package_sig_locs !== undefined) {
-                    sorted_beta_package_sig_locs = sortPackageLocations(beta_package_sig_locs);
+                    sorted_beta_package_sig_locs = sortBetaLocations(beta_package_sig_locs);
                     beta_package_sig_locs = sorted_beta_package_sig_locs;
                 }
                 if (beta_package_locations !== null && beta_package_locations !== undefined) {
@@ -550,41 +550,56 @@ function add_lead_zero(number) {
     }
 }
 
-function sortPackageLocations(package_locations_param) {
-    for (var k = 0; k < package_locations_param.length; k++) {
-        var package_name = package_locations_param[k].split('=')[0].toLowerCase();
-        var packageName;
-        if (package_name.indexOf("java") > -1) {
-            packageName = "java";
-        }
-        else if (package_name.indexOf("jakarta") > -1) {
-            packageName = "jakarta";
-        }
-        else if (package_name.indexOf("webprofile") > -1) {
-            packageName = "webProfile";
-        }
-        else if (package_name.indexOf("microprofile") > -1) {
-            packageName = "microProfile";
-        }
-        var clonePackageLocationArray = package_locations_param.slice(0);
-        package_locations_param = package_locations_param.filter(function(element) {
-            if (element.split('.')[0].indexOf(packageName) > -1) {
-                return true;
-            }
-        });
-        package_locations_param.sort(function(a, b) {
-            if(a < b) { return -1; }
-            if(a > b) { return 1; }
-            return 0;
-        });
-        clonePackageLocationArray.forEach(function(element, index) {
-            if (element.split('.')[0].indexOf(packageName) == -1) {
-                package_locations_param.splice(index, 0, element);
-            }
-        });
+function sortBetaLocations(package_locations_param) {
+    var sortArr = [];
+    package_locations_param.forEach(function (x) {
+      ver = x.split("=")[0];
+      ver = ver.substring(0, ver.lastIndexOf("."));
+      sortArr.push({ location: x, version: ver });
+    });
+    sortArr.sort(orderVersions);
+    var newLoc = sortArr.map(function(x) {return x.location});
+    return newLoc;
+  }
+  
+  function orderVersions(a, b) {
+    var arrA = a.version.split(".");
+    var arrB = b.version.split(".");
+    for (var i = 0; i < arrA.length; i++) {
+      if (parseInt(arrA[i]) > parseInt(arrB[i])) {
+        return -1;
+      } else if (parseInt(arrA[i]) < parseInt(arrB[i])) {
+        return 1;
+      }
     }
-    return package_locations_param;
-}
+    return 0;
+  }
+  
+  function sortRuntimeLocations(package_locations_param) {
+    // this array is used to order the different applications available for each runtime version
+    // priority should list newest to oldest platforms, ending with kernel and GA
+    app_priority_array = [
+      "jakartaee9",
+      "webProfile9",
+      "microProfile5",
+      "javaee8",
+      "webProfile8",
+      "microProfile4",
+      "microProfile3",
+      "kernel",
+      "openliberty",
+    ];
+    var newLocations = [];
+    var packageNames = package_locations_param.map(function(x) {return x.split(".")[0]});
+    for (var k = 0; k < app_priority_array.length; k++) {
+      ind = packageNames.indexOf(app_priority_array[k]);
+      if (ind > -1) {
+        newLocations.push(package_locations_param[ind]);
+      }
+    }
+    return newLocations;
+  }
+
 
 function sort_builds(builds, key, descending) {
     builds.sort(function (a, b) {

--- a/src/main/content/_config.yml
+++ b/src/main/content/_config.yml
@@ -34,7 +34,16 @@ plugins:
   - jekyll-asciidoc
   - jekyll-assets
   - jekyll-include-cache
+  - jekyll-multiple-languages-plugin
   - ol-target-blank
+
+# jekyll-multiple-languages-plugin settings:
+languages: ["en"]
+
+exclude_from_localizations: ["img","fonts","favicon.ico","javascript", "images"]
+
+default_locale_in_subfolder: false
+
 exclude:
   - vendor # TravisCI bundles all gems in the vendor directory on its build servers, which Jekyll will mistakenly read and explode on.
   - docs

--- a/src/main/content/_i18n/en.yml
+++ b/src/main/content/_i18n/en.yml
@@ -1,0 +1,253 @@
+global:
+  tagline: English
+  openliberty: Open Liberty
+  ol_logo_subtitile: An IBM Open Source Project
+  about: About
+  twitter: Twitter
+  github: GitHub
+  learnmore: Learn more
+  readmore: Read more
+  follow: Follow
+  and: and
+  and_with: And with
+  or: or
+  trans_yes: 'Yes'
+  websphere_application_server: WebSphere Application Server
+  news_and_updates: News & updates
+  openlibertyio: openliberty.io
+  stackoverflow: Stack Overflow
+  q_and_a: Q & A
+  groupsio: Groups.io
+  community_forums: Community forums
+  gitter: Gitter
+  community_chat: Community chat
+  openliberty_without_space: OpenLiberty
+  404_error_message: Oh no! You’ve reached an unexplored corner of the universe.
+langs:
+  en: English
+  de: German
+  jp: Japanese
+pages:
+  start: Get Started
+  guides: Guides
+  docs: Docs
+  support: Support
+  blog: Blog
+footer:
+  copyright: Copyright IBM Corp. 2017, 2021
+  privacy_policy: Privacy policy
+  license: License
+  logos: Logos
+  ol_logo_subtitile: an IBM open source project
+home:
+  intro_title: A lightweight open framework for building fast and efficient cloud-native Java microservices.
+  intro_paragraph1: Build cloud-native apps and microservices while running only what you need.
+  intro_paragraph2: is the most flexible server runtime available to Java
+  intro_paragraph3: developers in this solar system.
+  get_openliberty: Get Open Liberty
+  cloud_native_develop_title: Develop cloud-native Java microservices
+  cloud_native_develop_text1: Open Liberty starts up fast, with a low memory footprint and live reload for quick iteration. Adding and removing features from the latest versions of
+  cloud_native_develop_text2: you focus on what's important, not the APIs changing under you.
+  fast_iteration_develop_title: Dev mode for fast iteration
+  fast_iteration_develop_text: Launch into dev mode and get coding. No more manual compiling, packaging, and deploying—we handle that for you. 
+                    Get automated testing, debugger support, and a fast turn-around time in any editor.
+  deploy_containers_develop_title: Deploy in containers to any cloud
+  deploy_containers_develop_text1: Containerized and deployable with fast throughput on any Kubernetes cloud. Battle-hardened and proven in production, with 
+  deploy_containers_develop_text2: Easy-to-manage configuration from development to test to production.
+  monitor_microservice_develop_title: Monitor microservices in the cloud
+  monitor_microservice_develop_text: Trace your live microservices. Gather metrics and configure alerts, and browse metrics in dashboards. Consolidate and 
+                    analyze logs from across your hybrid cloud.
+  openlibery_opensource_community_title: Open Liberty integrates with the Open Source community
+  openliberty_news: Open Liberty News
+  openliberty_news_text: Check out the latest news on our blog and follow us on Twitter.
+  link_to_blog_post: View all Open Liberty Blog posts
+  support_title: A crew that supports you
+  support_text1:     As a member of the Open Liberty crew, you have the support and 
+                    expertise of an entire community at your fingertips. Don't forget 
+                    to lean on them when you have questions!
+  support_text2: And for times that you need an extra boost, check out Open Liberty 
+                 Enterprise Support from IBM.
+  link_to_openliberty_support: Get Open Liberty support
+  get_involved_title: Get involved
+  get_involved_text:  Open Liberty thrives on users’ collaboration, contributions and creativity. 
+                We invite you to share your skills and ideas with users in this galaxy and beyond.
+  contribute_link: Contribute to Open Liberty
+  contributors_title: Here are some of our awesome contributors!
+start:
+  get_start_title: Get started with Open Liberty
+  intro_text: Whether trying or updating Open Liberty, we've got you covered!
+  starter_app_heading: Create a starter application
+  starter_desc1: Select the development tools that you prefer to use, then generate a package to 
+                start developing your application.
+  starter_desc2: Find a bug? Need an enhancement?
+  raise_an_issue: Raise an issue.
+  group: Group
+  artifact: Artifact
+  build_tool: Build Tool
+  java_se_version: Java SE Version
+  java_jakarta_ee_version: Java EE/Jakarta EE Version
+  microprofile_version: MicroProfile Version
+  generate_project: Generate Project
+  guides_smallcase: guides
+  generate_project_modal:
+    heading: Your zip file has been beamed to your computer!
+    instruction: Unzip it and run this command, or refer to the included README.
+    guide_link: For more help, visit our 
+    got_it: Got it!
+  get_OL_section_title: Add to an existing application
+  get_OL_section_text: Get Open Liberty using these commands for Maven, Gradle, or Docker.
+  find_out: Find out
+  how_to_use_maven: how to use Maven with Open Liberty.
+  how_to_use_gradle: how to use Gradle with Open Liberty.
+  how_to_use_docker: how to use Docker with Open Liberty.
+  download_package: Download package
+  download_package_section:
+    para: We recommend using the latest release, but beta and development builds are also available for use. Once downloaded, you're ready for lift-off.
+    releases: Releases
+    development_builds: Development builds
+    betas: Betas
+    nightly_builds: Nightly Builds
+    eclipse_developer_tools: Eclipse Developer Tools
+    table_header:
+      version: Version
+      package: Package
+      download: Download
+      verification: Verification
+      build_date: Build Date
+      tests: Tests
+      logs: Logs
+    releases_content1: New releases will be announced on the Open Liberty
+    releases_content2: Starting with version 22.0.0.1, signature files are produced for every package of an Open Liberty release. You can use these signature files
+                      and the corresponding public key to verify the authenticity and integrity of an Open Liberty release package. For more information, see
+    verify_oio_release_packages: Verifying Open Liberty release packages.
+    obtain_public_key: Obtain the public key from this link.
+    save_file_from_browser: Save the file from your browser as a
+    pem: .pem
+    file: file
+    beta_content1: Try out new features in our betas and let us know
+    beta_content2: your feedback.
+    beta_content3: Beta content may change from 
+    beta_content4: release to release.
+    beta_content5: Starting with version 22.0.0.1, signature files are produced for every package of an Open Liberty release. You can use these signature files
+                  and the corresponding public key to verify the authenticity and integrity of an Open Liberty release package. For more information, see
+    nightly_builds_content: Nightly builds contain in-development features, have not gone through the full release process and are potentially unstable.
+    eclipse_developer_tools_content1: We recommend IDE tools based on Eclipse since it gives you an integrated environment right out of the box.
+    eclipse_developer_tools_content2: Learn how to install the tools here.
+    cow_text: Don't have a cow.
+    more_downloads_on_the_way: More downloads are on the way.
+    check_back_soon: Check back soon!
+support:
+  you_are_not_alone: You are not alone...
+  support_for_all_text: Whether you're an enterprise or a smaller crew, there's Open Liberty support for all
+  find_out_more: Find out more
+  community_support: Community support
+  community_support_text: You can rely on your Open Liberty crew to get you un-stuck
+  connect_text1: Connect with others using the tag
+  connect_text2: across all social media.
+  fix_text1: Found something that needs to be fixed?
+  fix_text2: Check out the open issues or report a new one.
+  open_issue_github: Open an issue on GitHub
+  contributor_title: Become a contributor
+  contributor_text: Open Liberty is speeding toward the future, but your contributions can get us there at lightspeed
+  contribute_to_openliberty: Contribute to Open Liberty
+contribute:
+  intro_paragraph1: Contributing to open source projects can seem scarier than a certain spherical, planet-destroying space station, but it doesn't have to be.
+  intro_paragraph2: The Open Liberty community welcomes contributions at all levels. Whether you're an ensign or a seasoned commander, every user has the potential to help out.
+  ol_license_under_text: Open Liberty is licensed under
+  epl_version: EPL v-1.0.
+  getting_started: Getting Started
+  getting_started_paragraph: Thank you for joining the Open Liberty community. We can’t wait to see what we build together! There 
+                are so many ways to contribute to Open Liberty; just be sure to check out the contributor guidelines 
+                before you blast off and start making cool stuff.
+  view_contributor_guidelines: View the contributor guidelines
+  fix_a_bug: Fix a bug
+  issue_text: This is a current list of open, unassigned issues. See something that you might be able to help with? Show us your best solution!
+  view_all_open_issues: View all open issues
+  tools_and_test_title1: Tools and tests
+  tools_and_test_paragraph1: Contribute to the next release by writing tests and helping craft better tools.
+  tools_and_test_title2: Contribute to developer tools
+  tools_and_test_paragraph2: Open Liberty works with all developer tools, so use whatever you like best! However, we'll be releasing updates to Eclipse developer tools that
+                are tailored for the newest Open Liberty releases. With your contributions, these tools will evolve alongside Open Liberty to form a perfect
+                pairing, making your workflow smoother. 
+  learn_more_about_eclipse_tools: Learn more about Eclipse developer tools
+  view_eclipse_tools_repo: View the Eclipse developer tools repository
+  tools_and_test_title3: Provide a test
+  tools_and_test_paragraph3: Testing is an essential step to having a robust, helpful release. The more high quality tests we run before a release, the more headaches we
+                save our users in the future.
+  learn_in_and_out_testing_oio: Learn the ins and outs of testing for Open Liberty
+  future_of_ol: The Future of Open Liberty
+  ready_to_go_beyond: Ready to go above and beyond?
+  future_of_ol_paragraph: If you’d like to work on new features, get up to speed with our handy guide to writing them. 
+                We also encourage you to participate in the forum to discuss upcoming features, and see where 
+                you could pitch in.  And don’t forget to leave suggestions for future development items so your 
+                great ideas can be heard!
+  ol_contributor_forum: Open Liberty contributor forum (Groups.io)
+  open_issues_new_features: Open issues for new features
+  connect_with_ol_crew: Connect with the Open Liberty crew
+  more_ways_to_connect: With Open Liberty, you can boldly go where no one has gone before… but don’t forget the rest of your team!
+  connect_with_your_community: Connect with your community
+certifications:
+  certification_title: Certifications
+  certification_desc: Open Liberty, certified for warp speed development!
+  olio_tck_results: List of Open Liberty TCK Results
+guides:
+  description: The quickest way to learn all things Open Liberty, and beyond!
+  suggested_tags: Suggested tags
+  new: new
+  new_camel_case: New
+  run_in_cloud: run in cloud
+  interactive: interactive
+  interactive_camel_case: Interactive
+  toggle_navigation: Toggle navigation
+  table_of_contents: Table of contents
+  updated: Updated
+  no_results_found: No results found
+  no_guides_matching: Sorry, we couldn't find any guides matching
+  want_to_see_guide_on_this_topic: Want to see a guide on this topic?
+  checkout_and_raise_issue: Check out our project board and raise an issue.
+  back_to_all_ol_guides: Back to all Open Liberty guides
+  placeholder_filter_guides: Filter guides
+  contents: Contents
+  tags: Tags
+  prerequisites: Prerequisites
+  copied_to_clipboard: Copied to clipboard
+  back_to_text: Back to text
+blog:
+  see_all_blog_posts: See all blog posts
+  never_miss_a_post: Never miss a post!
+  be_sure_to_follow: Be sure to follow
+  twitter_or_subscribe: on Twitter or subscribe to our
+  rss_feed: RSS feed.
+  featured_tags: Featured Tags
+  no_results_found: No results found.
+  see: See
+  all_blogs: all blogs.
+  filtered_by_tag: Filtered by tag
+  latest_posts: Latest Posts
+  older_posts: Older Posts
+  stay_light_years_ahead: Stay lightyears ahead.
+overview:
+  contribute_on_github: Contribute on GitHub
+  open_issue: Open Issue
+  edit_topic: Edit Topic
+endofguide:
+  nice_work: Nice work!
+  where_to_next: Where to next?
+  what_do_you_think_of_this_guide: What did you think of this guide?
+  thanks_for_feedback: Thank you for your feedback!
+  close: Close
+  open_github_issue: Would you like to open an issue in GitHub?
+  no_thankyou: No, thank you
+  what_makes_guide_better: What could make this guide better?
+  raise_an_issue: Raise an issue
+  to_share_feedback: to share feedback
+  create_pr: Create a pull request
+  to_contribute_guide: to contribute to this guide
+  need_help: Need help?
+  ask_ques_on_stackoverflow: Ask a question on Stack Overflow
+  like_olio: Like Open Liberty? Star our repo on GitHub.
+  star: Star
+  download_sample_app: Download the sample application for this guide bundled with Open Liberty on github
+  keep_exploring: Keep exploring
+  with_these_guides: with these guides.
+  

--- a/src/main/content/_includes/end-of-guide.html
+++ b/src/main/content/_includes/end-of-guide.html
@@ -28,12 +28,17 @@
 <!-- Sort list of guides by date with most recent first -->
 {% assign all_guides_by_date = all-guides | sort: "releasedate" | reverse %}
 
+{% assign baseURL = '' %}
+{% if site.lang != 'en' %}
+    {% assign baseURL = '/' | append: site.lang %}
+{% endif %}
+
 <div id="end_of_guide">
-        <h2 tabindex="0">Nice work! Where to next?</h2>
+        <h2 tabindex="0">{% t endofguide.nice_work %} {% t endofguide.where_to_next %}</h2>
         <div id="end_of_guide_left_section">
             <p id="guide_attribution"></p>
             
-            <h3 id="feedback_rating_question">What did you think of this guide?</h3>
+            <h3 id="feedback_rating_question">{% t endofguide.what_do_you_think_of_this_guide %}</h3>
             <div id="feedback_ratings">
                 <img class="guide_rating" id="extreme_dislike" src="/img/1_Extreme_Dislike.png" onclick="$('#dislike_popup').show(); $('.popup_content').focus();" alt="Extreme Dislike" data-guide-rating="1" tabindex="0" aria-label="Rate this guide as extreme dislike">
                 <img class="guide_rating" id="dislike" src="/img/2_Dislike.png" onclick="$('#dislike_popup').show(); $('.popup_content').focus();" alt="Dislike" data-guide-rating="2" tabindex="0" aria-label="Rate this guide as dislike">
@@ -43,48 +48,48 @@
 
             <div id="like_popup" class="popup">
                 <div class="popup_content" tabindex="0">
-                    <p class="popup_title">Thank you for your feedback!</p>
-                    <button id="close_button" class="popup_button" onclick="$('#like_popup').hide();">Close</button>
+                    <p class="popup_title">{% t endofguide.thanks_for_feedback %}</p>
+                    <button id="close_button" class="popup_button" onclick="$('#like_popup').hide();">{% t endofguide.close %}</button>
                 </div>
             </div>
 
             <div id="dislike_popup" class="popup">
                 <div class="popup_content" tabindex="0">
-                    <p class="popup_title">Thank you for your feedback!</p>
-                    <p id="open_issue">Would you like to open an issue in GitHub?</p>
+                    <p class="popup_title">{% t endofguide.thanks_for_feedback %}</p>
+                    <p id="open_issue">{% t endofguide.open_github_issue %}</p>
                     {% if page.layout == 'guide' or page.layout == 'guide-multipane' %}
-                        <a href="https://github.com/OpenLiberty/guide-{{page.url | replace: '/guides/', ''}}/issues/new" target="_blank" id="yes_button" class="popup_button" onclick="$('#dislike_popup').hide();">Yes</a>
+                        <a href="https://github.com/OpenLiberty/guide-{{page.url | replace: '/guides/', ''}}/issues/new" target="_blank" id="yes_button" class="popup_button" onclick="$('#dislike_popup').hide();">{% t global.trans_yes %}</a>
                     {% elsif page.layout == 'iguide-multipane' %}
-                        <a href="https://github.com/OpenLiberty/iguide-{{page.url | replace: '/guides/', ''}}/issues/new" target="_blank" id="yes_button" class="popup_button" onclick="$('#dislike_popup').hide();">Yes</a>
+                        <a href="https://github.com/OpenLiberty/iguide-{{page.url | replace: '/guides/', ''}}/issues/new" target="_blank" id="yes_button" class="popup_button" onclick="$('#dislike_popup').hide();">{% t global.trans_yes %}</a>
                     {% endif %}
-                    <button id="no_button" class="popup_button" onclick="$('#dislike_popup').hide();">No, thank you</button>
+                    <button id="no_button" class="popup_button" onclick="$('#dislike_popup').hide();">{% t endofguide.no_thankyou %}</button>
                 </div>
             </div>
 
-            <h3 id="improve_guide_feedback">What could make this guide better?</h3>
+            <h3 id="improve_guide_feedback">{% t endofguide.what_makes_guide_better %}</h3>
             {% if page.layout == 'guide' or page.layout == 'guide-multipane' %}
-                <p><a target="_blank" rel="noopener noreferrer" href="https://github.com/OpenLiberty/guide-{{page.url | replace: '/guides/', ''}}/issues">Raise an issue</a> to share feedback</p>
-                <p><a target="_blank" rel="noopener noreferrer" href="https://github.com/OpenLiberty/guide-{{page.url | replace: '/guides/', ''}}/pulls">Create a pull request</a> to contribute to this guide</p>
+                <p><a target="_blank" rel="noopener noreferrer" href="https://github.com/OpenLiberty/guide-{{page.url | replace: '/guides/', ''}}/issues">{% t endofguide.raise_an_issue %}</a> {% t endofguide.to_share_feedback %}</p>
+                <p><a target="_blank" rel="noopener noreferrer" href="https://github.com/OpenLiberty/guide-{{page.url | replace: '/guides/', ''}}/pulls">{% t endofguide.create_pr %}</a> {% t endofguide.to_contribute_guide %}</p>
             {% elsif page.layout == 'iguide-multipane' %}
-                <p><a target="_blank" rel="noopener noreferrer" href="https://github.com/OpenLiberty/iguide-{{page.url | replace: '/guides/', ''}}/issues">Raise an issue</a> to share feedback</p>
-                <p><a target="_blank" rel="noopener noreferrer" href="https://github.com/OpenLiberty/iguide-{{page.url | replace: '/guides/', ''}}/pulls">Create a pull request</a> to contribute to this guide</p>
+                <p><a target="_blank" rel="noopener noreferrer" href="https://github.com/OpenLiberty/iguide-{{page.url | replace: '/guides/', ''}}/issues">{% t endofguide.raise_an_issue %}</a> {% t endofguide.to_share_feedback %}</p>
+                <p><a target="_blank" rel="noopener noreferrer" href="https://github.com/OpenLiberty/iguide-{{page.url | replace: '/guides/', ''}}/pulls">{% t endofguide.create_pr %}</a> {% t endofguide.to_contribute_guide %}</p>
             {% endif %}
 
-            <h3 id="need_help">Need help?</h3>
-            <p><a target="_blank" rel="noopener noreferrer" href="https://stackoverflow.com/questions/tagged/open-liberty">Ask a question on Stack Overflow</a></p>
+            <h3 id="need_help">{% t endofguide.need_help %}</h3>
+            <p><a target="_blank" rel="noopener noreferrer" href="https://stackoverflow.com/questions/tagged/open-liberty">{% t endofguide.ask_ques_on_stackoverflow %}</a></p>
 
-            <h3>Like Open Liberty? Star our repo on GitHub.</h3>
-            <a class="github-button" href="https://github.com/OpenLiberty/open-liberty" data-icon="octicon-star" aria-label="Star OpenLiberty/open-liberty on GitHub">Star</a>
+            <h3>{% t endofguide.like_olio %}</h3>
+            <a class="github-button" href="https://github.com/OpenLiberty/open-liberty" data-icon="octicon-star" aria-label="Star OpenLiberty/open-liberty on GitHub">{% t endofguide.star %}</a>
         </div>
         <div id="end_of_guide_right_section">
-            <h3 id="where_to_next">Where to next?</h3>
+            <h3 id="where_to_next">{% t endofguide.where_to_next %}</h3>
 
             {% if page.layout == 'iguide-multipane' %}
-                <p><a target="_blank" rel="noopener noreferrer" href="https://github.com/OpenLiberty/iguide-{{page.url | replace: '/guides/', ''}}/tree/prod/finish">Download the sample application for this guide bundled with Open Liberty on github</a></p>
+                <p><a target="_blank" rel="noopener noreferrer" href="https://github.com/OpenLiberty/iguide-{{page.url | replace: '/guides/', ''}}/tree/prod/finish">{% t endofguide.download_sample_app %}</a></p>
                 <br>
             {% endif %}
             {% if page.categories %}
-            <p>Keep exploring <b>{{ page.categories }}</b> with these guides.</p>
+            <p>{% t endofguide.keep_exploring %} <b>{{ page.categories }}</b> {% t endofguide.with_these_guides %}</p>
             {% endif %}
 
             <!-- Related guides section -->
@@ -98,7 +103,7 @@
                         <!-- Only create a card if we find the permalink -->
                         {% assign related-guide-metadata = list[0] %}
                         <div class="col-sm-12 col-lg-6">
-                            <a href="/guides/{{related-guide}}.html" class="small_guide_item">
+                            <a href="{{baseURL}}/guides/{{related-guide}}.html" class="small_guide_item">
                                 <div class="guide_title_container">
                                     <h3 class="guide_title">{{related-guide-metadata.title}}</h3>
                                 </div>
@@ -111,7 +116,7 @@
                                     {% if related-guide-metadata.title ==  all_guides_by_date[0].title or related-guide-metadata.title ==  all_guides_by_date[1].title 
                                     or related-guide-metadata.title ==  all_guides_by_date[2].title or related-guide-metadata.title ==  all_guides_by_date[3].title %}
                                         <div class="new_guide_container">
-                                            <span class="guide_new">New</span>
+                                            <span class="guide_new">{% t guides.new_camel_case %}</span>
                                         </div>
                                     {% endif %}
                                 <!-- If new posts count is >= 4, use posts from last 30 days-->
@@ -122,7 +127,7 @@
                                     <!-- 2592000 is 30 days in seconds (30 days * 24 hours * 60 minutes * 60 seconds) -->
                                     {% if date_difference < 2592000 %}
                                         <div class="new_guide_container">
-                                            <span class="guide_new">New</span>
+                                            <span class="guide_new">{% t guides.new_camel_case %}</span>
                                         </div>
                                     {% endif %}
                                 {% endif %}
@@ -134,13 +139,13 @@
                                 {% assign date_now = 'now' | date:'%s' %} {% assign date_difference =
                                 date_now | minus: date_updated %} {% if date_difference < 7257600 %}
                                 <div class="updated_guide_container">
-                                    <span class="guide_updated">Updated</span>
+                                    <span class="guide_updated">{% t guides.updated %}</span>
                                 </div>
                                 {% endif %}{% endif %}
                                 {% if related-guide-metadata.layout == 'iguide-multipane' %}
                                     <div class="guide_interactive_container">
                                         <img class="interactive_bolt_icon" src="/img/guide_lightning_bolt.svg" alt="Interactive">
-                                        <span class="guide_interactive">Interactive</span>
+                                        <span class="guide_interactive">{% t guides.interactive_camel_case %}</span>
                                     </div>
                                 {% endif %}
                             </a>

--- a/src/main/content/_includes/footer.html
+++ b/src/main/content/_includes/footer.html
@@ -1,9 +1,15 @@
- <footer>
+
+{% assign baseURL = '' %}
+{% if site.lang != 'en' %}
+    {% assign baseURL = '/' | append: site.lang %}
+{% endif %}
+
+<footer>
     <div id="footer_gray_background">
         <div id="footer_top_container" class="footer_container container-fluid">
             <div id="footer_project_container">
                 <span id="footer_open_liberty"></span>
-                <p id="footer_project">an IBM open source project</p>
+                <p id="footer_project">{% t footer.ol_logo_subtitile %}</p>
             </div>
             <div id="footer_round_links_container">
                 <a id="footer_github_link" class="footer_round_btn" href="https://github.com/OpenLiberty/" target="_blank" rel="noopener" aria-label="Github"></a>
@@ -17,18 +23,18 @@
 
     <div id="footer_bottom_container" class="footer_container container-fluid">
         <div id="footer_bottom_left_section">
-            <p id="footer_copyright">&copy; Copyright IBM Corp. 2017, 2021</p>
+            <p id="footer_copyright">&copy; {% t footer.copyright %}</p>
             <p class="vertical_bar">|</p>
-            <a id="footer_privacy_policy_link" href="https://www.ibm.com/privacy/" target="_blank" rel="noopener" class="left_footer_link">Privacy policy</a>
+            <a id="footer_privacy_policy_link" href="https://www.ibm.com/privacy/" target="_blank" rel="noopener" class="left_footer_link">{% t footer.privacy_policy %}</a>
             <p class="vertical_bar">|</p>
-            <a id="footer_license_link" href="https://github.com/OpenLiberty/open-liberty/blob/release/LICENSE" target="_blank" rel="noopener" class="left_footer_link">License</a>
+            <a id="footer_license_link" href="https://github.com/OpenLiberty/open-liberty/blob/release/LICENSE" target="_blank" rel="noopener" class="left_footer_link">{% t footer.license %}</a>
             <p class="vertical_bar">|</p>
-            <a id="footer_logos_link" href="https://github.com/OpenLiberty/logos" target="_blank" rel="noopener" class="left_footer_link">Logos</a>
+            <a id="footer_logos_link" href="https://github.com/OpenLiberty/logos" target="_blank" rel="noopener" class="left_footer_link">{% t footer.logos %}</a>
         </div>
         <div id="footer_bottom_right_section">
-            <a id="footer_docs_link" href="/docs" aria-label="Open Liberty Docs" class="right_footer_link blue_link_light_background">Docs</a>
-            <a id="footer_blog_link" href="/blog" aria-label="Open Liberty Blog" class="right_footer_link blue_link_light_background">Blog</a>
-            <a id="footer_support_link" href="/support" aria-label="Open Liberty Support" class="right_footer_link blue_link_light_background">Support</a>
+            <a id="footer_docs_link" href="{{baseURL}}/docs" aria-label="Open Liberty Docs" class="right_footer_link blue_link_light_background">{% t pages.docs %}</a>
+            <a id="footer_blog_link" href="{{baseURL}}/blog" aria-label="Open Liberty Blog" class="right_footer_link blue_link_light_background">{% t pages.blog %}</a>
+            <a id="footer_support_link" href="{{baseURL}}/support" aria-label="Open Liberty Support" class="right_footer_link blue_link_light_background">{% t pages.support %}</a>
         </div>
     </div>
 </footer>

--- a/src/main/content/_includes/header.html
+++ b/src/main/content/_includes/header.html
@@ -1,7 +1,15 @@
+
+{% assign baseURL = '' %}
+{% assign homeURL = '/' %}
+{% if site.lang != 'en' %}
+    {% assign baseURL = '/' | append: site.lang %}
+    {% assign homeURL = baseURL %}
+{% endif %}
+
 <header>
     <nav id="nav_bar">
         <div id="nav_header">
-            <a id="home_link" href="/" aria-label="Open Liberty Home">
+            <a id="home_link" href="{{homeURL}}" aria-label="Open Liberty Home">
                 <img id="ol_logo" src="/img/docs_openliberty_logo.png" alt="Open Liberty Logo">
             </a>
             <button id="hamburger_toggle_button" onclick="$('#nav_bar').toggleClass('responsive');">
@@ -11,19 +19,19 @@
         <div id="hamburger_menu">
             <ul class="nav_list">
                 <li class="nav_link">
-                    <a href="/start/">Get Started</a>
+                    <a href="{{baseURL}}/start/">{% t pages.start %}</a>
                 </li>
                 <li class="nav_link">
-                    <a href="/guides/">Guides</a>
+                    <a href="{{baseURL}}/guides/">{% t pages.guides %}</a>
                 </li>
                 <li class="nav_link">
-                    <a href="/docs/">Docs</a>
+                    <a href="{{baseURL}}/docs/">{% t pages.docs %}</a>
                 </li>
                 <li class="nav_link">
-                    <a href="/support/">Support</a>
+                    <a href="{{baseURL}}/support/">{% t pages.support %}</a>
                 </li>
                 <li class="nav_link">
-                    <a href="/blog/">Blog</a>
+                    <a href="{{baseURL}}/blog/">{% t pages.blog %}</a>
                 </li>
             </ul>
             <div id="header_round_links_container"> 
@@ -33,5 +41,6 @@
                 <a id="header_gitter_link" class="header_round_button" href="https://gitter.im/OpenLiberty/" target="_blank" rel="noopener noreferrer" aria-label="Open Liberty Gitter"></a>
             </div>
         </div>
+
     </nav>
 </header>

--- a/src/main/content/_includes/overview.html
+++ b/src/main/content/_includes/overview.html
@@ -5,10 +5,10 @@
         {% if page.title == "Server commands overview" %}
             <p id="github_link">
                 <img id="docs_github_logo" src="/img/docs_github_logo.svg" alt="GitHub logo">
-                Contribute on GitHub:
-                <a id="open_issue_link" href="" target="_blank" rel="noopener">Open Issue</a>
+                {% t overview.contribute_on_github %}:
+                <a id="open_issue_link" href="" target="_blank" rel="noopener">{% t overview.open_issue %}</a>
                 |
-                <a id="edit_topic_link" href="" target="_blank" rel="noopener">Edit Topic</a>
+                <a id="edit_topic_link" href="" target="_blank" rel="noopener">{% t overview.edit_topic %}</a>
             </p>
         {% endif %}
     </div>

--- a/src/main/content/_layouts/guide-multipane.html
+++ b/src/main/content/_layouts/guide-multipane.html
@@ -57,11 +57,11 @@ plus: 1 %} {% endif %} {% endfor %}
           tabindex="0"
         />
       </div>
-      <h3 id="toc_title">Contents</h3>
+      <h3 id="toc_title">{% t guides.contents %}</h3>
       <div id="toc_container">{{ toc }}</div>
       <div id="toc_separator"></div>
       {% endif %}
-      <h3 id="tag_title">Tags</h3>
+      <h3 id="tag_title">{% t guides.tags %}</h3>
       <div id="tags_container"></div>
     </div>
   </div>
@@ -92,7 +92,7 @@ plus: 1 %} {% endif %} {% endfor %}
           all_guides_by_date[2].title or page.title ==
           all_guides_by_date[3].title %}
           <div class="new_guide_container">
-            <span class="guide_new">New</span>
+            <span class="guide_new">{% t guides.new_camel_case %}</span>
           </div>
           {% endif %}
           <!-- If new posts count is >= 4, use posts from last 30 days-->
@@ -102,7 +102,7 @@ plus: 1 %} {% endif %} {% endfor %}
           <!-- 2592000 is 30 days in seconds (30 days * 24 hours * 60 minutes * 60 seconds) -->
           {% if date_difference < 2592000 %}
           <div class="new_guide_container">
-            <span class="guide_new">New</span>
+            <span class="guide_new">{% t guides.new_camel_case %}</span>
           </div>
           {% endif %} {% endif %}
           <!-- Add Updated flag to guides if the last major update is within last 12 weeks. -->
@@ -113,12 +113,12 @@ plus: 1 %} {% endif %} {% endfor %}
           {% assign date_now = 'now' | date:'%s' %} {% assign date_difference =
           date_now | minus: date_updated %} {% if date_difference < 7257600 %}
           <div class="updated_guide_container">
-            <span class="guide_updated">Updated</span>
+            <span class="guide_updated">{% t guides.updated %}</span>
           </div>
           {% endif %}{% endif %}
         </div>
         <div id="mobile_prereqs_section">
-          <p id="mobile_prereqs_title">Prerequisites:</p>
+          <p id="mobile_prereqs_title">{% t guides.prerequisites %}:</p>
           <div class="prereqs_list"></div>
           <div class="skills_network_container">
             <div class="skills_network_description"></div>
@@ -141,7 +141,7 @@ plus: 1 %} {% endif %} {% endfor %}
             type="button"
             tabindex="0"
           >
-            <span class="sr-only">Toggle navigation</span>
+            <span class="sr-only">{% t guides.toggle_navigation %}</span>
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
@@ -151,14 +151,14 @@ plus: 1 %} {% endif %} {% endfor %}
               alt="Table of contents close button"
             />
           </button>
-          <span>Table of contents</span>
+          <span>{% t guides.table_of_contents %}</span>
         </div>
       </div>
 
       <!-- Guide content section -->
       {{ content }}
     </div>
-    <div id="guide_section_copied_confirmation">Copied to clipboard</div>
+    <div id="guide_section_copied_confirmation">{% t guides.copied_to_clipboard %}</div>
     <img
       id="copy_to_clipboard"
       src="/img/guides_copy_button.svg"
@@ -184,7 +184,7 @@ plus: 1 %} {% endif %} {% endfor %}
     <div id="code_column_content"></div>
 
     <div id="prereqs_container">
-      <p id="prereqs_title">Prerequisites:</p>
+      <p id="prereqs_title">{% t guides.prerequisites %}:</p>
       <div class="prereqs_list"></div>
       <div class="skills_network_container">
         <div class="skills_network_description"></div>
@@ -192,7 +192,7 @@ plus: 1 %} {% endif %} {% endfor %}
     </div>
 
     <button id="dismiss_button" aria-label="Back to text" tabindex="0">
-      Back to text
+      {% t guides.back_to_text %}
     </button>
   </div>
 </div>

--- a/src/main/content/_layouts/guide.html
+++ b/src/main/content/_layouts/guide.html
@@ -55,11 +55,11 @@ plus: 1 %} {% endif %} {% endfor %}
             tabindex="0"
           />
         </div>
-        <h3 id="toc_title">Contents</h3>
+        <h3 id="toc_title">{% t guides.contents %}</h3>
         <div id="toc_container">{{ toc }}</div>
         <div id="toc_separator"></div>
         {% endif %}
-        <h3 id="tag_title">Tags</h3>
+        <h3 id="tag_title">{% t guides.tags %}</h3>
         <div id="tags_container"></div>
       </div>
     </div>
@@ -93,7 +93,7 @@ plus: 1 %} {% endif %} {% endfor %}
             all_guides_by_date[2].title or page.title ==
             all_guides_by_date[3].title %}
             <div class="new_guide_container">
-              <span class="guide_new">New</span>
+              <span class="guide_new">{% t guides.new_camel_case %}</span>
             </div>
             {% endif %}
             <!-- If new posts count is >= 4, use posts from last 30 days-->
@@ -103,7 +103,7 @@ plus: 1 %} {% endif %} {% endfor %}
             <!-- 2592000 is 30 days in seconds (30 days * 24 hours * 60 minutes * 60 seconds) -->
             {% if date_difference < 2592000 %}
             <div class="new_guide_container">
-              <span class="guide_new">New</span>
+              <span class="guide_new">{% t guides.new_camel_case %}</span>
             </div>
             {% endif %} {% endif %}
             <!-- Add Updated flag to guides if the last major update is within last 12 weeks. -->
@@ -114,12 +114,12 @@ plus: 1 %} {% endif %} {% endfor %}
             {% assign date_now = 'now' | date:'%s' %} {% assign date_difference =
             date_now | minus: date_updated %} {% if date_difference < 7257600 %}
             <div class="updated_guide_container">
-              <span class="guide_updated">Updated</span>
+              <span class="guide_updated">{% t guides.updated %}</span>
             </div>
             {% endif %}{% endif %}
           </div>
           <div id="mobile_prereqs_section">
-            <p id="mobile_prereqs_title">Prerequisites:</p>
+            <p id="mobile_prereqs_title">{% t guides.prerequisites %}:</p>
             <div class="prereqs_list"></div>
           </div>
         </div>
@@ -139,7 +139,7 @@ plus: 1 %} {% endif %} {% endfor %}
               type="button"
               tabindex="0"
             >
-              <span class="sr-only">Toggle navigation</span>
+              <span class="sr-only">{% t guides.toggle_navigation %}</span>
               <span class="icon-bar"></span>
               <span class="icon-bar"></span>
               <span class="icon-bar"></span>
@@ -149,14 +149,14 @@ plus: 1 %} {% endif %} {% endfor %}
                 alt="Table of contents close button"
               />
             </button>
-            <span>Table of contents</span>
+            <span>{% t guides.table_of_contents %}</span>
           </div>
         </div>
 
         <!-- Guide content section -->
         {{ content }}
       </div>
-      <div id="guide_section_copied_confirmation">Copied to clipboard</div>
+      <div id="guide_section_copied_confirmation">{% t guides.copied_to_clipboard %}</div>
       <img
         id="copy_to_clipboard"
         src="/img/guides_copy_button.svg"

--- a/src/main/content/_layouts/iguide-multipane.html
+++ b/src/main/content/_layouts/iguide-multipane.html
@@ -53,12 +53,12 @@ plus: 1 %} {% endif %} {% endfor %}
           tabindex="0"
         />
       </div>
-      <h3 id="toc_title">Contents</h3>
+      <h3 id="toc_title">{% t guides.contents %}</h3>
       <div id="toc_container">
         <ul class="sectlevel1"></ul>
       </div>
       <div id="toc_separator"></div>
-      <h3 id="tag_title">Tags</h3>
+      <h3 id="tag_title">{% t guides.tags %}</h3>
       <div id="tags_container"></div>
     </div>
   </div>
@@ -89,7 +89,7 @@ plus: 1 %} {% endif %} {% endfor %}
           all_guides_by_date[2].title or page.title ==
           all_guides_by_date[3].title %}
           <div class="new_guide_container">
-            <span class="guide_new">New</span>
+            <span class="guide_new">{% t guides.new_camel_case %}</span>
           </div>
           {% endif %}
           <!-- If new posts count is >= 4, use posts from last 30 days-->
@@ -99,7 +99,7 @@ plus: 1 %} {% endif %} {% endfor %}
           <!-- 2592000 is 30 days in seconds (30 days * 24 hours * 60 minutes * 60 seconds) -->
           {% if date_difference < 2592000 %}
           <div class="new_guide_container">
-            <span class="guide_new">New</span>
+            <span class="guide_new">{% t guides.new_camel_case %}</span>
           </div>
           {% endif %} {% endif %}
           <!-- Add Updated flag to guides if the last major update is within last 12 weeks. -->
@@ -110,7 +110,7 @@ plus: 1 %} {% endif %} {% endfor %}
           {% assign date_now = 'now' | date:'%s' %} {% assign date_difference =
           date_now | minus: date_updated %} {% if date_difference < 7257600 %}
           <div class="updated_guide_container">
-            <span class="guide_updated">Updated</span>
+            <span class="guide_updated">{% t guides.updated %}</span>
           </div>
           {% endif %}{% endif %}
           <div class="guide_interactive_container">
@@ -119,7 +119,7 @@ plus: 1 %} {% endif %} {% endfor %}
               src="/img/guide_lightning_bolt.svg"
               alt="Interactive"
             />
-            <span class="guide_interactive">Interactive</span>
+            <span class="guide_interactive">{% t guides.interactive_camel_case %}</span>
           </div>
         </div>
         <p>{{ page.description }}</p>
@@ -141,7 +141,7 @@ plus: 1 %} {% endif %} {% endfor %}
             type="button"
             tabindex="0"
           >
-            <span class="sr-only">Toggle navigation</span>
+            <span class="sr-only">{% t guides.toggle_navigation %}</span>
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
@@ -151,14 +151,14 @@ plus: 1 %} {% endif %} {% endfor %}
               alt="Table of contents close button"
             />
           </button>
-          <span>Table of contents</span>
+          <span>{% t guides.table_of_contents %}</span>
         </div>
       </div>
 
       <!-- Guide content section -->
       {{ content }}
     </div>
-    <div id="guide_section_copied_confirmation">Copied to clipboard</div>
+    <div id="guide_section_copied_confirmation">{% t guides.copied_to_clipboard %}</div>
     <img
       id="copy_to_clipboard"
       src="/img/guides_copy_button.svg"

--- a/src/main/content/_layouts/post.html
+++ b/src/main/content/_layouts/post.html
@@ -6,11 +6,16 @@ css:
 js: post
 ---
 
+{% assign baseURL = '' %}
+{% if site.lang != 'en' %}
+    {% assign baseURL = '/' | append: site.lang %}
+{% endif %}
+
 <div id="article_container" class="container-fluid">
     <article class="post" aria-label="article">
         <header id="post_header">
             <div class="container">
-                <a id="blog_link" href="/blog"><img class="arrow" src="/img/post_arrow.svg" alt="back to all blogs">See all blog posts</a>
+                <a id="blog_link" href="{{baseURL}}/blog"><img class="arrow" src="/img/post_arrow.svg" alt="back to all blogs">{% t blog.see_all_blog_posts %}</a>
                 <div class="share_post_container">
                     {% assign page_title = page.title | replace: "'" , "\\\\'" %}
                     <a class="twitter_link" href="//twitter.com/intent" onclick="window.open('https://twitter.com/intent/tweet?text=' + encodeURIComponent('{{ page_title }}') + '&url=' + encodeURIComponent(window.location)); return false" aria-label="Twitter link"></a>
@@ -32,12 +37,12 @@ js: post
                     <a class="author_name" href="{{ page.author_github }}" target="_blank" rel="noopener">{{ page.author }}</a>
                     {% for author in page.additional_authors %}
                         {% if additional_author_count == 1 %}
-                            <span>and</span>
+                            <span>{% t global.and %}</span>
                         {% elsif additional_author_count > 1 %}
                             {% if current < additional_author_count %}
                                 <span class="comma">,</span>
                             {% elsif current == additional_author_count %}
-                                <span class="comma">, and</span>
+                                <span class="comma">, {% t global.and %}</span>
                             {% endif %}
                         {% endif %}
                         {% assign current = current | plus: 1 %}
@@ -57,12 +62,12 @@ js: post
                 <a class="reddit_link" href="//www.reddit.com/submit" onclick="window.open('//www.reddit.com/submit?url=' + encodeURIComponent(window.location)); return false" aria-label="Reddit link"></a>
             </div>
             <div id="blog_link_container">
-                <a id="blog_link_bottom" href="/blog"><img class="arrow" src="/img/post_arrow.svg" alt="back to all blogs">See all blog posts</a>
+                <a id="blog_link_bottom" href="{{baseURL}}/blog"><img class="arrow" src="/img/post_arrow.svg" alt="back to all blogs">{% t blog.see_all_blog_posts %}</a>
             </div>
         </div>
         <div class="tags_container_bottom">	
             <div class="container">	
-                <p id="tags">Tags</p>	
+                <p id="tags">{% t guides.tags %}</p>	
                 <div class="post_tags_container"></div>	
             </div>	
         </div>

--- a/src/main/content/blog.html
+++ b/src/main/content/blog.html
@@ -7,6 +7,11 @@ permalink: /blog/
 seo-description: Latest news and information about Open Liberty, a lightweight open framework for building cloud-native Java applications and microservices. Blogs include latest release and beta updates, technical articles on Jakarta EE, MicroProfile, Kubernetes and container-related Java technologies, and community content.
 ---
 
+{% assign baseURL = '' %}
+{% if site.lang != 'en' %}
+    {% assign baseURL = '/' | append: site.lang %}
+{% endif %}
+
 <!-- BLOG -->
 <div id="background_container">
     <img id="right_cloud_back" class="d-none d-xl-block" src="/img/blog_cloud_back.svg" alt="cloud">
@@ -21,9 +26,9 @@ seo-description: Latest news and information about Open Liberty, a lightweight o
                 <span id="star4" class="star d-none d-md-block"></span>
                 <span id="star5" class="star d-none d-md-block"></span>
                 <span id="star6" class="star d-none d-md-block"></span>
-                <h2 class="blog_subtitle">Never miss a post!</h2>
-                <p class="blog_subtext">Be sure to follow <a class="green_link" href="https://twitter.com/OpenLibertyIO" target="_blank" rel="noopener">@openlibertyio</a> on Twitter or subscribe to our <a class="green_link" href="https://openliberty.io/feed.xml" target="_blank" rel="noopener">RSS feed</a>.</p>
-                <h2 class="blog_subtitle">Featured Tags</h2>
+                <h2 class="blog_subtitle">{% t blog.never_miss_a_post %}</h2>
+                <p class="blog_subtext">{% t blog.be_sure_to_follow %} <a class="green_link" href="https://twitter.com/OpenLibertyIO" target="_blank" rel="noopener">@{% t global.openlibertyio %}</a> {% t blog.twitter_or_subscribe %} <a class="green_link" href="https://openliberty.io/feed.xml" target="_blank" rel="noopener">{% t blog.rss_feed %}</a></p>
+                <h2 class="blog_subtitle">{% t blog.featured_tags %}</h2>
                 <div role="list" id="featured_tags_list">
 
                 </div>
@@ -33,9 +38,11 @@ seo-description: Latest news and information about Open Liberty, a lightweight o
             <div id="right_column" class="col-md-12 col-lg-8 offset-lg-4">
                 <div id="filter">
                     <img tabindex="0" id="x_button" src="/img/blog_x_button.svg" onclick="blog.removeFilter(); blog.updateSearchUrl();" onkeypress="blog.removeFilter(); blog.updateSearchUrl();" alt="Remove tag filter">
-                    <span id="no_results_message">No results found. See <a class="orange_link_light_background" href="/blog/">all blogs</a>.</span>
+                    <span id="no_results_message">{% t blog.no_results_found %} {% t blog.see %}
+                      <a class="orange_link_light_background" href="{{baseURL}}/blog/">{% t blog.all_blogs %}</a>
+                    </span>
                     <span id="filter_message">
-                        <span>Filtered by tag: </span>
+                        <span>{% t blog.filtered_by_tag %}: </span>
                         <span id="filter_tag"></span>
                     </span>                    
                 </div>
@@ -71,7 +78,7 @@ seo-description: Latest news and information about Open Liberty, a lightweight o
                     <div class="row blog_post_row">
                         <div class="blog_post_column">
                             {% if count == 1 %}
-                            <p class="green_bar">Latest Posts</p>
+                            <p class="green_bar">{% t blog.latest_posts %}</p>
                             {% endif %}
                             {% if count <= latest_posts_count %}
                                     <div class="blog_post_content">
@@ -119,16 +126,16 @@ seo-description: Latest news and information about Open Liberty, a lightweight o
                                         <div role="list" class="blog_tags_container col-md-7"></div>
                                         <div class="read_more_link_container col-sm-12 col-md-5">
                                         {% if post.redirect_link %}
-                                            <a href="{{ post.redirect_link }}" target="_blank" rel="noopener" class="read_more_link read_more_link_external">Read more</a>
+                                            <a href="{{ post.redirect_link }}" target="_blank" rel="noopener" class="read_more_link read_more_link_external">{% t global.readmore %}</a>
                                         {% else %}
-                                            <a href="{{ post.url | relative_url }}" class="read_more_link">Read more</a>
+                                            <a href="{{ post.url | relative_url }}" class="read_more_link">{% t global.readmore %}</a>
                                         {% endif %}
                                         </div>
                                     </div>
                                     <div class="bottom_border"></div>
                                 </div>
                             {% if count == latest_posts_count %}
-                                <p id="older_posts" class="green_bar">Older Posts</p>
+                                <p id="older_posts" class="green_bar">{% t blog.older_posts %}</p>
                             {% endif %}
                             {% else %}
                                 <div class="blog_post_content">
@@ -172,9 +179,9 @@ seo-description: Latest news and information about Open Liberty, a lightweight o
                                         <div role="list" class="blog_tags_container col-md-7"></div>
                                         <div class="read_more_link_container col-sm-12 col-md-5">
                                         {% if post.redirect_link %}
-                                            <a href="{{ post.redirect_link }}" target="_blank" rel="noopener" class="read_more_link read_more_link_external">Read more</a>
+                                            <a href="{{ post.redirect_link }}" target="_blank" rel="noopener" class="read_more_link read_more_link_external">{% t global.readmore %}</a>
                                         {% else %}
-                                            <a href="{{ post.url | relative_url }}" class="read_more_link">Read more</a>
+                                            <a href="{{ post.url | relative_url }}" class="read_more_link">{% t global.readmore %}</a>
                                         {% endif %}
                                         </div>
                                     </div>
@@ -187,8 +194,8 @@ seo-description: Latest news and information about Open Liberty, a lightweight o
                 {% endfor %}
                 <div class="row blog_post_row">
                     <div id="final_post" class="blog_post_content">
-                        <p id="final_post_title">Stay lightyears ahead.</p>
-                        <p>Follow <a class="orange_link_light_background" href="https://twitter.com/OpenLibertyIO" target="_blank" rel="noopener">@openlibertyio</a> on Twitter or subscribe to our <a class="orange_link_light_background" href="https://openliberty.io/feed.xml" target="_blank" rel="noopener">RSS feed</a>.</p>
+                        <p id="final_post_title">{% t blog.stay_light_years_ahead %}</p>
+                        <p>{% t global.follow %} <a class="orange_link_light_background" href="https://twitter.com/OpenLibertyIO" target="_blank" rel="noopener">@{% t global.openlibertyio %}</a> {% t blog.twitter_or_subscribe %} <a class="orange_link_light_background" href="https://openliberty.io/feed.xml" target="_blank" rel="noopener">{% t blog.rss_feed %}</a></p>
                     </div>
                 </div>
             </div>

--- a/src/main/content/certifications.html
+++ b/src/main/content/certifications.html
@@ -13,12 +13,12 @@ permalink: /certifications/
   <article class="post" aria-label="article">
       <header id="post_header">
           <div class="container">
-              <h1 id="post_title">Certifications</h1>
-              <p id="cert_description">Open Liberty, certified for warp speed development!</p>
+              <h1 id="post_title">{% t certifications.certification_title %}</h1>
+              <p id="cert_description">{% t certifications.certification_desc %}</p>
           </div>
       </header>
       <div id="article_body" class="container">
-        <h1 id="TCKs">List of Open Liberty TCK Results</h1>
+        <h1 id="TCKs">{% t certifications.olio_tck_results %}</h1>
         <ul>
           {% assign certifications = site.pages | where: 'layout', 'certification' | sort: "url" %}
           {% assign previous_cert_url_parts = "" %}

--- a/src/main/content/contribute.html
+++ b/src/main/content/contribute.html
@@ -18,13 +18,14 @@ permalink: /contribute/
             </div>
             <div class="col-md-7">
                 <p id="contribute_intro_paragraph_1">
-                    Contributing to open source projects can seem scarier than a certain spherical, planet-destroying space station, but it doesn't have to be.
+                    {% t contribute.intro_paragraph1 %}
                 </p>
                 <p id="contribute_intro_paragraph_2">
-                    The Open Liberty community welcomes contributions at all levels. Whether you're an ensign or a seasoned commander, every user has the potential to help out.
+                    {% t contribute.intro_paragraph2 %}
                 </p>
                 <p>
-                    Open Liberty is licensed under <a href="https://github.com/OpenLiberty/open-liberty/blob/release/LICENSE" target="_blank" rel="noopener" class="light_green_link_dark_background">EPL v-1.0.</a>
+                    {% t contribute.ol_license_under_text %}
+                    <a href="https://github.com/OpenLiberty/open-liberty/blob/release/LICENSE" target="_blank" rel="noopener" class="light_green_link_dark_background">{% t contribute.epl_version %}</a>
                 </p>
             </div>
         </div>
@@ -42,16 +43,14 @@ permalink: /contribute/
     </div>
     <div class="row">
         <div class="col-md-5">
-            <h2 id="getting_started_title">Getting Started</h2>
+            <h2 id="getting_started_title">{% t contribute.getting_started %}</h2>
         </div>
         <div class="col-md-7">
             <p id="getting_started_paragraph">
-                Thank you for joining the Open Liberty community. We can’t wait to see what we build together! There 
-                are so many ways to contribute to Open Liberty; just be sure to check out the contributor guidelines 
-                before you blast off and start making cool stuff.  
+                {% t contribute.getting_started_paragraph %}
             </p>
             <a href="https://github.com/OpenLiberty/open-liberty/blob/integration/CONTRIBUTING.md" class="large_link orange_link_light_background line_link" target="_blank" rel="noopener">
-                <span class="line"></span> View the contributor guidelines
+                <span class="line"></span> {% t contribute.view_contributor_guidelines %}
             </a>
         </div>
     </div>
@@ -65,11 +64,11 @@ permalink: /contribute/
         <div class="row">
             <div class="col-md-4">
                 <div id="issues_description">
-                    <h2 id="issues_title">Fix a bug</h2>
+                    <h2 id="issues_title">{% t contribute.fix_a_bug %}</h2>
                     <p id="issues_text">
-                        This is a current list of open, unassigned issues. See something that you might be able to help with? Show us your best solution!
+                        {% t contribute.issue_text %}
                     </p>
-                    <a href="https://github.com/OpenLiberty/open-liberty/issues" target="_blank" rel="noopener" class="large_link light_green_link_dark_background line_link"><span class="line"></span> View all open issues</a>
+                    <a href="https://github.com/OpenLiberty/open-liberty/issues" target="_blank" rel="noopener" class="large_link light_green_link_dark_background line_link"><span class="line"></span> {% t contribute.view_all_open_issues %}</a>
                 </div>
             </div>
             <div class="col-md-8">
@@ -99,40 +98,37 @@ permalink: /contribute/
     </div>
     <div class="row">
         <div class="col-md-5">
-            <h2 id="tools_and_tests_title_1">Tools and tests</h2>
+            <h2 id="tools_and_tests_title_1">{% t contribute.tools_and_test_title1 %}</h2>
             <p id="tools_and_tests_paragraph_1">
-                Contribute to the next release by writing tests and helping craft better tools. 
+                {% t contribute.tools_and_test_paragraph1 %}
             </p>
             <img id="tools_and_tests_image" src="{{ "/img/contribute2.jpg" | relative }}" class="img-fluid d-block mx-auto" alt="Four UFOs working together to transport a hammer and a wrench">
         </div>
         <div class="col-md-7">
-            <h3 id="tools_and_tests_title_2">Contribute to developer tools</h3>
+            <h3 id="tools_and_tests_title_2">{% t contribute.tools_and_test_title2 %}</h3>
             <p id="tools_and_tests_paragraph_3">
-                Open Liberty works with all developer tools, so use whatever you like best! However, we'll be releasing updates to Eclipse developer tools that
-                are tailored for the newest Open Liberty releases. With your contributions, these tools will evolve alongside Open Liberty to form a perfect
-                pairing, making your workflow smoother. 
+                {% t contribute.tools_and_test_paragraph2 %}
             </p>
             <div class="row">
                 <div class="col-12">
                     <a id="tools_and_tests_link_1" href="https://github.com/OpenLiberty/open-liberty-tools/blob/integration/README.md" target="_blank" rel="noopener" class="regular_link orange_link_light_background line_link">
-                        <span class="line"></span> Learn more about Eclipse developer tools
+                        <span class="line"></span> {% t contribute.learn_more_about_eclipse_tools %}
                     </a>                        
                 </div>
             </div>
             <div class="row">
                 <div class="col-12">
                     <a id="tools_and_tests_link_2" href="https://github.com/OpenLiberty/open-liberty-tools" target="_blank" rel="noopener" class="regular_link orange_link_light_background line_link">
-                        <span class="line"></span> View the Eclipse developer tools repository
+                        <span class="line"></span> {% t contribute.view_eclipse_tools_repo %}
                     </a>    
                 </div>
             </div>
-            <h3 id="tools_and_tests_title_3">Provide a test</h3>
+            <h3 id="tools_and_tests_title_3">{% t contribute.tools_and_test_title3 %}</h3>
             <p id="tools_and_tests_paragraph_4">
-                Testing is an essential step to having a robust, helpful release. The more high quality tests we run before a release, the more headaches we
-                save our users in the future. 
+                {% t contribute.tools_and_test_paragraph3 %}
             </p>
             <a id="tools_and_tests_link_3" href="https://github.com/OpenLiberty/open-liberty/blob/release/README.md#contributing" target="_blank" rel="noopener" class="regular_link orange_link_light_background line_link">
-                <span class="line"></span> Learn the ins and outs of testing for Open Liberty
+                <span class="line"></span> {% t contribute.learn_in_and_out_testing_oio %}
             </a>
         </div>
     </div>
@@ -149,27 +145,24 @@ permalink: /contribute/
     </div>
     <div class="row">
         <div class="col-md-5">
-            <h2 id="the_future_of_open_liberty_title">The Future of Open Liberty</h2>
-            <h3>Ready to go above and beyond?</h3>
+            <h2 id="the_future_of_open_liberty_title">{% t contribute.future_of_ol %}</h2>
+            <h3>{% t contribute.ready_to_go_beyond %}</h3>
         </div>
         <div class="col-md-7">
             <p id="the_future_of_open_liberty_paragraph">
-                If you’d like to work on new features, get up to speed with our handy guide to writing them. 
-                We also encourage you to participate in the forum to discuss upcoming features, and see where 
-                you could pitch in.  And don’t forget to leave suggestions for future development items so your 
-                great ideas can be heard!
+                {% t contribute.future_of_ol_paragraph %}
             </p>
             <div class="row">
                 <div class="col-12">
                     <a id="the_future_of_open_liberty_link_1" href="https://groups.io/g/openliberty" target="_blank" rel="noopener" class="regular_link orange_link_light_background line_link">
-                        <span class="line"></span> Open Liberty contributor forum (Groups.io)
+                        <span class="line"></span> {% t contribute.ol_contributor_forum %}
                     </a>                        
                 </div>
             </div>
             <div class="row">
                 <div class="col-12">
                     <a id="the_future_of_open_liberty_link_2" href="https://github.com/OpenLiberty/open-liberty/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=" target="_blank" rel="noopener" class="regular_link orange_link_light_background line_link">
-                        <span class="line"></span> Open issues for new features
+                        <span class="line"></span> {% t contribute.open_issues_new_features %}
                     </a>                            
                 </div>
             </div>
@@ -184,21 +177,21 @@ permalink: /contribute/
     <div id="more_ways_to_connect_row_1" class="row">
         <div class="col-12">
             <div id="more_ways_to_connect_bar"></div>
-            <h2 id="more_ways_to_connect_title">Connect with the Open Liberty crew</h2>
+            <h2 id="more_ways_to_connect_title">{% t contribute.connect_with_ol_crew %}</h2>
         </div>
     </div>
     <div class="row">
         <div class="col-md-6  offset-md-3">
             <p id="more_ways_to_connect_text">
                 <br>
-                With Open Liberty, you can boldly go where no one has gone before… but don’t forget the rest of your team!
+                {% t contribute.more_ways_to_connect %}
             </p>
         </div>
     </div>
     <div class="row">
         <div class="col-md-6  offset-md-3">
             <a id="more_ways_to_connect_link_1" href="/community" class="rounded_corner_link link_green_border link_green_right_arrow">
-                <div class="button_label">Connect with your community</div>
+                <div class="button_label">{% t contribute.connect_with_your_community %}</div>
             </a>
         </div>
     </div>

--- a/src/main/content/guides.html
+++ b/src/main/content/guides.html
@@ -34,15 +34,15 @@ plus: 1 %} {% endif %} {% endfor %}
 
 <!-- Sort list of guides by date with most recent first -->
 {% assign all_guides_by_date = all-guides | sort: "releasedate" | reverse %}
-
+{% capture placeholder_filter_guides %}{% t guides.placeholder_filter_guides %}{% endcapture%}
 <!-- INTRODUCTION AND SEARCH BAR -->
 <div id="guides_information_container" class="container">
   <div id="guides_border"></div>
   <div class="row">
     <div id="guide_search_information" class="col-xs-12 col-sm-7 col-md-6">
-      <h2 id="guides_title">Guides</h2>
+      <h2 id="guides_title">{% t pages.guides %}</h2>
       <p id="guides_description">
-        The quickest way to learn all things Open Liberty, and beyond!
+        {% t guides.description %}
       </p>
     </div>
     <img id="clouds" src="{{ "/img/guides_clouds.png" | relative }}"
@@ -51,7 +51,7 @@ plus: 1 %} {% endif %} {% endfor %}
       <input
         id="guide_search_input"
         class="search-box"
-        placeholder="Filter guides"
+        placeholder="{{placeholder_filter_guides}}"
         autocomplete="off"
         data-toggle="popover"
         data-placement="bottom"
@@ -65,12 +65,12 @@ plus: 1 %} {% endif %} {% endfor %}
         aria-label="Clear search bar"
       ></button>
       <div id="popover_content" class="hide" style="display: none">
-        <p class="tags_title">Suggested tags</p>
-        <button type="button" class="tag_button">new</button>
+        <p class="tags_title">{% t guides.suggested_tags %}</p>
+        <button type="button" class="tag_button">{% t guides.new %}</button>
         <button type="button" class="tag_button">microprofile</button>
         <button type="button" class="tag_button">jakarta ee</button>
-        <button type="button" class="tag_button">run in cloud</button>
-        <button type="button" class="tag_button">interactive</button>
+        <button type="button" class="tag_button">{% t guides.run_in_cloud %}</button>
+        <button type="button" class="tag_button">{% t guides.interactive %}</button>
       </div>
     </div>
   </div>
@@ -90,11 +90,11 @@ plus: 1 %} {% endif %} {% endfor %}
       type="button"
       tabindex="0"
     >
-      <span class="sr-only">Toggle navigation</span>
+      <span class="sr-only">{% t guides.toggle_navigation %}</span>
       <span class="icon-bar"></span> <span class="icon-bar"></span>
       <span class="icon-bar"></span>
     </button>
-    <span>Table of contents</span>
+    <span>{% t guides.table_of_contents %}</span>
   </div>
 </div>
 
@@ -144,7 +144,7 @@ plus: 1 %} {% endif %} {% endfor %}
         guide == all_guides_by_date[1] or guide == all_guides_by_date[2] or
         guide == all_guides_by_date[3] %}
         <div class="new_guide_container">
-          <span class="guide_new">New</span>
+          <span class="guide_new">{% t guides.new_camel_case %}</span>
         </div>
         {% endif %}
 
@@ -153,7 +153,7 @@ plus: 1 %} {% endif %} {% endfor %}
         {% assign date_now = 'now' | date:'%s' %} {% assign date_difference =
         date_now | minus: date_published %} {% if date_difference < 2592000 %}
         <div class="new_guide_container">
-          <span class="guide_new">New</span>
+          <span class="guide_new">{% t guides.new_camel_case %}</span>
         </div>
         {% endif %} {% endif %} 
         <!-- Add Updated flag to guides if the last major update is within last 12 weeks. -->
@@ -164,7 +164,7 @@ plus: 1 %} {% endif %} {% endfor %}
         {% assign date_now = 'now' | date:'%s' %} {% assign date_difference =
         date_now | minus: date_updated %} {% if date_difference < 7257600 %}
         <div class="updated_guide_container">
-          <span class="guide_updated">Updated</span>
+          <span class="guide_updated">{% t guides.updated %}</span>
         </div>
         {% endif %}{% endif %}
         {% if guide.layout == 'iguide-multipane' %}
@@ -174,7 +174,7 @@ plus: 1 %} {% endif %} {% endfor %}
             src="/img/guide_lightning_bolt.svg"
             alt="Interactive"
           />
-          <span class="guide_interactive">Interactive</span>
+          <span class="guide_interactive">{% t guides.interactive_camel_case %}</span>
         </div>
         {% endif %} 
       </a>
@@ -185,30 +185,30 @@ plus: 1 %} {% endif %} {% endfor %}
   <!-- Zero Search Results -->
   <div class="no_results_section row">
     <h2 id="no_results_title">
-      <b class="search_term"></b> - No results found
+      <b class="search_term"></b> - {% t guides.no_results_found %}
     </h2>
     <div id="no_search_results_container" class="container">
       <div class="subtitle">
         <p>
           <b
-            >Sorry, we couldn't find any guides matching
+            >{% t guides.no_guides_matching %}
             <span class="search_term"></span
           ></b>
         </p>
         <p>
-          Want to see a guide on this topic?
+          {% t guides.want_to_see_guide_on_this_topic %}
           <b
             ><a
               href="https://github.com/OpenLiberty/guides-common/projects/1"
               class="orange_link_light_background"
-              >Check out our project board and raise an issue.</a
+              >{% t guides.checkout_and_raise_issue %}</a
             ></b
           >
         </p>
       </div>
       <button id="back_to_guides_button" class="btn">
         <img class="arrow" src="/img/guides_arrow_left.svg" alt="" /><b
-          >Back to all Open Liberty guides</b
+          >{% t guides.back_to_all_ol_guides %}</b
         >
       </button>
     </div>

--- a/src/main/content/index.html
+++ b/src/main/content/index.html
@@ -7,6 +7,11 @@ css:
 - home
 ---
 
+{% assign baseURL = '' %}
+{% if site.lang != 'en' %}
+    {% assign baseURL = '/' | append: site.lang %}
+{% endif %}
+
 <!-- INTRO -->
 <div id="intro_background">
     <span id="star1" class="star"></span>
@@ -21,14 +26,16 @@ css:
             <div class="col-md-6">
                 <div id="intro_content">
                     <img id="intro_logo" src="/img/ol_logo_tm.svg" class="img-fluid" alt="Open Liberty: An IBM open source project">
-                    <div id="an_ibm_open_source_project" class="d-none d-md-block">An IBM Open Source Project</div>
-                    <h3 id="intro_lighten_up_title">A lightweight open framework for building fast and efficient cloud-native Java microservices.</h3>
+                    <div id="an_ibm_open_source_project" class="d-none d-md-block">{% t global.ol_logo_subtitile %}</div>
+                    <h3 id="intro_lighten_up_title">{% t home.intro_title %}</h3>
                     <p id="intro_paragraph">
-                        Build cloud-native apps and microservices while running only what you need.
-                        Open Liberty<sup>TM</sup> is the most flexible server runtime available to Java<sup>TM</sup> developers in this solar system.
+                        {% t home.intro_paragraph1 %}
+                        {% t global.openliberty %}<sup>TM</sup>
+                        {% t home.intro_paragraph2 %}<sup>TM</sup>
+                        {% t home.intro_paragraph3 %}
                     </p>
                     <div id="download_links_container">
-                        <a id="download_link" href="/start">Get Open Liberty</a>
+                        <a id="download_link" href="{{baseURL}}/start">{% t home.get_openliberty %}</a>
                     </div>
                 </div>
             </div>
@@ -37,17 +44,17 @@ css:
                 <img id="cloud_2" class="d-none d-md-block" src="/img/home_cloud_1.png" alt="Cloud 2">
                 <img id="beam" src="/img/home_beam.png" alt="Beam">
                 <img id="ufo" src="/img/home_ufo.png" alt="Ufo">
-                <img id="person_1" src="img/home_person_1.png" alt="Person 1">
-                <img id="coffee" src="img/home_coffee.png" alt="Coffee cup">
-                <img id="shoe" src="img/home_shoe.png" alt="Shoe">
-                <img id="laptop" class="d-none d-md-block" src="img/home_laptop.png" alt="Laptop">
-                <img id="ball" class="d-none d-md-block" src="img/home_ball.png" alt="Ball">
-                <img id="dog" class="d-none d-md-block" src="img/home_dog.png" alt="Dog">
-                <img id="phone" class="d-none d-md-block" src="img/home_phone.png" alt="Phone">
-                <img id="mouse" class="d-none d-md-block" src="img/home_mouse.png" alt="Mouse">
+                <img id="person_1" src="/img/home_person_1.png" alt="Person 1">
+                <img id="coffee" src="/img/home_coffee.png" alt="Coffee cup">
+                <img id="shoe" src="/img/home_shoe.png" alt="Shoe">
+                <img id="laptop" class="d-none d-md-block" src="/img/home_laptop.png" alt="Laptop">
+                <img id="ball" class="d-none d-md-block" src="/img/home_ball.png" alt="Ball">
+                <img id="dog" class="d-none d-md-block" src="/img/home_dog.png" alt="Dog">
+                <img id="phone" class="d-none d-md-block" src="/img/home_phone.png" alt="Phone">
+                <img id="mouse" class="d-none d-md-block" src="/img/home_mouse.png" alt="Mouse">
                 <img id="cloud_4" src="/img/home_cloud_1.png" alt="Cloud 4">
                 <img id="cloud_5" class="d-none d-md-block" src="/img/home_cloud_1.png" alt="Cloud 5">
-                <img id="person_2" src="img/home_person_2.png" alt="Person 2">
+                <img id="person_2" src="/img/home_person_2.png" alt="Person 2">
             </div>
         </div>
     </div>
@@ -62,34 +69,37 @@ css:
     <div class="container">
         <div class="row">
             <div class="col-md-6">
-                <h2 class="develop_title">Develop cloud-native Java microservices</h2>
-                <p class="develop_text">Open Liberty is fast to start up with a low memory footprint and live reload for quick iteration. Simple to add 
-                    and remove features from the latest versions of <a class="blue_link_light_background_external" href="/docs/latest/microprofile.html">MicroProfile</a> and <a class="blue_link_light_background_external" href="/docs/latest/jakarta-ee.html">Jakarta EE</a>. <a class="blue_link_light_background_external" href="/docs/latest/zero-migration-architecture.html">Zero migration</a> lets you focus on what's 
-                    important, not the APIs changing under you.
+                <h2 class="develop_title">{% t home.cloud_native_develop_title %}</h2>
+                <p class="develop_text">
+                    {% t home.cloud_native_develop_text1 %}
+                    <a class="blue_link_light_background_external" href="{{baseURL}}/docs/latest/microprofile.html">MicroProfile</a>
+                    {% t global.and %}
+                    <a class="blue_link_light_background_external" href="{{baseURL}}/docs/latest/jakarta-ee.html">Jakarta EE</a>.
+                    {% t global.and_with %}
+                    <a class="blue_link_light_background_external" href="{{baseURL}}/docs/latest/zero-migration-architecture.html">zero migration</a>,
+                    {% t home.cloud_native_develop_text2 %}
                 </p>
                 <div class="learn_more_container">
-                    <a class="learn_more_link" href="/docs/ref/general/#microprofile.html">Learn more</a>
+                    <a class="learn_more_link" href="{{baseURL}}/docs/ref/general/#microprofile.html">{% t global.learnmore %}</a>
                 </div>
             </div>
             <div class="col-md-6">
                 <div id="develop_image">
-                    <div class="green_box"><a href="/guides/microprofile-opentracing.html">OpenTracing</a></div>
-                    <div class="green_box"><a href="/guides/microprofile-health.html">Health Check</a></div>
-                    <div class="green_box"><a href="/guides/microprofile-metrics.html">Metrics</a></div>
+                    <div class="green_box"><a href="{{baseURL}}/guides/microprofile-opentracing.html">OpenTracing</a></div>
+                    <div class="green_box"><a href="{{baseURL}}/guides/microprofile-health.html">Health Check</a></div>
+                    <div class="green_box"><a href="{{baseURL}}/guides/microprofile-metrics.html">Metrics</a></div>
                     <div class="green_box space_holder"></div>
                     <div class="green_box space_holder"></div>
-
-                    <div class="green_box"><a href="/guides/microprofile-openapi.html">OpenAPI</a></div>
-                    <div class="green_box"><a href="/guides/retry-timeout.html" class="long_title">Fault Tolerance</a></div>
-                    <div class="green_box"><a href="/guides/microprofile-jwt.html" class="long_title">JWT</a></div>
-                    <div class="green_box"><a href="/guides/microprofile-config-intro.html">Config</a></div>
+                    <div class="green_box"><a href="{{baseURL}}/guides/microprofile-openapi.html">OpenAPI</a></div>
+                    <div class="green_box"><a href="{{baseURL}}/guides/retry-timeout.html" class="long_title">Fault Tolerance</a></div>
+                    <div class="green_box"><a href="{{baseURL}}/guides/microprofile-jwt.html" class="long_title">JWT</a></div>
+                    <div class="green_box"><a href="{{baseURL}}/guides/microprofile-config-intro.html">Config</a></div>
                     <div class="green_box space_holder"></div>
-
-                    <div class="green_box"><a href="/guides/microprofile-rest-client.html">Rest Client</a></div>
-                    <div class="green_box"><a href="/guides/rest-intro.html">JAX-RS</a></div>
-                    <div class="green_box"><a href="/guides/rest-client-java.html">JSON-P</a></div>
-                    <div class="green_box"><a href="/guides/rest-client-java.html">JSON-B</a></div>
-                    <div class="green_box"><a href="/guides/cdi-intro.html">CDI</a></div>
+                    <div class="green_box"><a href="{{baseURL}}/guides/microprofile-rest-client.html">Rest Client</a></div>
+                    <div class="green_box"><a href="{{baseURL}}/guides/rest-intro.html">JAX-RS</a></div>
+                    <div class="green_box"><a href="{{baseURL}}/guides/rest-client-java.html">JSON-P</a></div>
+                    <div class="green_box"><a href="{{baseURL}}/guides/rest-client-java.html">JSON-B</a></div>
+                    <div class="green_box"><a href="{{baseURL}}/guides/cdi-intro.html">CDI</a></div>
                 </div>
                 <h2 id="table_label" class="d-none d-md-block">MicroProfile</h2>
 
@@ -100,23 +110,25 @@ css:
                 <img id="dev_mode_image" class="d-none d-md-block img-fluid" src="/img/home_dev_mode.svg" alt="Dev mode graphic">
             </div>
             <div class="col-md-6">
-                <h2 class="develop_title">Dev mode for fast iteration</h2>
-                <p class="develop_text">Launch into dev mode and get coding. No more manual compiling, packaging, and deploying—we handle that for you. 
-                    Get automated testing, debugger support, and a fast turn-around time in any editor.
+                <h2 class="develop_title">{% t home.fast_iteration_develop_title %}</h2>
+                <p class="develop_text">
+                    {% t home.fast_iteration_develop_text %}
                 </p>
                 <div class="learn_more_container">
-                    <a class="learn_more_link" href="/docs/latest/development-mode.html">Learn more</a>
+                    <a class="learn_more_link" href="{{baseURL}}/docs/latest/development-mode.html">{% t global.learnmore %}</a>
                 </div>
             </div>
         </div>
         <div class="row">
             <div class="col-md-6">
-                <h2 class="develop_title">Deploy in containers to any cloud</h2>
-                <p class="develop_text">Containerized and deployable with fast throughput on any Kubernetes cloud. Battle-hardened and proven in production, 
-                    with <a class="blue_link_light_background_external" href="/docs/latest/zero-migration-architecture.html">zero migration</a>. Easy-to-manage configuration from development to test to production.
+                <h2 class="develop_title">{% t home.deploy_containers_develop_title %}</h2>
+                <p class="develop_text">
+                    {% t home.deploy_containers_develop_text1 %}
+                    <a class="blue_link_light_background_external" href="{{baseURL}}/docs/latest/zero-migration-architecture.html">zero migration</a>.
+                    {% t home.deploy_containers_develop_text2 %}
                 </p>
                 <div class="learn_more_container">
-                    <a class="learn_more_link" href="/guides/?search=cloud">Learn more</a>
+                    <a class="learn_more_link" href="{{baseURL}}/guides/?search=cloud">{% t global.learnmore %}</a>
                 </div>
             </div>
             <div class="col-md-6">
@@ -128,12 +140,12 @@ css:
                 <img id="monitor_image" class="d-none d-md-block img-fluid" src="/img/home_monitor.png" alt="Monitor graphic">
             </div>
             <div class="col-md-6">
-                <h2 class="develop_title">Monitor microservices in the cloud</h2>
-                <p class="develop_text">Trace your live microservices. Gather metrics and configure alerts, and browse metrics in dashboards. Consolidate and 
-                    analyze logs from across your hybrid cloud.
+                <h2 class="develop_title">{% t home.monitor_microservice_develop_title %}</h2>
+                <p class="develop_text">
+                {% t home.monitor_microservice_develop_text %}
                 </p>
                 <div class="learn_more_container">
-                    <a class="learn_more_link" href="/blog/2018/10/05/microprofile-faulttolerance-1.1-metrics.html">Learn more</a>
+                    <a class="learn_more_link" href="{{baseURL}}/blog/2018/10/05/microprofile-faulttolerance-1.1-metrics.html">{% t global.learnmore %}</a>
                 </div>
             </div>
         </div>
@@ -152,62 +164,36 @@ css:
             </div>
         </div>
         <div class="learn_more_container">
-            <a class="learn_more_link" href="/blog/2019/10/30/faster-startup-open-liberty.html">Learn more</a>
+            <a class="learn_more_link" href="{{baseURL}}/blog/2019/10/30/faster-startup-open-liberty.html">{% t global.learnmore %}</a>
         </div>
     </div>
 
     <div class="container" id="logos_section">
         <div class="row justify-content-center">
             <div class="col">
-                <h3 id="logos_title">Open Liberty integrates with the Open Source community</h3>
+                <h3 id="logos_title">{% t home.openlibery_opensource_community_title %}</h3>
                 <div id="logo_image_row" class="row justify-content-center">
                     <div class="col-sm-12 col-md">
-                        <a href="https://microprofile.io/">
-                            <img id="microprofile_logo"  src="/img/home_logo_microprofile.png" alt="MicroProfile Logo">
-                        </a>
+                        <img id="microprofile_logo"  src="/img/home_logo_microprofile.png" alt="MicroProfile Logo">
                     </div>
                     <div class="col-sm-12 col-md">
-                        <a href="https://jakarta.ee/">
-                            <img id="jakarta_ee_logo"  src="/img/home_logo_jakartaee.png" alt="Jakarta EE logo">
-                        </a>
+                        <img id="jakarta_ee_logo"  src="/img/home_logo_jakartaee.png" alt="Jakarta EE logo">
                     </div>
                 </div>
                 <div class="logos_row row justify-content-center">
-                    <a href="https://www.jenkins.io/">
-                        <p>Jenkins</p>
-                    </a>
-                    <a href="https://spring.io/">
-                        <p>Spring</p>
-                    </a>
-                    <a href="https://www.docker.com/">
-                        <p>Docker</p>
-                    </a>
-                    <a href="https://grafana.com/">
-                        <p>Grafana</p>
-                    </a>
-                    <a href="https://gradle.org/">
-                        <p>Gradle</p>
-                    </a>
-                    <a href="https://www.elastic.co/logstash/">
-                        <p>Logstash</p>
-                    </a>
+                    <p>Jenkins</p>
+                    <p>Spring</p>
+                    <p>Docker</p>
+                    <p>Grafana</p>
+                    <p>Gradle</p>
+                    <p>Logstash</p>
                 </div>
                 <div class="logos_row row justify-content-center">
-                    <a href="https://prometheus.io/">
-                        <p>Prometheus</p>
-                    </a>
-                    <a href="https://maven.apache.org/">
-                        <p>Maven</p>
-                    </a>
-                    <a href="https://kubernetes.io/">
-                        <p>Kubernetes</p>
-                    </a>
-                    <a href="https://www.elastic.co/kibana/">
-                        <p>Kibana</p>
-                    </a>
-                    <a href="https://www.elastic.co/elasticsearch/">
-                        <p>Elastic Search</p>
-                    </a>
+                    <p>Prometheus</p>
+                    <p>Maven</p>
+                    <p>Kubernetes</p>
+                    <p>Kibana</p>
+                    <p>Elastic Search</p>
                 </div>
             </div>
         </div>
@@ -226,9 +212,9 @@ css:
         <img id="cloud_13" class="d-none d-md-block" src="/img/home_cloud_2.png" alt="Cloud 13">
         <img id="cloud_14" class="d-none d-md-block" src="/img/home_cloud_2.png" alt="Cloud 14">
     </div>
-    <h2 id="news_title">Open Liberty News</h2>
-    <p id="news_text">Check out the latest news on our blog and follow us on Twitter.</p>
-    <div id="news_row" class="row">
+    <h2 id="news_title">{% t home.openliberty_news %}</h2>
+    <p id="news_text">{% t home.openliberty_news_text %}</p>
+    <div class="row">
         <div class="col-xs-12 col-lg-6">
             <div id="blog_post">
                 {% for post in site.posts limit:1 %}
@@ -277,24 +263,17 @@ css:
                         {% endif %}
                     </p>
                 {% endfor %}
-                <a id="blog_link" href="/blog/">View all Open Liberty Blog posts</a>
-
+                <a id="blog_link" href="{{baseURL}}/blog/">{% t home.link_to_blog_post %}</a>
             </div>
         </div>
         <div class="col-xs-12 col-lg-6">
             <div id="twitter_follow_div">
                 <img id="ufo_logo"  src="/img/home_logo.svg" alt="Open Liberty Logo">
-                <a id="twitter_handle" href="https://twitter.com/OpenLibertyIO" target="_blank" rel="noopener">@openliberty.io</a>
-                <a id="twitter_link" href="https://twitter.com/OpenLibertyIO" target="_blank" rel="noopener">Follow</a>
+                <a id="twitter_handle" href="https://twitter.com/OpenLibertyIO" target="_blank" rel="noopener">@{% t global.openlibertyio %}</a>
+                <a id="twitter_link" href="https://twitter.com/OpenLibertyIO" target="_blank" rel="noopener">{% t global.follow %}</a>
             </div>
             <div id="twitter_iframe_div">
-                <a class="twitter-timeline"
-                    href="https://twitter.com/OpenLibertyIO?ref_src=twsrc%5Etfw"
-                    rel="noopener" data-tweet-limit="3"
-                    data-chrome="noheader nofooter"
-                    data-width="520"
-                    data-height="650" >
-                </a>
+                <a class="twitter-timeline" href="https://twitter.com/OpenLibertyIO?ref_src=twsrc%5Etfw" rel="noopener" data-tweet-limit="3" data-chrome="noheader nofooter"></a>
                 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
             </div>
         </div>
@@ -305,19 +284,16 @@ css:
 <!-- SUPPORT -->
 <div id="support_background">
     <div id="support_container" class="container">
-        <h2 id="support_title">A crew that supports you</h2>        
+        <h2 id="support_title">{% t home.support_title %}</h2>        
         <div class="row">
             <div class="col-md-6">
                 <p id="support_text">
-                    As a member of the Open Liberty crew, you have the support and 
-                    expertise of an entire community at your fingertips. Don't forget 
-                    to lean on them when you have questions!
+                    {% t home.support_text1 %}
                     <br>
                     <br>
-                    And for times that you need an extra boost, check out Open Liberty 
-                    Enterprise Support from IBM.
+                    {% t home.support_text2 %}
                 </p>
-                <a id="support_link" href="/support/">Get Open Liberty support</a>
+                <a id="support_link" href="{{baseURL}}/support/">{% t home.link_to_openliberty_support %}</a>
             </div>
             <div id="support_image" class="col-md-6 order-first order-md-2">
                 <span id="star6" class="star d-none d-sm-block"></span>
@@ -348,15 +324,14 @@ css:
     </div>
     <div id="get_involved_row" class="row">
         <div class="col-md-7 col-lg-6">
-            <h2 id="get_involved_title">Get involved</h2>
+            <h2 id="get_involved_title">{% t home.get_involved_title %}</h2>
             <p id="get_involved_text">
-                Open Liberty thrives on users’ collaboration, contributions and creativity. 
-                We invite you to share your skills and ideas with users in this galaxy and beyond.
+            {% t home.get_involved_text %}
             </p>
             <div id="contribute_link_container">
-                <a id="contribute_link" href="/contribute/">Contribute to Open Liberty</a>
+                <a id="contribute_link" href="{{baseURL}}/contribute/">{% t home.contribute_link %}</a>
             </div>
-            <p id="contributors_title">Here are some of our awesome contributors!</p>
+            <p id="contributors_title">{% t home.contributors_title %}</p>
             <div id="contributors_div">
                 <img class="contributor_image" src="https://avatars0.githubusercontent.com/u/4081634?s=50" alt="Contributor picture">
                 <img class="contributor_image" src="https://avatars3.githubusercontent.com/u/3322532?s=50" alt="Contributor picture">

--- a/src/main/content/start.html
+++ b/src/main/content/start.html
@@ -9,6 +9,11 @@ permalink: /start/
 seo-description: Use Maven or Gradle to create a starter application for developing cloud-native Java applications on Open Liberty that use Jakarta EE and MicroProfile APIs. Information about Open Liberty Docker images, Maven and Gradle coordinates, and release, beta, and development build downloads.
 ---
 
+{% assign baseURL = '' %}
+{% if site.lang != 'en' %}
+    {% assign baseURL = '/' | append: site.lang %}
+{% endif %}
+
 <!-- INTRO -->
 <div id="downloads_intro_background">
     <img id="leftcloud" class="d-none d-lg-block" src="{{ "/img/home_cloud_1.png" | relative }}" alt="">
@@ -21,9 +26,9 @@ seo-description: Use Maven or Gradle to create a starter application for develop
     <div class="container" id="downloads_intro_text">
         <div class="row">
             <div class="col">
-                <h1 id="get_started">Get started with Open Liberty</h1>
+                <h1 id="get_started">{% t start.get_start_title %}</h1>
                 <p id="intro_text_1">
-                    Whether trying or updating Open Liberty, we've got you covered!
+                    {% t start.intro_text %}
                 </p>
             </div>
         </div>
@@ -34,36 +39,35 @@ seo-description: Use Maven or Gradle to create a starter application for develop
 <div id="starter_section" class="container">
     <div class="row">
         <div class="col">
-            <h2 class="section_title">Create a starter application</h2> 
+            <h2 class="section_title">{% t start.starter_app_heading %}</h2> 
         </div>               
     </div>   
     <div class="row">
         <div class="col">
             <p id="starter_description">
-                Select the development tools that you prefer to use, then generate a package to 
-                start developing your application.
+                {% t start.starter_desc1 %}
                 <br />
-                Find a bug? Need an enhancement?
+                {% t start.starter_desc2 %}
                 <a href="https://github.com/OpenLiberty/start.openliberty.io/issues/new/choose" 
-                    class="orange_link_light_background">Raise an issue</a>.
+                class="orange_link_light_background">{% t start.raise_an_issue %}</a>
             </p>
         </div>        
     </div> 
     <div id="starter_form">
         <div class="row-no-gutters">
             <div id="base_package_section" class="starter_field" data-starter-field="g">
-                <label class="starter_field_label" for="Starter_Base_Package">Group</label>
+                <label class="starter_field_label" for="Starter_Base_Package">{% t start.group %}</label>
                 <input type="text" class="starter_field_input" id="Starter_Base_Package" />
             </div>
             <div id="app_name_section" class="starter_field" data-starter-field="a">
-                <label class="starter_field_label" for="Starter_App_Name">Artifact</label>
+                <label class="starter_field_label" for="Starter_App_Name">{% t start.artifact %}</label>
                 <input type="text" class="starter_field_input" id="Starter_App_Name" />
             </div>         
         </div>
         <div class="row">
             <div class="col">
                 <div id="build_system_section" class="starter_field" data-starter-field="b">
-                    <span class="starter_field_label" id="build_system_section_description">Build Tool</span>
+                    <span class="starter_field_label" id="build_system_section_description">{% t start.build_tool %}</span>
                     <div class="radio_group" role="radiogroup" aria-labelledby="build_system_section_description"></div>
                 </div>
             </div>            
@@ -71,17 +75,17 @@ seo-description: Use Maven or Gradle to create a starter application for develop
         <div class="row">
             <div class="col">
                 <div id="java_version_section" class="starter_field" data-starter-field="j">
-                    <label class="starter_field_label" for="Starter_Java_Version">Java SE Version</label>
+                    <label class="starter_field_label" for="Starter_Java_Version">{% t start.java_se_version %}</label>
                     <select class="starter_field_input starter_field_selector" id="Starter_Java_Version" aria-label="Java SE Version">
                     </select>
                 </div>
                 <div id="jakarta_version_section" class="starter_field" data-starter-field="e">
-                    <label class="starter_field_label" for="Starter_Jakarta_Version">Java EE/Jakarta EE Version</label>
+                    <label class="starter_field_label" for="Starter_Jakarta_Version">{% t start.java_jakarta_ee_version %}</label>
                     <select class="starter_field_input starter_field_selector" id="Starter_Jakarta_Version" aria-label="Java EE/Jakarta EE Version">
                     </select>
                 </div>
                 <div id="microprofile_version_section" class="starter_field" data-starter-field="m">
-                    <label class="starter_field_label" for="Starter_MicroProfile_Version">MicroProfile Version</label>
+                    <label class="starter_field_label" for="Starter_MicroProfile_Version">{% t start.microprofile_version %}</label>
                     <select class="starter_field_input starter_field_selector" id="Starter_MicroProfile_Version" aria-label="MicroProfile Version">
                     </select>
                 </div>
@@ -91,7 +95,7 @@ seo-description: Use Maven or Gradle to create a starter application for develop
     <div class="row">
         <div class="col">
             <div id="starter_warnings"></div>
-            <a id="starter_submit" class="light_green_link_light_background disabled" tabindex="0" data-toggle="modal">Generate Project</a>
+            <a id="starter_submit" class="light_green_link_light_background disabled" tabindex="0" data-toggle="modal">{% t start.generate_project %}</a>
         </div>        
     </div>
 </div>
@@ -106,13 +110,15 @@ seo-description: Use Maven or Gradle to create a starter application for develop
           </button>
         </div>
         <div class="modal-body">
-            <h3>Your zip file has been beamed to your computer!</h3>
-            <p>Unzip it and run this command, or refer to the included README.</p>
+            <h3>{% t start.generate_project_modal.heading %}</h3>
+            <p>{% t start.generate_project_modal.instruction %}</p>
             <div id="cmd_to_run" class="cmd_to_run"></div>
-            <p class="guide-link">For more help, visit our <a href="/guides/" class="orange_link_light_background" tabindex="0">guides.</a></p>
+            <p class="guide-link">{% t start.generate_project_modal.guide_link %}
+                <a href="{{baseURL}}/guides/" class="orange_link_light_background" tabindex="0">{% t start.guides_smallcase %}</a>.
+            </p>
         </div>
         <div class="modal-footer">
-          <button type="button" id="gen_proj_popup_button" class="btn btn-primary"  data-dismiss="modal">Got it!</button>
+          <button type="button" id="gen_proj_popup_button" class="btn btn-primary"  data-dismiss="modal">{% t start.generate_project_modal.got_it %}</button>
         </div>
       </div>
     </div>
@@ -120,8 +126,8 @@ seo-description: Use Maven or Gradle to create a starter application for develop
 
 <!-- MAVEN, GRADLE, DOCKER -->
 <div id="get_section" class="container">
-    <h2 id="getOL" class="section_title">Add to an existing application</h2>
-    <p>Get Open Liberty using these commands for Maven, Gradle, or Docker.</p>
+    <h2 id="getOL" class="section_title">{% t start.get_OL_section_title %}</h2>
+    <p>{% t start.get_OL_section_text %}</p>
     <div class="row tabs_container">
         <!-- TABS -->
         <div class="col">
@@ -145,17 +151,23 @@ seo-description: Use Maven or Gradle to create a starter application for develop
                 <!-- MAVEN -->
                 <div id="maven" class="tab-pane fade show active" tabindex="0" role="tabpanel" aria-labelledby="getOL-maven">
                     <pre class="code_container">&lt;dependency&gt;<br>    &lt;groupId&gt;io.openliberty&lt;/groupId&gt;<br>    &lt;artifactId&gt;openliberty-runtime&lt;/artifactId&gt;<br>    &lt;version&gt;[<span class="latest_version">19.0.0.9</span>,)&lt;/version&gt;<br>    &lt;type&gt;zip&lt;/type&gt;<br>&lt;/dependency&gt;</pre>
-                    <p>Find out <a href="/guides/maven-intro.html" class="orange_link_light_background">how to use Maven with Open Liberty</a>.</p>
+                    <p>{% t start.find_out %}
+                        <a href="{{baseURL}}/guides/maven-intro.html" class="orange_link_light_background">{% t start.how_to_use_maven %}</a>
+                    </p>
                 </div>
                 <!-- GRADLE -->
                 <div id="gradle" class="tab-pane fade" tabindex="-1" role="tabpanel" aria-labelledby="getOL-gradle">
                     <pre class="code_container">dependencies {<br>    libertyRuntime group: 'io.openliberty', name: 'openliberty-runtime', version: '[<span class="latest_version">19.0.0.9</span>,)'<br>}</pre>
-                    <p>Find out <a href="/guides/gradle-intro.html" class="orange_link_light_background">how to use Gradle with Open Liberty</a>.</p>
+                    <p>{% t start.find_out %}
+                        <a href="{{baseURL}}/guides/gradle-intro.html" class="orange_link_light_background">{% t start.how_to_use_gradle %}</a>
+                    </p>
                 </div>
                 <!-- DOCKER -->
                 <div id="docker" class="tab-pane fade" tabindex="-1" role="tabpanel" aria-labelledby="getOL-docker">
                     <div class="code_container">docker pull open-liberty</div>
-                    <p>Find out <a href="/guides/containerize.html" class="orange_link_light_background">how to use Docker with Open Liberty</a>.</p>
+                    <p>{% t start.find_out %}
+                        <a href="{{baseURL}}/guides/containerize.html" class="orange_link_light_background">{% t start.how_to_use_docker %}</a>
+                    </p>
                 </div>
             </div>
         </div>
@@ -166,21 +178,21 @@ seo-description: Use Maven or Gradle to create a starter application for develop
 
 <!-- DOWNLOADS TABLE TABS -->
 <div class="container">
-    <h2 id="downloads-pkg" class="section_title">Download package</h2>
-    <p>We recommend using the latest release, but beta and development builds are also available for use. Once downloaded, you're ready for lift-off.</p>
+    <h2 id="downloads-pkg" class="section_title">{% t start.download_package %}</h2>
+    <p>{% t start.download_package_section.para %}</p>
     <div class="row tabs_container">
         <ul class="nav nav-tabs" role="tablist" aria-labelledby="downloads-pkg">
             <li class="nav-item" role="presentation">
-                <a id="downloads-releases" class="nav-link active" aria-controls="runtime_releases" href="#runtime_releases" role="tab" data-toggle="tab" tabindex="0" aria-selected="true">Releases</a>
+                <a id="downloads-releases" class="nav-link active" aria-controls="runtime_releases" href="#runtime_releases" role="tab" data-toggle="tab" tabindex="0" aria-selected="true">{% t start.download_package_section.releases %}</a>
             </li>
             <li class="nav-item" role="presentation">
-                <a id="downloads-betas" class="nav-link" aria-controls="runtime_betas" href="#runtime_betas" role="tab" data-toggle="tab" tabindex="-1" aria-selected="false">Betas</a>
+                <a id="downloads-betas" class="nav-link" aria-controls="runtime_betas" href="#runtime_betas" role="tab" data-toggle="tab" tabindex="-1" aria-selected="false">{% t start.download_package_section.betas %}</a>
             </li>
             <li class="nav-item" role="presentation">
-                <a id="downloads-devbuilds" class="nav-link" aria-controls="development_builds" href="#development_builds" role="tab" data-toggle="tab" tabindex="-1" aria-selected="false">Nightly Builds</a>
+                <a id="downloads-devbuilds" class="nav-link" aria-controls="development_builds" href="#development_builds" role="tab" data-toggle="tab" tabindex="-1" aria-selected="false">{% t start.download_package_section.nightly_builds %}</a>
             </li>
             <li class="nav-item" role="presentation">
-                <a id="downloads-eclipse-devtools" class="nav-link" aria-controls="eclipse_developer_tools" href="#eclipse_developer_tools" role="tab" data-toggle="tab" tabindex="-1" aria-selected="false">Eclipse Developer Tools</a>
+                <a id="downloads-eclipse-devtools" class="nav-link" aria-controls="eclipse_developer_tools" href="#eclipse_developer_tools" role="tab" data-toggle="tab" tabindex="-1" aria-selected="false">{% t start.download_package_section.eclipse_developer_tools %}</a>
             </li>
         </ul>
     </div>
@@ -192,28 +204,30 @@ seo-description: Use Maven or Gradle to create a starter application for develop
                 <div class="row">
                     <div class="col-sm-12">
                         <p class="download_sentence">
-                            New releases will be announced on the Open Liberty <a href="/blog/?search=release&key=tag" class="orange_link_light_background">blog</a>
-                            and <a href="https://twitter.com/OpenLibertyIO" target="_blank" rel="noopener" class="orange_link_light_background">Twitter</a>.
+                            {% t start.download_package_section.releases_content1 %}
+                            <a href="{{baseURL}}/blog/?search=release&key=tag" class="orange_link_light_background">{% t pages.blog %}</a>
+                            {% t global.and %} <a href="https://twitter.com/OpenLibertyIO" target="_blank" rel="noopener" class="orange_link_light_background">{% t global.twitter %}</a>.
                             <br/>
                             <br/>
-                            Starting with version 22.0.0.1, signature files are produced for every package of an Open Liberty release. You can use these signature files
-                            and the corresponding public key to verify the authenticity and integrity of an Open Liberty release package. For more information, see
-                            <a href="/docs/22.0.0.1/verifying-package-signatures.html"
-                            class="orange_link_light_background">Verifying Open Liberty release packages</a>.
+                            {% t start.download_package_section.releases_content2 %} 
+                            <a href="{{baseURL}}/docs/22.0.0.1/verifying-package-signatures.html"
+                            class="orange_link_light_background">{% t start.download_package_section.verify_oio_release_packages %}</a>
                             <br/>
                             <br/>
-                            <a href="https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/sign/public_keys/WebSphereLiberty_06-02-2021.pem" class="orange_link_light_background">Obtain the public key
-                            from this link</a>.
-                            Save the file from your browser as a <code>.pem</code> file.
+                            <a href="https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/sign/public_keys/WebSphereLiberty_06-02-2021.pem" class="orange_link_light_background">
+                                {% t start.download_package_section.obtain_public_key %}
+                            </a>
+                            {% t start.download_package_section.save_file_from_browser %}
+                            <code>{% t start.download_package_section.pem %}</code> {% t start.download_package_section.file %}.
                         </p>
                         <div id="runtime_releases_table_container" class="narrow_table_container">
                             <table class="build_table releases_table white_table" data-builds-id="runtime_releases" id="runtime_releases_table">
                                 <thead>
                                     <tr>
-                                        <th id="runtime_releases_version" class="version_column"><a href="" data-key="version" data-descending="true" class="functional_link sort_link">Version</a></th>
-                                        <th id="runtime_releases_package" class="package_name_column">Package</th>
-                                        <th id="runtime_releases_download" class="download_button_column">Download</th>
-                                        <th id="runtime_releases_verification" class="download_button_column">Verification</th>
+                                        <th id="runtime_releases_version" class="version_column"><a href="" data-key="version" data-descending="true" class="functional_link sort_link">{% t start.download_package_section.table_header.version %}</a></th>
+                                        <th id="runtime_releases_package" class="package_name_column">{% t start.download_package_section.table_header.package %}</th>
+                                        <th id="runtime_releases_download" class="download_button_column">{% t start.download_package_section.table_header.download %}</th>
+                                        <th id="runtime_releases_verification" class="download_button_column">{% t start.download_package_section.table_header.verification %}</th>
                                     </tr>
                                 </thead>
                                 <tbody class="release_table_body">
@@ -228,27 +242,29 @@ seo-description: Use Maven or Gradle to create a starter application for develop
                 <div class="row">
                     <div class="col-sm-12">
                         <p class="download_sentence">
-                            Try out new features in our betas and let us know <a href="/contribute" class="orange_link_light_background">your feedback</a>. Beta content may change from <a href="/blog/?search=beta&key=tag" class="orange_link_light_background">release to release</a>.
+                            {% t start.download_package_section.beta_content1 %}
+                            <a href="{{baseURL}}/contribute" class="orange_link_light_background">{% t start.download_package_section.beta_content2 %}</a>
+                            {% t start.download_package_section.beta_content3 %}
+                            <a href="{{baseURL}}/blog/?search=beta&key=tag" class="orange_link_light_background">{% t start.download_package_section.beta_content4 %}</a>
                             <br/>
                             <br/>
-                            Starting with version 22.0.0.1, signature files are produced for every package of an Open Liberty release. You can use these signature files
-                            and the corresponding public key to verify the authenticity and integrity of an Open Liberty release package. For more information, see
-                            <a href="/docs/22.0.0.1/verifying-package-signatures.html"
-                            class="orange_link_light_background">Verifying Open Liberty release packages</a>.
+                            {% t start.download_package_section.beta_content5 %}
+                            <a href="{{baseURL}}/docs/22.0.0.1/verifying-package-signatures.html"
+                            class="orange_link_light_background">{% t start.download_package_section.verify_oio_release_packages %}</a>
                             <br/>
                             <br/>
-                            <a href="https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/sign/public_keys/WebSphereLiberty_06-02-2021.pem" class="orange_link_light_background">Obtain the public key
-                            from this link</a>.
-                            Save the file from your browser as a <code>.pem</code> file.
+                            <a href="https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/sign/public_keys/WebSphereLiberty_06-02-2021.pem" class="orange_link_light_background">
+                            {% t start.download_package_section.obtain_public_key %}</a>
+                            {% t start.download_package_section.save_file_from_browser %} <code>{% t start.download_package_section.pem %}</code> {% t start.download_package_section.file %}.
                         </p>
                         <div id="runtime_betas_table_container" class="narrow_table_container">
                             <table class="build_table releases_table white_table" data-builds-id="runtime_betas" id="runtime_betas_table">
                                 <thead>
                                     <tr>
-                                        <th id="runtime_betas_version" class="version_column"><a href="" data-key="version" data-descending="true" class="functional_link sort_link">Version</a></th>
-                                        <th id="runtime_betas_package" class="package_name_column">Package</th>
-                                        <th id="runtime_betas_download" class="download_button_column">Download</th>
-                                        <th id="runtime_betas_verification" class="download_button_column">Verification</th>
+                                        <th id="runtime_betas_version" class="version_column"><a href="" data-key="version" data-descending="true" class="functional_link sort_link">{% t start.download_package_section.table_header.version %}</a></th>
+                                        <th id="runtime_betas_package" class="package_name_column">{% t start.download_package_section.table_header.package %}</th>
+                                        <th id="runtime_betas_download" class="download_button_column">{% t start.download_package_section.table_header.download %}</th>
+                                        <th id="runtime_betas_verification" class="download_button_column">{% t start.download_package_section.table_header.verification %}</th>
                                     </tr>
                                 </thead>
                                 <tbody class="release_table_body">
@@ -263,16 +279,16 @@ seo-description: Use Maven or Gradle to create a starter application for develop
                 <div class="row">
                     <div class="col-sm-12">
                         <p class="download_sentence">
-                            Nightly builds contain in-development features, have not gone through the full release process and are potentially unstable.
+                            {% t start.download_package_section.nightly_builds_content %}
                         </p>
                         <div id="runtime_development_builds_table_container" class="table_container">
                             <table class="build_table development_builds_table white_table" data-builds-id="runtime_development_builds">
                                 <thead>
                                     <tr>
-                                        <th id="runtime_development_builds_date" class="date_column"><a href="" data-key="date" data-descending="true" class="functional_link sort_link">Build Date</a></th>
-                                        <th id="runtime_development_builds_tests" class="tests_passed_column"><a href="" data-key="test_passed" data-descending="false" class="functional_link sort_link">Tests<span class="table_header_arrow" aria-hidden="true"></span></a></th>
-                                        <th id="runtime_development_builds_logs" class="view_logs_column">Logs</th>
-                                        <th id="runtime_development_builds_download" class="download_button_column">Download</th>
+                                        <th id="runtime_development_builds_date" class="date_column"><a href="" data-key="date" data-descending="true" class="functional_link sort_link">{% t start.download_package_section.table_header.build_date %}</a></th>
+                                        <th id="runtime_development_builds_tests" class="tests_passed_column"><a href="" data-key="test_passed" data-descending="false" class="functional_link sort_link">{% t start.download_package_section.table_header.tests %}<span class="table_header_arrow" aria-hidden="true"></span></a></th>
+                                        <th id="runtime_development_builds_logs" class="view_logs_column">{% t start.download_package_section.table_header.logs %}</th>
+                                        <th id="runtime_development_builds_download" class="download_button_column">{% t start.download_package_section.table_header.download %}</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -287,18 +303,18 @@ seo-description: Use Maven or Gradle to create a starter application for develop
                 <div class="row">
                     <div class="col-sm-12">
                         <p class="download_sentence">
-                            We recommend IDE tools based on Eclipse since it gives you an integrated environment right out of the box.
-                            <a href="https://github.com/OpenLiberty/open-liberty-tools" target="_blank" rel="noopener" class="orange_link_light_background">Learn how to install the tools here</a>. 
+                            {% t start.download_package_section.eclipse_developer_tools_content1 %}
+                            <a href="https://github.com/OpenLiberty/open-liberty-tools" target="_blank" rel="noopener" class="orange_link_light_background">{% t start.download_package_section.eclipse_developer_tools_content2 %}</a>
                         </p>
                         <div class="clearfix">
-                            <h3 class="eclipse_development_tools_title pull-left">Releases</h3>
+                            <h3 class="eclipse_development_tools_title pull-left">{% t start.download_package_section.releases %}</h3>
                         </div>
                         <div id="eclipse_development_tools_releases_table_container" class="narrow_table_container">
                             <table class="build_table releases_table white_table" data-builds-id="developer_tools_releases">
                                 <thead>
                                     <tr>
-                                        <th id="developer_tools_releases_version" class="date_column"><a href="" data-key="version" data-descending="true" class="functional_link sort_link">Version</a></th>
-                                        <th id="developer_tools_releases_download" class="download_button_column">Download</th>
+                                        <th id="developer_tools_releases_version" class="date_column"><a href="" data-key="version" data-descending="true" class="functional_link sort_link">{% t start.download_package_section.table_header.version %}</a></th>
+                                        <th id="developer_tools_releases_download" class="download_button_column">{% t start.download_package_section.table_header.download %}</th>
                                     </tr>
                                 </thead>
                                 <tbody class="release_table_body">
@@ -306,16 +322,16 @@ seo-description: Use Maven or Gradle to create a starter application for develop
                             </table>
                         </div>
                         <div class="clearfix">
-                            <h3 class="eclipse_development_tools_title pull-left">Development builds</h3>
+                            <h3 class="eclipse_development_tools_title pull-left">{% t start.download_package_section.development_builds %}</h3>
                         </div>
                         <div id="eclipse_development_tools_development_builds_table_container" class="table_container">
                             <table class="build_table development_builds_table white_table" data-builds-id="developer_tools_development_builds">
                                 <thead>
                                     <tr>
-                                        <th id="developer_tools_development_builds_date" class="date_column"><a href="" data-key="date" data-descending="true" class="functional_link sort_link">Version</a></th>
-                                        <th id="developer_tools_development_builds_tests" class="tests_passed_column"><a href="" data-key="test_passed" data-descending="false" class="functional_link sort_link">Tests<span class="table_header_arrow" aria-hidden="true"></span></a></th>
-                                        <th id="developer_tools_development_builds_logs" class="view_logs_column">Logs</th>
-                                        <th id="developer_tools_development_builds_download" class="download_button_column">Download</th>
+                                        <th id="developer_tools_development_builds_date" class="date_column"><a href="" data-key="date" data-descending="true" class="functional_link sort_link">{% t start.download_package_section.table_header.version %}</a></th>
+                                        <th id="developer_tools_development_builds_tests" class="tests_passed_column"><a href="" data-key="test_passed" data-descending="false" class="functional_link sort_link">{% t start.download_package_section.table_header.tests %}<span class="table_header_arrow" aria-hidden="true"></span></a></th>
+                                        <th id="developer_tools_development_builds_logs" class="view_logs_column">{% t start.download_package_section.table_header.logs %}</th>
+                                        <th id="developer_tools_development_builds_download" class="download_button_column">{% t start.download_package_section.table_header.download %}</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -339,10 +355,11 @@ seo-description: Use Maven or Gradle to create a starter application for develop
     <img id="bottomleftclouds" src="{{ "/img/bottom_left_clouds.png" | relative }}" alt="bottom left clouds">
     <img id="bottomrightcloud" src="{{ "/img/bottom_right_cloud.png" | relative }}" alt="bottom right cloud">
     <p id="cow_text">
-            Don't have a cow.
+        {% t start.download_package_section.cow_text %}
     </p>
     <p id="more_downloads_text">
-        More downloads are on the way.<br>
-        Check back soon!
+        {% t start.download_package_section.more_downloads_on_the_way %}
+        <br>
+        {% t start.download_package_section.check_back_soon %}
     </p>
 </div>

--- a/src/main/content/start.html
+++ b/src/main/content/start.html
@@ -152,21 +152,21 @@ seo-description: Use Maven or Gradle to create a starter application for develop
                 <div id="maven" class="tab-pane fade show active" tabindex="0" role="tabpanel" aria-labelledby="getOL-maven">
                     <pre class="code_container">&lt;dependency&gt;<br>    &lt;groupId&gt;io.openliberty&lt;/groupId&gt;<br>    &lt;artifactId&gt;openliberty-runtime&lt;/artifactId&gt;<br>    &lt;version&gt;[<span class="latest_version">19.0.0.9</span>,)&lt;/version&gt;<br>    &lt;type&gt;zip&lt;/type&gt;<br>&lt;/dependency&gt;</pre>
                     <p>{% t start.find_out %}
-                        <a href="{{baseURL}}/guides/maven-intro.html" class="orange_link_light_background">{% t start.how_to_use_maven %}</a>
+                        <a href="{{baseURL}}/guides/maven-intro.html" class="blue_link_light_background_external">{% t start.how_to_use_maven %}</a>
                     </p>
                 </div>
                 <!-- GRADLE -->
                 <div id="gradle" class="tab-pane fade" tabindex="-1" role="tabpanel" aria-labelledby="getOL-gradle">
                     <pre class="code_container">dependencies {<br>    libertyRuntime group: 'io.openliberty', name: 'openliberty-runtime', version: '[<span class="latest_version">19.0.0.9</span>,)'<br>}</pre>
                     <p>{% t start.find_out %}
-                        <a href="{{baseURL}}/guides/gradle-intro.html" class="orange_link_light_background">{% t start.how_to_use_gradle %}</a>
+                        <a href="{{baseURL}}/guides/gradle-intro.html" class="blue_link_light_background_external">{% t start.how_to_use_gradle %}</a>
                     </p>
                 </div>
                 <!-- DOCKER -->
                 <div id="docker" class="tab-pane fade" tabindex="-1" role="tabpanel" aria-labelledby="getOL-docker">
                     <div class="code_container">docker pull open-liberty</div>
                     <p>{% t start.find_out %}
-                        <a href="{{baseURL}}/guides/containerize.html" class="orange_link_light_background">{% t start.how_to_use_docker %}</a>
+                        <a href="{{baseURL}}/guides/containerize.html" class="blue_link_light_background_external">{% t start.how_to_use_docker %}</a>
                     </p>
                 </div>
             </div>
@@ -205,13 +205,13 @@ seo-description: Use Maven or Gradle to create a starter application for develop
                     <div class="col-sm-12">
                         <p class="download_sentence">
                             {% t start.download_package_section.releases_content1 %}
-                            <a href="{{baseURL}}/blog/?search=release&key=tag" class="orange_link_light_background">{% t pages.blog %}</a>
+                            <a href="{{baseURL}}/blog/?search=release&key=tag" class="blue_link_light_background_external">{% t pages.blog %}</a>
                             {% t global.and %} <a href="https://twitter.com/OpenLibertyIO" target="_blank" rel="noopener" class="orange_link_light_background">{% t global.twitter %}</a>.
                             <br/>
                             <br/>
                             {% t start.download_package_section.releases_content2 %} 
                             <a href="{{baseURL}}/docs/22.0.0.1/verifying-package-signatures.html"
-                            class="orange_link_light_background">{% t start.download_package_section.verify_oio_release_packages %}</a>
+                            class="blue_link_light_background_external">{% t start.download_package_section.verify_oio_release_packages %}</a>
                             <br/>
                             <br/>
                             <a href="https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/sign/public_keys/WebSphereLiberty_06-02-2021.pem" class="orange_link_light_background">

--- a/src/main/content/support.html
+++ b/src/main/content/support.html
@@ -7,6 +7,11 @@ permalink: /support/
 seo-description: How to obtain community and commercial support for Open Liberty to build and deploy cloud-native Java workloads. Links to contact Open Liberty team via Twitter, Stack Overflow, Groups.io and Gitter. How to raise issues and contribute to Open Liberty on GitHub.
 ---
 
+{% assign baseURL = '' %}
+{% if site.lang != 'en' %}
+    {% assign baseURL = '/' | append: site.lang %}
+{% endif %}
+
 <!-- ENTERPRISE SUPPORT SECTION -->
 <div id="enterprise_support_section" class="container">
     <div id="cloud_images_div">
@@ -19,17 +24,17 @@ seo-description: How to obtain community and commercial support for Open Liberty
     </div>
 
     <div id="not_alone_text">
-        You are not alone...
+        {% t support.you_are_not_alone %}
     </div>
     <p id="support_for_all_text">
-        Whether you're an enterprise or a smaller crew, there's Open Liberty support for all
+        {% t support.support_for_all_text %}
     </p>
     
     <div class="row support_options_row">
         <div class="support_box col-md-6">
             <img id="websphere_logo" src="/img/support_websphere.png" class="d-block mx-auto" alt="WebSphere Liberty logo">
-            <h2>WebSphere Application Server</h2>
-            <a class="support_link" href="https://www.ibm.com/cloud/websphere-liberty" target="_blank" rel="noopener">Find out more</a>
+            <h2>{% t global.websphere_application_server %}</h2>
+            <a class="support_link" href="https://www.ibm.com/cloud/websphere-liberty" target="_blank" rel="noopener">{% t support.find_out_more %}</a>
         </div>
     </div>
 </div>
@@ -39,10 +44,10 @@ seo-description: How to obtain community and commercial support for Open Liberty
 <div id="community_support_section">
     <div class="container">
         <div id="community_support_title">
-            Community support
+            {% t support.community_support %}
         </div>
         <p id="community_support_text">
-            You can rely on your Open Liberty crew to get you un-stuck
+            {% t support.community_support_text %}
         </p>
 
         <div id="cards_container" class="container">
@@ -53,8 +58,8 @@ seo-description: How to obtain community and commercial support for Open Liberty
                             <img id="twitter_logo" src="/img/twitter_logo.svg" class="d-block mx-auto" alt="twitter">
                         </figure>
                         <div class="card-body">
-                            <h5 class="card-title">@openlibertyio</h5>
-                            <p class="card-text">News & updates</p>
+                            <h5 class="card-title">@{% t global.openlibertyio %}</h5>
+                            <p class="card-text">{% t global.news_and_updates %}</p>
                         </div>
                     </a>
                 </div>
@@ -65,8 +70,8 @@ seo-description: How to obtain community and commercial support for Open Liberty
                             <img id="stack_overflow_logo" src="/img/stack_overflow_logo.svg" class="d-block mx-auto" alt="stackoverflow">
                         </figure>
                         <div id="stack_overflow_body" class="card-body">
-                            <h5 class="card-title">Stack Overflow</h5>
-                            <p class="card-text">Q & A</p>
+                            <h5 class="card-title">{% t global.stackoverflow %}</h5>
+                            <p class="card-text">{% t global.q_and_a %}</p>
                         </div>
                     </a>
                 </div>
@@ -77,8 +82,8 @@ seo-description: How to obtain community and commercial support for Open Liberty
                             <img id="groups_io_logo" src="/img/groups.io_logo.svg" class="d-block mx-auto" alt="groups">
                         </figure>
                         <div class="card-body">
-                            <h5 class="card-title">Groups.io</h5>
-                            <p class="card-text">Community forums</p>
+                            <h5 class="card-title">{% t global.groupsio %}</h5>
+                            <p class="card-text">{% t global.community_forums %}</p>
                         </div>
                     </a>
                 </div>
@@ -89,8 +94,8 @@ seo-description: How to obtain community and commercial support for Open Liberty
                             <img id="gitter_logo" src="/img/gitter_logo.svg" class="d-block mx-auto" alt="gitter">
                         </figure>
                         <div class="card-body">
-                            <h5 class="card-title">Gitter</h5>
-                            <p class="card-text">Community chat</p>
+                            <h5 class="card-title">{% t global.gitter %}</h5>
+                            <p class="card-text">{% t global.community_chat %}</p>
                         </div>
                     </a>
                 </div>
@@ -98,19 +103,21 @@ seo-description: How to obtain community and commercial support for Open Liberty
         </div>
 
         <p id="connect_text">
-            Connect with others using the tag <span id="bold_text">#OpenLiberty</span> across all social media.
+            {% t support.connect_text1 %} 
+            <span id="bold_text">#{% t global.openliberty_without_space %}</span> 
+            {% t support.connect_text2 %} 
         </p>
         
         <p id="fix_text">
-            Found something that needs to be fixed?<br>
-            Check out the open issues or report a new one.
+            {% t support.fix_text1 %}<br>
+            {% t support.fix_text2 %}
         </p>
         <div class="row">
             <div class="col-xs-12 col-sm-6 col-md-7">
                 <div id="github_link_container">
                     <a id="github_link" href="https://github.com/OpenLiberty/openliberty.io/issues" target="_blank" rel="noopener">
                         <div class="github_link_label_container">
-                            <div class="button_label">Open an issue on GitHub</div>
+                            <div class="button_label">{% t support.open_issue_github %}</div>
                         </div>
                     </a>
                 </div>
@@ -124,21 +131,20 @@ seo-description: How to obtain community and commercial support for Open Liberty
 
 </div>
 
-
 <!-- CONTRIBUTE SECTION -->
 <div id="contribute_section">
         <img id="spaceship" src="{{ "/img/spaceship.svg" | relative }}" class="img-fluid" alt="spaceship">
 
         <div id="contribute_title">
-            Become a contributor
+            {% t support.contributor_title %}
         </div>
         <p id="contribute_text">
-            Open Liberty is speeding toward the future, but your contributions can get us there at lightspeed
+            {% t support.contributor_text %}
         </p>
         <div id="contribute_link_container">
-            <a id="contribute_link" href="/contribute/">
+            <a id="contribute_link" href="{{baseURL}}/contribute/">
                 <div class="contribute_link_label_container">
-                    <div class="button_label">Contribute to Open Liberty</div>
+                    <div class="button_label">{% t support.contribute_to_openliberty %}</div>
                 </div>
             </a>
         </div>


### PR DESCRIPTION
- Only links to external domains should be orange.
- Use `blue_link_light_background_external` instead of
`blue_link_light_background`. The color between the text
and `blue_link_light_background` is too similar and makes it difficult
to know the text is a link. This choice of using the `*_external` for
more color contrast was done on the home page too.

# Before
<img width="1187" alt="image" src="https://user-images.githubusercontent.com/31117513/184955874-9fe761fd-fffe-4e3a-ae1d-77e36c695601.png">

# After
<img width="1151" alt="image" src="https://user-images.githubusercontent.com/31117513/184955795-e2f38670-b787-420c-84e3-2e28ba14f1ce.png">

#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] IBM Equal Access Accessibility Checker (https://www.ibm.com/able/toolkit/verify/automated)
- [ ] Lighthouse (in Chrome dev tools)

