### PR TITLE
Update `Content-Security-Policy`

### DIFF
--- a/src/main/java/io/openliberty/website/TLSFilter.java
+++ b/src/main/java/io/openliberty/website/TLSFilter.java
@@ -83,7 +83,7 @@ public class TLSFilter implements Filter {
             response.setHeader("X-Content-Type-Options", "nosniff"); // Stops a browser from trying to MIME-sniff the
                                                                      // content type.
             response.setHeader("Content-Security-Policy",
-                    "default-src 'self' 'unsafe-inline' 'unsafe-eval' maxcdn.bootstrapcdn.com fonts.googleapis.com ajax.googleapis.com code.jquery.com fonts.gstatic.com  *.githubusercontent.com api.github.com www.googletagmanager.com tagmanager.google.com www.google-analytics.com cdnjs.cloudflare.com data: buttons.github.io www.youtube.com *.twitter.com *.twimg.com video.ibm.com https://start.openliberty.io/ gitlab.com starter-staging.rh9j6zz75er.us-east.codeengine.appdomain.cloud"); // Mitigating
+                    "default-src 'self' 'unsafe-inline' 'unsafe-eval' cdn.jsdelivr.net fonts.googleapis.com ajax.googleapis.com code.jquery.com fonts.gstatic.com  *.githubusercontent.com api.github.com www.googletagmanager.com tagmanager.google.com www.google-analytics.com cdnjs.cloudflare.com data: buttons.github.io www.youtube.com *.twitter.com *.twimg.com video.ibm.com https://start.openliberty.io/ gitlab.com starter-staging.rh9j6zz75er.us-east.codeengine.appdomain.cloud"); // Mitigating
             // cross
             // site
             // scripting


### PR DESCRIPTION
#### What was fixed?  (Issue # or description of fix)

Issue #2841
- Remove `maxcdn.bootstrapcdn.com` in favor for `cdn.jsdelivr.net`

Fix problem on draft where the jsdeliver domain is untrusted
<img width="1725" alt="image" src="https://user-images.githubusercontent.com/31117513/191998463-d0582485-0cde-4997-8387-2c55cf4da85c.png">


#### Were the changes tested on
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
- [ ] Internet Explorer (Desktop)
- [ ] iOS (Mobile)
- [ ] Android (Mobile)
#### Running validation tools
- [ ] https://validator.w3.org/checklink
- [ ] https://validator.w3.org
- [ ] IBM Equal Access Accessibility Checker (https://www.ibm.com/able/toolkit/verify/automated)
- [ ] Lighthouse (in Chrome dev tools)

