### PR TITLE
Disable blog tags for non-English posts

### DIFF
--- a/src/main/content/_assets/js/blog.js
+++ b/src/main/content/_assets/js/blog.js
@@ -3,8 +3,8 @@ var blog = function(){
 
     // Read tags from json file and add tag to class
     function getTags(callback) {
-        if(document.documentElement.lang === 'ja') {
-            // Temporarily disable tags for Japanese posts until there is a design in place on how the
+        if(document.documentElement.lang !== 'en') {
+            // Temporarily disable tags for non-English posts until there is a design in place on how the
             // code should manage tags for a post in different languages.
             return;
         }


### PR DESCRIPTION
## What was changed and why?

Disable blog tags for non-English posts until a system is in place for managing blog tags for multiple languages.

Related to https://github.com/OpenLiberty/openliberty.io/pull/2919

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
