### PR TITLE
lack of hover over behaviour for starter dropdown and radio button

### DIFF
--- a/src/main/content/_assets/css/start.scss
+++ b/src/main/content/_assets/css/start.scss
@@ -198,6 +198,14 @@ html, body {
         padding: 4px 4px;
     }
 
+    .starter_field_selector,
+    input[type=radio] {
+        &:hover {
+            cursor: pointer;
+            text-decoration: none;
+        }
+    }
+
     #base_package_section {
         min-width: 350px;
     }


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] IBM Equal Access Accessibility Checker (https://www.ibm.com/able/toolkit/verify/automated)
- [ ] Lighthouse (in Chrome dev tools)

