### PR TITLE
#2957 fix external blog tags

### DIFF
--- a/src/main/content/_assets/js/blog.js
+++ b/src/main/content/_assets/js/blog.js
@@ -45,7 +45,7 @@ var blog = function(){
     }
 
     function getFilename(uri) {
-        return uri.split('/').pop();
+        return uri.replace(/\d{4}-\d{2}-\d{2}-/, "").split('/').pop(); // Remove the date from external blogs and then remove all of the previous file folders from uri.
     }
 
     function removeFileExtension(filename) {


### PR DESCRIPTION
## What was changed and why?
Added tags to external blogs. See it here: https://draft-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/blog/

ctrl-f for "Continued on" and it will show all of the external blogs.

## Link GitHub issue
Issue #2957

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
