### PR TITLE
Fix removal of file extension for posts

### DIFF
--- a/src/main/content/_assets/js/blog.js
+++ b/src/main/content/_assets/js/blog.js
@@ -44,7 +44,7 @@ var blog = function(){
     }
 
     function removeFileExtension(filename) {
-        return filename.split('.')[0];
+        return filename.substring(0, filename.lastIndexOf('.')) || filename
     }
 
     function updateSearchUrl(tag) {

--- a/src/main/content/_assets/js/post.js
+++ b/src/main/content/_assets/js/post.js
@@ -35,7 +35,7 @@ function getFilename(uri) {
 }
 
 function removeFileExtension(filename) {
-    return filename.split('.')[0];
+    return filename.substring(0, filename.lastIndexOf('.')) || filename
 }
 
 var code_blocks_with_copy_to_clipboard = 'pre:not(.no_copy pre)'; // CSS Selector


### PR DESCRIPTION
## What was changed and why?
Fix incorrect parsing of file extension causing blogs tags to not appear for posts with periods in name.

## Link GitHub issue
Issue #2891

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
