### PR TITLE
Delete Cloud Foundry URLs that are no longer used

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -24,81 +24,6 @@ applications:
     - route: www.openliberty.io
     - route: openliberty.io
     - route: us-south.openliberty.io
-- name: openlibertydev
-  <<: *defaults
-  memory: 256M
-  routes:
-    - route: openlibertydev.mybluemix.net
-- name: staging-openlibertyio
-  <<: *defaults
-  memory: 256M
-  routes:
-    - route: staging-openlibertyio.mybluemix.net
-- name: ui-staging-openlibertyio
-  <<: *defaults
-  memory: 192M
-  routes:
-    - route: ui-staging-openlibertyio.mybluemix.net
-- name: docs-staging-openlibertyio
-  <<: *defaults
-  memory: 256M
-  routes:
-    - route: docs-staging-openlibertyio.mybluemix.net
-- name: blogs-staging-openlibertyio
-  <<: *defaults
-  memory: 192M
-  routes:
-    - route: blogs-staging-openlibertyio.mybluemix.net
-- name: guides-staging-openlibertyio
-  <<: *defaults
-  memory: 192M
-  routes:
-    - route: guides-staging-openlibertyio.mybluemix.net
-- name: certifications-staging-openlibertyio
-  <<: *defaults
-  memory: 192M
-  routes:
-    - route: certifications-staging-openlibertyio.mybluemix.net
-- name: draft-openlibertyio
-  <<: *defaults
-  memory: 256M
-  routes:
-    - route: draft-openlibertyio.mybluemix.net
-- name: ui-draft-openlibertyio
-  <<: *defaults
-  memory: 192M
-  routes:
-    - route: ui-draft-openlibertyio.mybluemix.net
-- name: docs-draft-openlibertyio
-  <<: *defaults
-  memory: 256M
-  routes:
-    - route: docs-draft-openlibertyio.mybluemix.net
-- name: blogs-draft-openlibertyio
-  <<: *defaults
-  memory: 192M
-  routes:
-    - route: blogs-draft-openlibertyio.mybluemix.net
-- name: guides-draft-openlibertyio
-  <<: *defaults
-  memory: 192M
-  routes:
-    - route: guides-draft-openlibertyio.mybluemix.net
-- name: certifications-draft-openlibertyio
-  <<: *defaults
-  memory: 192M
-  routes:
-    - route: certifications-draft-openlibertyio.mybluemix.net
-- name: demo1-openlibertyio
-  <<: *defaults
-  memory: 192M
-  routes:
-    - route: demo1-openlibertyio.mybluemix.net
-- name: demo2-openlibertyio
-  <<: *defaults
-  memory: 192M
-  routes:
-    - route: demo2-openlibertyio.mybluemix.net
 
 # US East
 - name: openliberty-blue-east
@@ -115,6 +40,7 @@ applications:
     - route: www.openliberty.io
     - route: openliberty.io
     - route: us-east.openliberty.io
+
 # United Kingdom
 - name: openliberty-blue-uk
   <<: *defaults
@@ -130,6 +56,7 @@ applications:
     - route: www.openliberty.io
     - route: openliberty.io
     - route: eu-gb.openliberty.io
+
 # Germany
 - name: openliberty-blue-germany
   <<: *defaults
@@ -145,6 +72,7 @@ applications:
     - route: www.openliberty.io
     - route: openliberty.io
     - route: eu-de.openliberty.io
+
 # Sydney
 - name: openliberty-blue-sydney
   memory: 256M


### PR DESCRIPTION
## What was changed and why?
These URLs are no longer used for development purposes.

Changes were made to `draft` with commit 8826de74fc3e70caca4a2f9c7ab7a7993f3e0239

## Link GitHub issue
Issue #

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
