### PR TITLE
Update to sort based on version.

### DIFF
--- a/src/main/java/io/openliberty/website/data/BuildData.java
+++ b/src/main/java/io/openliberty/website/data/BuildData.java
@@ -68,7 +68,7 @@ public class BuildData {
 
                 @Override
                 public int compare(BuildInfo o1, BuildInfo o2) {
-                    return o2.dateTime.compareTo(o1.dateTime);
+                    return o2.sortField.compareTo(o1.sortField);
                 }
             });
             this.builds.put(type, storedBuilds);
@@ -104,7 +104,7 @@ public class BuildData {
      * if the build already exists then the old data will be purged. It also
      * updates latestReleases with the new data.
      * 
-     * <p>BuildInfo must have dateTime set when this is called or a NPE will occur</p>
+     * <p>BuildInfo must have sortField set when this is called or a NPE will occur</p>
      * 
      * @param type The type of build being added
      * @param bi the build info for the build.
@@ -120,11 +120,11 @@ public class BuildData {
 
         // We need to update the latest release for both tools and
         // runtime. If the current value is null we set it to this, 
-        // otherwise we do a comparison based on the dateTime. If this
+        // otherwise we do a comparison based on the sortField. If this
         // build is the same or newer we update the release.
         if (type == BuildType.runtime_releases) {
             if (latestReleases.runtime == null || 
-                latestReleases.runtime.dateTime.compareTo(bi.dateTime) <= 0) {
+                latestReleases.runtime.sortField.compareTo(bi.sortField) <= 0) {
                 latestReleases.runtime = bi;
                 // Notify the build to any CDI event listeners.
                 if (type.isLatestBuildNotifiable() && event != null) {
@@ -133,7 +133,7 @@ public class BuildData {
             } 
         } else if (type == BuildType.tools_releases) {
             if (latestReleases.tools == null || 
-                latestReleases.tools.dateTime.compareTo(bi.dateTime) <= 0) {
+                latestReleases.tools.sortField.compareTo(bi.sortField) <= 0) {
                 latestReleases.tools = bi;
             } 
         }

--- a/src/main/java/io/openliberty/website/data/BuildInfo.java
+++ b/src/main/java/io/openliberty/website/data/BuildInfo.java
@@ -13,9 +13,12 @@ package io.openliberty.website.data;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.json.bind.JsonbBuilder;
 import javax.json.bind.annotation.JsonbProperty;
+import javax.json.bind.annotation.JsonbTransient;
 
 import io.openliberty.website.Constants;
 
@@ -70,6 +73,9 @@ public class BuildInfo {
     public List<String> packageLocations = new ArrayList<>();
     @JsonbProperty(Constants.PACKAGE_SIGNATURE_LOCATIONS)
     public List<String> packageSignatureLocations = new ArrayList<>();
+    @JsonbTransient
+    public String sortField;
+    private static Pattern parseVersion = Pattern.compile("\\.");
 
     // For unit testing
     public BuildInfo(String buildLog, String driverLocation, int testPassed, int totalTests, String testLog) {
@@ -148,6 +154,23 @@ public class BuildInfo {
 
         if(packageSignatureLocations != null && !packageSignatureLocations.isEmpty()) {
             packageSignatureLocations = fixLocations(prefix, packageSignatureLocations);
+        }
+
+        if (version != null) {
+            String[] elements = parseVersion.split(version);
+            StringBuilder versionMatch = new StringBuilder();
+            for (String e : elements) {
+                if (e.length() == 1) {
+                    versionMatch.append("00");
+                } else if (e.length() == 2) {
+                    versionMatch.append("0");
+                }
+                versionMatch.append(e);
+                versionMatch.append(".");
+            }
+            sortField = versionMatch.toString();
+        } else {
+            sortField = dateTime;
         }
     }
 


### PR DESCRIPTION
In 22.0.0.2 the uploads were changed from being in a date based directory to a version based one. This messed up the sort logic which assumed that the directory was the date of the release and it means that 22.0.0.10 no longer sorted as the most recent release.

Instead updating so if the version field is set we will sort based on version. The ideal is we will covert each version section to be a three digit version with leading zeros. That means that as long as we don't have 1000 numbers in any component then the sort will be fine. Based on current versioning this will last until the year 3000 or until we do 3 releases a day every day for a year, either seem to be unlikely.

## What was changed and why?


## Link GitHub issue
Issue https://github.com/OpenLiberty/openliberty.io/issues/2854

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
