### PR TITLE
2579 Modify text explaining beta downloads

### DIFF
--- a/src/main/content/_i18n/en.yml
+++ b/src/main/content/_i18n/en.yml
@@ -127,8 +127,9 @@ start:
     file: file
     beta_content1: Try out new features in our betas and let us know
     beta_content2: your feedback.
-    beta_content3: Beta content may change from 
-    beta_content4: release to release.
+    beta_content3: We publish beta releases to share and obtain early feedback on what the Open Liberty team is actively developing. 
+                  Beta content is subject to change and inclusion in a beta does not guarantee inclusion in a GA release. For details about what each beta release includes, checkout the 
+    beta_content4: beta blog posts.
     beta_content5: Starting with version 22.0.0.1, signature files are produced for every package of an Open Liberty release. You can use these signature files
                   and the corresponding public key to verify the authenticity and integrity of an Open Liberty release package. For more information, see
     nightly_builds_content: Nightly builds contain in-development features, have not gone through the full release process and are potentially unstable.


### PR DESCRIPTION
## What was changed and why?
Text was modified to be the requested wording agreed upon in the issue; while it was mentioned to put this text below the table, this would separate the table from the "More downloads on the way information" and does not look great.

## Link GitHub issue
Issue #2579 

## Tested using browser:
- [X] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
