### PR TITLE
2285 archive old releases

### DIFF
--- a/src/main/content/_assets/css/start.scss
+++ b/src/main/content/_assets/css/start.scss
@@ -507,6 +507,10 @@ html, body {
     margin-bottom: 41px;
 }
 
+.archive_sentence {
+    margin: 5px;
+}
+
 .eclipse_development_tools_title {
     margin-top: 0;
     margin-bottom: 15px;

--- a/src/main/content/_assets/css/start.scss
+++ b/src/main/content/_assets/css/start.scss
@@ -508,7 +508,8 @@ html, body {
 }
 
 .archive_sentence {
-    margin: 5px;
+    margin-top: 5px;
+    margin-left: 2.5px;
 }
 
 .eclipse_development_tools_title {

--- a/src/main/content/_assets/js/builds.js
+++ b/src/main/content/_assets/js/builds.js
@@ -180,7 +180,12 @@ function render_builds(builds, parent) {
     });
 
     builds.forEach(function (build) {
-        console.log(build);
+        if(parseInt(build.version.split(".")[3]) % 3 === 0 && !build.date_time.includes(".")){
+            var today = Date.now();
+            var pub = new Date(build.date);
+            var diff = Math.ceil(Math.abs(today - pub)/(1000*60*60*24));
+            console.log("Diff: "+diff+", Vers: "+build.version);
+        }
         if (parent.hasClass('release_table_body')) {
             if (build.version.indexOf('-RC') > -1) {
                 build.version.replace('-RC', ' Release Candidate');

--- a/src/main/content/_assets/js/builds.js
+++ b/src/main/content/_assets/js/builds.js
@@ -179,16 +179,16 @@ function render_builds(builds, parent) {
         }
     });
 
+    // get the newest release version
+    // used to only add builds from the last two years to the runtime release table
     var versArr = builds.map(function(b){
         if (parent.parent().data('builds-id') == 'runtime_releases')
         {
             return parseInt(b.version.split(".")[0]);
         }
     })
-
     var newest = Math.max.apply(Math, versArr);
     var subRelease = (new Date()).getMonth() + 1;
-
 
     builds.forEach(function (build) {
         if (parent.hasClass('release_table_body')) {
@@ -207,8 +207,6 @@ function render_builds(builds, parent) {
                 }
                 var package_signature_locations = build.package_signature_locations || [];
                 var sorted_package_signature_locations;
-                var primary = parseInt(build.version.split(".")[0]);
-                var secondary = parseInt(build.version.split(".")[3]);
                 if (package_signature_locations !== null && package_signature_locations !== undefined) {
                     sorted_package_signature_locations = sortRuntimeLocations(package_signature_locations);
                     package_signature_locations = sorted_package_signature_locations;
@@ -356,11 +354,11 @@ function render_builds(builds, parent) {
                         row.append(download_column);
                         row.append(verification_column);
 
+                        // checking if version is from the last two years before adding to table
+                        var primary = parseInt(build.version.split(".")[0]);
+                        var secondary = parseInt(build.version.split(".")[3]);
                         if(newest - primary <= 2){
-                            console.log("Primary: "+primary);
-                            console.log("Secondary: "+secondary);
-                            console.log("Newest: "+newest);
-                            if(primary === (newest - 2)){
+                            if((newest - primary) === 2){
                                 if(secondary >= subRelease){
                                     parent.append(row);
                                 }

--- a/src/main/content/_assets/js/builds.js
+++ b/src/main/content/_assets/js/builds.js
@@ -186,7 +186,7 @@ function render_builds(builds, parent) {
             }
 
             // ol releases table only
-            if (parent.parent().data('builds-id') == 'runtime_releases') {
+            if (parent.parent().data('builds-id') == 'runtime_releases' && parseInt(build.version.split(".")[3]) % 3 == 0) {
                 var releaseBuild = createBlogReleaseAndBetaLink("release",build);
                 var package_locations = build.package_locations;
                 var sorted_package_locations;
@@ -215,7 +215,7 @@ function render_builds(builds, parent) {
                             parent.append('<tr></tr>');
                         }
                     }
-
+                    
                     var version_column = $(
                         '<td headers="' +
                             tableID +
@@ -574,7 +574,7 @@ function createBlogReleaseAndBetaLink(buildId, build) {
     versionwithoutdots = versionwithdots.split('.').join("")
     var releasePostLink, betaPostLink
     if (buildId == "release") {
-        releaseTagPostLinks.filter(postLink => {
+        releaseTagPostLinks.filter(function (postLink) {
             if (postLink.includes(versionwithdots) || postLink.includes(versionwithoutdots)) {
                 releasePostLink = postLink;
             }
@@ -584,7 +584,7 @@ function createBlogReleaseAndBetaLink(buildId, build) {
         }
     }
     else if (buildId == "beta") {
-        betaTagPostLinks.filter(postLink => {
+        betaTagPostLinks.filter(function (postLink) {
             if (postLink.includes(versionwithdots) || postLink.includes(versionwithoutdots)) {
                 betaPostLink = postLink;
             }

--- a/src/main/content/_assets/js/builds.js
+++ b/src/main/content/_assets/js/builds.js
@@ -180,13 +180,14 @@ function render_builds(builds, parent) {
     });
 
     builds.forEach(function (build) {
+        console.log(build);
         if (parent.hasClass('release_table_body')) {
             if (build.version.indexOf('-RC') > -1) {
                 build.version.replace('-RC', ' Release Candidate');
             }
 
             // ol releases table only
-            if (parent.parent().data('builds-id') == 'runtime_releases' && parseInt(build.version.split(".")[3]) % 3 == 0) {
+            if (parent.parent().data('builds-id') == 'runtime_releases') {
                 var releaseBuild = createBlogReleaseAndBetaLink("release",build);
                 var package_locations = build.package_locations;
                 var sorted_package_locations;
@@ -342,7 +343,9 @@ function render_builds(builds, parent) {
                         row.append(package_column);
                         row.append(download_column);
                         row.append(verification_column);
-                        parent.append(row);
+                        if(parseInt(build.version.split(".")[3]) % 3 === 0){
+                            parent.append(row);
+                        }
                     }
                 }
             }

--- a/src/main/content/_assets/js/builds.js
+++ b/src/main/content/_assets/js/builds.js
@@ -180,12 +180,6 @@ function render_builds(builds, parent) {
     });
 
     builds.forEach(function (build) {
-        if(parseInt(build.version.split(".")[3]) % 3 === 0 && !build.date_time.includes(".")){
-            var today = Date.now();
-            var pub = new Date(build.date);
-            var diff = Math.ceil(Math.abs(today - pub)/(1000*60*60*24));
-            console.log("Diff: "+diff+", Vers: "+build.version);
-        }
         if (parent.hasClass('release_table_body')) {
             if (build.version.indexOf('-RC') > -1) {
                 build.version.replace('-RC', ' Release Candidate');
@@ -193,6 +187,15 @@ function render_builds(builds, parent) {
 
             // ol releases table only
             if (parent.parent().data('builds-id') == 'runtime_releases') {
+                var diff = 0;
+                var gnu = false;
+                if(!build.date_time.includes(".")){
+                    var today = Date.now();
+                    var pub = new Date(build.date);
+                    diff = Math.ceil(Math.abs(today - pub)/(1000*60*60*24));
+                }else{
+                    gnu = true;
+                }
                 var releaseBuild = createBlogReleaseAndBetaLink("release",build);
                 var package_locations = build.package_locations;
                 var sorted_package_locations;
@@ -348,7 +351,7 @@ function render_builds(builds, parent) {
                         row.append(package_column);
                         row.append(download_column);
                         row.append(verification_column);
-                        if(parseInt(build.version.split(".")[3]) % 3 === 0){
+                        if(diff < 730 || gnu){
                             parent.append(row);
                         }
                     }

--- a/src/main/content/_assets/js/builds.js
+++ b/src/main/content/_assets/js/builds.js
@@ -179,6 +179,17 @@ function render_builds(builds, parent) {
         }
     });
 
+    var versArr = builds.map(function(b){
+        if (parent.parent().data('builds-id') == 'runtime_releases')
+        {
+            return parseInt(b.version.split(".")[0]);
+        }
+    })
+
+    var newest = Math.max.apply(Math, versArr);
+    var subRelease = (new Date()).getMonth() + 1;
+
+
     builds.forEach(function (build) {
         if (parent.hasClass('release_table_body')) {
             if (build.version.indexOf('-RC') > -1) {
@@ -187,15 +198,6 @@ function render_builds(builds, parent) {
 
             // ol releases table only
             if (parent.parent().data('builds-id') == 'runtime_releases') {
-                var diff = 0;
-                var gnu = false;
-                if(!build.date_time.includes(".")){
-                    var today = Date.now();
-                    var pub = new Date(build.date);
-                    diff = Math.ceil(Math.abs(today - pub)/(1000*60*60*24));
-                }else{
-                    gnu = true;
-                }
                 var releaseBuild = createBlogReleaseAndBetaLink("release",build);
                 var package_locations = build.package_locations;
                 var sorted_package_locations;
@@ -205,6 +207,8 @@ function render_builds(builds, parent) {
                 }
                 var package_signature_locations = build.package_signature_locations || [];
                 var sorted_package_signature_locations;
+                var primary = parseInt(build.version.split(".")[0]);
+                var secondary = parseInt(build.version.split(".")[3]);
                 if (package_signature_locations !== null && package_signature_locations !== undefined) {
                     sorted_package_signature_locations = sortRuntimeLocations(package_signature_locations);
                     package_signature_locations = sorted_package_signature_locations;
@@ -351,8 +355,18 @@ function render_builds(builds, parent) {
                         row.append(package_column);
                         row.append(download_column);
                         row.append(verification_column);
-                        if(diff < 730 || gnu){
-                            parent.append(row);
+
+                        if(newest - primary <= 2){
+                            console.log("Primary: "+primary);
+                            console.log("Secondary: "+secondary);
+                            console.log("Newest: "+newest);
+                            if(primary === (newest - 2)){
+                                if(secondary >= subRelease){
+                                    parent.append(row);
+                                }
+                            } else {
+                                parent.append(row);
+                            }
                         }
                     }
                 }

--- a/src/main/content/_i18n/en.yml
+++ b/src/main/content/_i18n/en.yml
@@ -134,6 +134,8 @@ start:
     nightly_builds_content: Nightly builds contain in-development features, have not gone through the full release process and are potentially unstable.
     eclipse_developer_tools_content1: We recommend IDE tools based on Eclipse since it gives you an integrated environment right out of the box.
     eclipse_developer_tools_content2: Learn how to install the tools here.
+    archive_text1: You can find previous releases in
+    archive_text2: this archive.
     cow_text: Don't have a cow.
     more_downloads_on_the_way: More downloads are on the way.
     check_back_soon: Check back soon!

--- a/src/main/content/start.html
+++ b/src/main/content/start.html
@@ -238,6 +238,10 @@ seo-description: Use Maven or Gradle to create a starter application for develop
                                 <tbody class="release_table_body">
                                 </tbody>
                             </table>
+                            <p class="archive_sentence">
+                                Archived releases can be found 
+                                <a href="https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/" class="orange_link_light_background">here.</a>
+                            </p>
                         </div>
                     </div>
                 </div>

--- a/src/main/content/start.html
+++ b/src/main/content/start.html
@@ -239,7 +239,8 @@ seo-description: Use Maven or Gradle to create a starter application for develop
                                 </tbody>
                             </table>
                             <p class="archive_sentence">
-                                <a href="https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/" class="orange_link_light_background">Archived releases can obtained from this link.</a>
+                                {% t start.download_package_section.archive_text1 %}
+                                <a href="https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/" class="orange_link_light_background">{% t start.download_package_section.archive_text2 %}</a>
                             </p>
                         </div>
                     </div>

--- a/src/main/content/start.html
+++ b/src/main/content/start.html
@@ -239,8 +239,7 @@ seo-description: Use Maven or Gradle to create a starter application for develop
                                 </tbody>
                             </table>
                             <p class="archive_sentence">
-                                Archived releases can be found 
-                                <a href="https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/" class="orange_link_light_background">here.</a>
+                                <a href="https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/" class="orange_link_light_background">Archived releases can obtained from this link.</a>
                             </p>
                         </div>
                     </div>


### PR DESCRIPTION
## What was changed and why?
Releases older than two years were removed from the runtime release table and a link was added at the bottom of the table to direct users who require older versions to the archive hosted on the public DHE

## Link GitHub issue
Issue #2285 

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [X] Chrome (Desktop)
