### PR TITLE
3000 kernal base image

### DIFF
--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -49,7 +49,15 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 package
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:22.0.0.13-full-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:22.0.0.13-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 COPY src/main/wlp/server.xml /config/server.xml
+
+# This script will add the requested XML snippets to enable Liberty features and grow image to be fit-for-purpose using featureUtility. 
+# Only available in 'kernel-slim'. The 'full' tag already includes all features for convenience.
+RUN features.sh
+
 COPY --from=war --chown=1001:0 target/openliberty-website-1.0-SNAPSHOT /config/apps/openliberty.war
+
+# This script will add the requested server configurations, apply any interim fixes and populate caches to optimize runtime
+RUN configure.sh

--- a/docker/Dockerfile.draft
+++ b/docker/Dockerfile.draft
@@ -50,7 +50,18 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 package
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:22.0.0.13-full-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:22.0.0.13-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
+
 COPY src/main/wlp/server.xml /config/server.xml
+
+# This script will add the requested XML snippets to enable Liberty features and grow image to be fit-for-purpose 
+# using featureUtility. 
+# Only available in 'kernel-slim'. The 'full' tag already includes all features for convenience.
+RUN features.sh
+
 COPY --from=war --chown=1001:0 target/openliberty-website-1.0-SNAPSHOT /config/apps/openliberty.war
+
+# This script will add the requested server configurations, apply any interim fixes and populate caches to
+# optimize runtime
+RUN configure.sh


### PR DESCRIPTION
## What was changed and why?

Switch from using the Open Liberty image containing all the features to a kernel image that only has the features needed by the `server.xml`.

I tested this locally on my M1 Mac using `amd64` but would like to see how the change perform in IBM Code Engine.

I followed https://github.com/OpenLiberty/ci.docker#building-an-application-image

## Link GitHub issue
Issue #3000

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
