### PR TITLE
2921 broken ja links

### DIFF
--- a/src/main/content/_includes/footer.html
+++ b/src/main/content/_includes/footer.html
@@ -32,9 +32,9 @@
             <a id="footer_logos_link" href="https://github.com/OpenLiberty/logos" target="_blank" rel="noopener" class="left_footer_link">{% t footer.logos %}</a>
         </div>
         <div id="footer_bottom_right_section">
-            <a id="footer_docs_link" href="{{baseURL}}/docs" aria-label="Open Liberty Docs" class="right_footer_link blue_link_light_background">{% t pages.docs %}</a>
-            <a id="footer_blog_link" href="{{baseURL}}/blog" aria-label="Open Liberty Blog" class="right_footer_link blue_link_light_background">{% t pages.blog %}</a>
-            <a id="footer_support_link" href="{{baseURL}}/support" aria-label="Open Liberty Support" class="right_footer_link blue_link_light_background">{% t pages.support %}</a>
+            <a id="footer_docs_link" href="/docs" aria-label="Open Liberty Docs" class="right_footer_link blue_link_light_background">{% t pages.docs %}</a>
+            <a id="footer_blog_link" href="/blog" aria-label="Open Liberty Blog" class="right_footer_link blue_link_light_background">{% t pages.blog %}</a>
+            <a id="footer_support_link" href="/support" aria-label="Open Liberty Support" class="right_footer_link blue_link_light_background">{% t pages.support %}</a>
         </div>
     </div>
 </footer>

--- a/src/main/content/_includes/header.html
+++ b/src/main/content/_includes/header.html
@@ -9,7 +9,7 @@
 <header>
     <nav id="nav_bar">
         <div id="nav_header">
-            <a id="home_link" href="{{homeURL}}" aria-label="Open Liberty Home">
+            <a id="home_link" href="/" aria-label="Open Liberty Home">
                 <img id="ol_logo" src="/img/docs_openliberty_logo.png" alt="Open Liberty Logo">
             </a>
             <button id="hamburger_toggle_button" onclick="$('#nav_bar').toggleClass('responsive');">

--- a/src/main/content/_layouts/post.html
+++ b/src/main/content/_layouts/post.html
@@ -54,20 +54,9 @@ js: post
                 <div class="post_tags_container"></div>
                 <div class="language_container">
                     <span class="lang_text">{% t blog.post_in_other_lang %}:</span>
-                    {% for current_lang in page.blog-available-in-languages %}
-                    <!-- Make sure to exclude the currently selected language from the language picker -->
-                    {% if current_lang != site.lang %}
-                        {% if 'en' == current_lang %}
-                            <!-- Special case: `en` URLs do not have /en/blogs but rather just /blogs -->
-                            <!-- Assume `page.url` does not include the language from the URL path set by -->
-                            <!-- the folder structure created from `jekyll-multiple-languages-plugin` -->
-                            {% assign href_lang = page.url %}
-                        {% else %}
-                            {% assign href_lang = '/' | append: current_lang | append: page.url %}
-                        {% endif %}
-                        <a class="blog_lang" href="{{href_lang}}">{% t langs.{{current_lang}} %}</a>
+                    {% for i18n in page.blog-available-in-languages %}
+                        <a class="blog_lang" href="{{i18n.path}}">{% t langs.{{i18n.lang}} %}</a>
                         <span class="comma">, </span>
-                    {% endif %}
                     {% endfor %}
                 </div>
             </div>


### PR DESCRIPTION
## What was changed and why?

- Discovered the `jekyll-multiple-languages-plugin` is converting the `/` paths into `/<ja>`. Not all the English pages have a Japanese equivalent. Force the links to be `/` to the 404 links.

## Link GitHub issue
Issue #2921 

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
