### PR TITLE
set max height for code blocks in blogs

### DIFF
--- a/src/main/content/_assets/css/post.scss
+++ b/src/main/content/_assets/css/post.scss
@@ -299,6 +299,8 @@ footer {
 
 .CodeRay {
     padding: 10px;
+    max-height: 500px;
+    overflow: auto;
 }
 
 // custom styling for asciidoc definition/description lists

--- a/src/main/content/_assets/css/post.scss
+++ b/src/main/content/_assets/css/post.scss
@@ -297,7 +297,7 @@ footer {
     margin-bottom: 10px;
 }
 
-.CodeRay {
+#article_container pre {
     padding: 10px;
     max-height: 500px;
     overflow: auto;


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)
Issue #2825 
#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] IBM Equal Access Accessibility Checker (https://www.ibm.com/able/toolkit/verify/automated)
- [ ] Lighthouse (in Chrome dev tools)

