### PR TITLE
css fixes and removing extra code

### DIFF
--- a/src/main/content/_assets/css/blog.scss
+++ b/src/main/content/_assets/css/blog.scss
@@ -220,6 +220,9 @@ html {
         color: #C9D6FE;
         @media (max-width: 767.98px) {
             color: #5E6B8D;
+            &:hover {
+                color: #3F4659 !important;
+            }
         }
     }
 
@@ -250,12 +253,6 @@ html {
     &:hover {
         color: #E6ECFF;
         cursor: pointer;
-    }
-
-    @media (max-width: 767.98px) {
-        &:hover {
-            color: #3F4659 !important;
-        }
     }
 }
 

--- a/src/main/content/_assets/css/blog.scss
+++ b/src/main/content/_assets/css/blog.scss
@@ -217,7 +217,10 @@ html {
     font-size: 16px;
     color: #C9D6FE;
     & > a {
-        color: #C9D6FE
+        color: #C9D6FE;
+        @media (max-width: 767.98px) {
+            color: #5E6B8D;
+        }
     }
 
     & span {
@@ -228,12 +231,14 @@ html {
         }
     }
 
-    @media (max-width: 991.98px) {
-        padding-bottom: 50px;
-    }
-
     @media (max-width: 767.98px) {
         color: #5E6B8D;
+    }
+}
+
+#language_list{
+    @media (max-width: 991.98px) {
+        padding-bottom: 50px;
     }
 }
 
@@ -249,7 +254,7 @@ html {
 
     @media (max-width: 767.98px) {
         &:hover {
-            color: #3F4659;
+            color: #3F4659 !important;
         }
     }
 }

--- a/src/main/content/_assets/css/blog.scss
+++ b/src/main/content/_assets/css/blog.scss
@@ -221,7 +221,7 @@ html {
         @media (max-width: 767.98px) {
             color: #5E6B8D;
             &:hover {
-                color: #3F4659 !important;
+                color: #3F4659;
             }
         }
     }

--- a/src/main/content/_layouts/post.html
+++ b/src/main/content/_layouts/post.html
@@ -54,9 +54,20 @@ js: post
                 <div class="post_tags_container"></div>
                 <div class="language_container">
                     <span class="lang_text">{% t blog.post_in_other_lang %}:</span>
-                    {% for i18n in page.blog-available-in-languages %}
-                        <a class="blog_lang" href="{{i18n.path}}">{% t langs.{{i18n.lang}} %}</a>
+                    {% for current_lang in page.blog-available-in-languages %}
+                    <!-- Make sure to exclude the currently selected language from the language picker -->
+                    {% if current_lang != site.lang %}
+                        {% if 'en' == current_lang %}
+                            <!-- Special case: `en` URLs do not have /en/blogs but rather just /blogs -->
+                            <!-- Assume `page.url` does not include the language from the URL path set by -->
+                            <!-- the folder structure created from `jekyll-multiple-languages-plugin` -->
+                            {% assign href_lang = page.url %}
+                        {% else %}
+                            {% assign href_lang = '/' | append: current_lang | append: page.url %}
+                        {% endif %}
+                        <a class="blog_lang" href="{{href_lang}}">{% t langs.{{current_lang}} %}</a>
                         <span class="comma">, </span>
+                    {% endif %}
                     {% endfor %}
                 </div>
             </div>

--- a/src/main/content/blog.html
+++ b/src/main/content/blog.html
@@ -37,8 +37,6 @@ i18n-seo-description: seo.blogs
                 <h2 class="blog_subtitle">{% t blog.featured_tags %}</h2>
                 <div role="list" id="featured_tags_list">
                 </div>
-                <div role="list" id="featured_tags_list">
-                </div>
                 <h2 class="blog_subtitle">{% t blog.posts_in_other_languages %}</h2>
                 <div role="list" id="language_list">
                     {% for current_lang in site.languages %}


### PR DESCRIPTION
## What was changed and why?
Spacing for the language picker was corrected for tablet and mobile sizes.  The link color for the languages on mobile was also corrected, and duplicate code was removed from HTML.

Link color issue original:
![Screen Shot 2022-11-02 at 3 55 09 PM](https://user-images.githubusercontent.com/84740311/199812782-efbe29ed-cc2b-4eba-95aa-b09d640191b8.png)


## Link GitHub issue
Issue #2895 

## Tested using browser:
- [X] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
