### PR TITLE
2934 jakarta blog feed

### DIFF
--- a/src/main/content/jakartaee.xml
+++ b/src/main/content/jakartaee.xml
@@ -19,7 +19,13 @@ permalink: /jakartaee.xml
         <description>{{ post.content | xml_escape }}</description>        
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
         <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
-        <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>
+        <guid isPermaLink="true">
+          {% if post.redirect_link %}
+            {{ post.redirect_link | xml_escape }}
+          {% else %}
+            {{ post.id | prepend: site.baseurl | prepend: site.url }}
+          {% endif %}
+        </guid>
         {% for tag in post.tags %}
         <category>{{ tag | xml_escape }}</category>
         {% endfor %}

--- a/src/main/content/jakartaee.xml
+++ b/src/main/content/jakartaee.xml
@@ -21,7 +21,7 @@ permalink: /jakartaee.xml
         <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
         <guid isPermaLink="true">
           {% if post.redirect_link %}
-            {{ post.redirect_link | xml_escape }}
+            {{ post.redirect_link }}
           {% else %}
             {{ post.id | prepend: site.baseurl | prepend: site.url }}
           {% endif %}


### PR DESCRIPTION
## What was changed and why?
Makes Jakarta EE RSS feed valid; validated by W3C: https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fdraft-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud%2Fjakartaee.xml

## Link GitHub issue
Issue #2934 

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
