### PR TITLE
Add GitHub Action for GitHub Projects

### DIFF
--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -1,0 +1,20 @@
+name: Add GitHub Issues and Pull Requests to GitHub Project
+
+on:
+  issues:
+    types:
+      - opened
+      - transferred
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue or pull request to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.4.0
+        with:
+          project-url: https://github.com/orgs/OpenLiberty/projects/10
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
## What was changed and why?

- This action will automatically add new Issues and Pull Requests to the GitHub Project for openliberty.io

Move to a more natively supported Kanban planner (GitHub Projects)

## Link GitHub issue
Issue #2949

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
