### PR TITLE
Modify `blog-available-in-languages` front matter

### DIFF
--- a/src/main/content/_layouts/post.html
+++ b/src/main/content/_layouts/post.html
@@ -54,20 +54,9 @@ js: post
                 <div class="post_tags_container"></div>
                 <div class="language_container">
                     <span class="lang_text">{% t blog.post_in_other_lang %}:</span>
-                    {% for current_lang in page.blog-available-in-languages %}
-                    <!-- Make sure to exclude the currently selected language from the language picker -->
-                    {% if current_lang != site.lang %}
-                        {% if 'en' == current_lang %}
-                            <!-- Special case: `en` URLs do not have /en/blogs but rather just /blogs -->
-                            <!-- Assume `page.url` does not include the language from the URL path set by -->
-                            <!-- the folder structure created from `jekyll-multiple-languages-plugin` -->
-                            {% assign href_lang = page.url %}
-                        {% else %}
-                            {% assign href_lang = '/' | append: current_lang | append: page.url %}
-                        {% endif %}
-                        <a class="blog_lang" href="{{href_lang}}">{% t langs.{{current_lang}} %}</a>
+                    {% for i18n in page.blog-available-in-languages %}
+                        <a class="blog_lang" href="{{i18n.path}}">{% t langs.{{i18n.lang}} %}</a>
                         <span class="comma">, </span>
-                    {% endif %}
                     {% endfor %}
                 </div>
             </div>


### PR DESCRIPTION
- The previous logic assumed a multilingual blog post had the same timestamp in their URLs and only differed by the lang. This is not true and breaks the ability to simply add and remove the lang from the URL to switch between languages for a multilingual post.

- Chose to have authors provide the full path to the blog post in other languages. This avoids any need of knowing how Jekyll build process works.

- In the case where someone changes the URL of a post used in the `blog-available-in-languages` front matter attribute, the old URL should always be valid because changing any existing URL for blog posts should be accompanied by a redirect from the old URL to the new.

- The `jekyll-multiple-languages-plugin` Jekyll plugin builds each i18n language in isolation, so blog posts for `ja` cannot see `en` posts. This means there is not a Liquid way of doing the cross linking between blog posts in different languages.

## What was changed and why?


## Link GitHub issue
Issue #

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
