### PR TITLE
2874 firefox homepage bug fixup

### DIFF
--- a/src/main/content/_assets/css/home.scss
+++ b/src/main/content/_assets/css/home.scss
@@ -517,6 +517,7 @@ body {
 
 #news_container {
   padding-top: 84px;
+  min-height: 775px;
   #news_row {
     // value is based on the data-height found on HTML element with class="twitter-timeline"
     min-height: 650px;

--- a/src/main/content/_assets/css/home.scss
+++ b/src/main/content/_assets/css/home.scss
@@ -518,10 +518,6 @@ body {
 #news_container {
   padding-top: 84px;
   min-height: 775px;
-  #news_row {
-    // value is based on the data-height found on HTML element with class="twitter-timeline"
-    min-height: 650px;
-  }
 }
 
 #cloud_images_div {


### PR DESCRIPTION
## What was changed and why?
Min height of news container was increased to prevent UI issues that occur when the Twitter feed widget does not render properly

## Link GitHub issue
Issue #2874 

## Tested using browser:
- [X] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
