### PR TITLE
2825 blog codeblock maxheight

### DIFF
--- a/src/main/content/_assets/css/post.scss
+++ b/src/main/content/_assets/css/post.scss
@@ -299,6 +299,8 @@ footer {
 
 .CodeRay {
     padding: 10px;
+    max-height: 500px;
+    overflow: auto;
 }
 
 // custom styling for asciidoc definition/description lists

--- a/src/main/content/_assets/css/post.scss
+++ b/src/main/content/_assets/css/post.scss
@@ -297,7 +297,7 @@ footer {
     margin-bottom: 10px;
 }
 
-.CodeRay {
+#article_container pre {
     padding: 10px;
     max-height: 500px;
     overflow: auto;


### PR DESCRIPTION
## What was changed and why?
Set a max height and overflow behavior for code blocks in blogs to better display large blocks of code

## Link GitHub issue
Issue #2825 

## Tested using browser:
- [ ] Firefox (Desktop)
- [X] Safari (Desktop)
- [ ] Chrome (Desktop)
