### PR TITLE
2830 double scrollbar bug

### DIFF
--- a/src/main/content/_assets/css/home.scss
+++ b/src/main/content/_assets/css/home.scss
@@ -15,7 +15,7 @@ html {
 
 body {
   position: relative;
-  overflow-x: hidden !important;
+  overflow: hidden !important;
 }
 
 @media (max-width: 767px) {


### PR DESCRIPTION
## What was changed and why?
Overflow CSS for the home page was modified so that one scrollbar renders from the beginning instead of having two scrollbars render initially and then consolidate to one.

## Link GitHub issue
Issue #2830 

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
