### PR TITLE
fix: changing the link to open new github issue

### DIFF
--- a/src/main/content/support.html
+++ b/src/main/content/support.html
@@ -115,7 +115,7 @@ seo-description: How to obtain community and commercial support for Open Liberty
         <div class="row">
             <div class="col-xs-12 col-sm-6 col-md-7">
                 <div id="github_link_container">
-                    <a id="github_link" href="https://github.com/OpenLiberty/openliberty.io/issues/new/choose" target="_blank" rel="noopener">
+                    <a id="github_link" href="https://github.com/OpenLiberty/open-liberty/issues/new/choose" target="_blank" rel="noopener">
                         <div class="github_link_label_container">
                             <div class="button_label">{% t support.open_issue_github %}</div>
                         </div>

--- a/src/main/content/support.html
+++ b/src/main/content/support.html
@@ -115,7 +115,7 @@ seo-description: How to obtain community and commercial support for Open Liberty
         <div class="row">
             <div class="col-xs-12 col-sm-6 col-md-7">
                 <div id="github_link_container">
-                    <a id="github_link" href="https://github.com/OpenLiberty/openliberty.io/issues/new" target="_blank" rel="noopener">
+                    <a id="github_link" href="https://github.com/OpenLiberty/openliberty.io/issues/new/choose" target="_blank" rel="noopener">
                         <div class="github_link_label_container">
                             <div class="button_label">{% t support.open_issue_github %}</div>
                         </div>

--- a/src/main/content/support.html
+++ b/src/main/content/support.html
@@ -115,7 +115,7 @@ seo-description: How to obtain community and commercial support for Open Liberty
         <div class="row">
             <div class="col-xs-12 col-sm-6 col-md-7">
                 <div id="github_link_container">
-                    <a id="github_link" href="https://github.com/OpenLiberty/openliberty.io/issues" target="_blank" rel="noopener">
+                    <a id="github_link" href="https://github.com/OpenLiberty/openliberty.io/issues/new" target="_blank" rel="noopener">
                         <div class="github_link_label_container">
                             <div class="button_label">{% t support.open_issue_github %}</div>
                         </div>


### PR DESCRIPTION
## What was changed and why?

Currently on https://openliberty.io/support/ the Open an issue on GitHub button opens an issue for the website. This should open a new issue for the runtime open-liberty

Created this PR on behalf of @naeemdadi to help get the commits through our internal processes.

## Link GitHub issue
Issue #3017

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
