### PR TITLE
2166 blog bulletlist font

### DIFF
--- a/src/main/content/_assets/css/post.scss
+++ b/src/main/content/_assets/css/post.scss
@@ -93,6 +93,7 @@ body {
 #article_body li > p {
     margin-top: 13px;
     margin-bottom: 13px;
+    font-size: 16px;
 }
 
 #article_body h1 {


### PR DESCRIPTION
## What was changed and why?
Made the font size of unordered lists on blog posts the same as the font size on the rest of the post.

## Link GitHub issue
Issue #2166 

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
