### PR TITLE
2858 opengraph alt text

### DIFF
--- a/src/main/content/_includes/head.html
+++ b/src/main/content/_includes/head.html
@@ -8,6 +8,7 @@
 {% endif %}
 
 {% assign default_image = 'https://openliberty.io/img/twitter_card.jpg' %}
+{% assign default_image_alt = 'Open Liberty Logo' %}
 
 <head>
   <meta charset="utf-8">
@@ -51,6 +52,7 @@
 
   <meta property='og:title' content="{% if page.seo-title %}{{ page.seo-title }}{% else %}{{site.title}}{% endif %}" />
   <meta property='og:image' content="{% if page.open-graph-image %}{{page.open-graph-image}}{% else %}{{default_image}}{% endif %}" />
+  <meta property='og:image:alt' content="{% if page.open-graph-image-alt %}{{page.open-graph-image-alt}}{% else %}{{default_image_alt}}{% endif %}" />
   <meta property='og:description' content="{{ description }}" />
   <meta property='og:url' content="{{ page.url | replace:'index.html','' | absolute_url }}" />
   <meta property='og:type' content="website" />


### PR DESCRIPTION
## What was changed and why?

From [Open graph](https://ogp.me/)

> `og:image:alt` - A description of what is in the image (not a caption). If the page specifies an `og:image` it should specify `og:image:alt`.

The new front matter is `open-graph-image-alt: <value>`

## Link GitHub issue
Issue https://github.com/OpenLiberty/openliberty.io/issues/2858

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
