### PR TITLE
Fix trailing space in URL

### DIFF
--- a/src/main/content/index.html
+++ b/src/main/content/index.html
@@ -164,7 +164,7 @@ css:
             </div>
         </div>
         <div class="learn_more_container">
-            <a class="learn_more_link" href="{{baseURL}}/blog/?search=performance_enhancements ">{% t global.learnmore %}</a>
+            <a class="learn_more_link" href="{{baseURL}}/blog/?search=performance_enhancements">{% t global.learnmore %}</a>
         </div>
     </div>
 


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

Fix issue found in draft related to https://github.com/OpenLiberty/openliberty.io/pull/2833

#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] IBM Equal Access Accessibility Checker (https://www.ibm.com/able/toolkit/verify/automated)
- [ ] Lighthouse (in Chrome dev tools)

