### PR TITLE
Update README Open Liberty Logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,1 @@
-![](src/main/content/img/logo.png)
-
+![Open Liberty logo](https://github.com/OpenLiberty/logos/blob/main/combomark/png/OL_logo_green_on_white.png)


### PR DESCRIPTION
## What was changed and why?

The current Open Liberty logo looks terrible in GitHub dark theme. Use a different logo that works well for both light and dark mode. I did similar changes to https://github.com/OpenLiberty/sample-getting-started/blob/main/README.md in the past.

## Link GitHub issue
Issue #

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
