### PR TITLE
Update copyright year to 2023

### DIFF
--- a/src/main/content/_i18n/en.yml
+++ b/src/main/content/_i18n/en.yml
@@ -36,7 +36,7 @@ pages:
   support: Support
   blog: Blog
 footer:
-  copyright: Copyright IBM Corp. 2017, 2021
+  copyright: Copyright IBM Corp. 2017, 2023
   privacy_policy: Privacy policy
   license: License
   logos: Logos

--- a/src/main/content/_i18n/ja.yml
+++ b/src/main/content/_i18n/ja.yml
@@ -36,7 +36,7 @@ pages:
   support: サポート
   blog: ブログ
 footer:
-  copyright: Copyright IBM Corp. 2017, 2022
+  copyright: Copyright IBM Corp. 2017, 2023
   privacy_policy: プライバシー・ポリシー
   license: ライセンス
   logos: ロゴ

--- a/src/main/content/_i18n/zh-Hans.yml
+++ b/src/main/content/_i18n/zh-Hans.yml
@@ -36,7 +36,7 @@ pages:
   support: 支持
   blog: 博客
 footer:
-  copyright: Copyright IBM Corp. 2017, 2021
+  copyright: Copyright IBM Corp. 2017, 2023
   privacy_policy: 隐私策略
   license: 许可证
   logos: 洛戈斯

--- a/src/main/content/antora_ui/src/partials/footer-content.hbs
+++ b/src/main/content/antora_ui/src/partials/footer-content.hbs
@@ -17,7 +17,7 @@
 
     <div id="footer_bottom_container" class="footer_container container-fluid">
         <div id="footer_bottom_left_section">
-            <p id="footer_copyright">&copy; Copyright IBM Corp. 2017, 2020</p>
+            <p id="footer_copyright">&copy; Copyright IBM Corp. 2017, 2023</p>
             <p class="vertical_bar">|</p>
             <a id="footer_privacy_policy_link" href="https://www.ibm.com/privacy/" target="_blank" rel="noopener" class="left_footer_link">Privacy policy</a>
             <p class="vertical_bar">|</p>


### PR DESCRIPTION
## What was changed and why?
Updated copyright year in docs, and the rest of the jekyll site for all languages.

## Link GitHub issue
Issue #2942

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
