### PR TITLE
guide codeblock fix

### DIFF
--- a/src/main/content/_assets/css/guide-common.scss
+++ b/src/main/content/_assets/css/guide-common.scss
@@ -211,7 +211,7 @@
 }
 
 /* Create pointed div using pseudo elements */
-#guide_content .code_command > .content {
+#guide_content .code_command > .code_block_wrapper {
   position: relative;
   border-left: 8px solid #96bc32;
   border-top: 1px solid #96bc32;
@@ -235,18 +235,18 @@
   padding-bottom: 10px;
 }
 
-#guide_content .code_command > .content:after,
-#guide_content .code_command > .content:before {
+#guide_content .code_command > .code_block_wrapper:after,
+#guide_content .code_command > .code_block_wrapper:before {
   content: "";
   position: absolute;
   left: 100%;
   width: 40px;
   height: 50.2%;
 }
-#guide_content .code_command > .content:before {
+#guide_content .code_command > .code_block_wrapper:before {
   top: 0px;
 }
-#guide_content .code_command > .content:after {
+#guide_content .code_command > .code_block_wrapper:after {
   bottom: 0px;
 }
 /* End of pointed div */
@@ -492,7 +492,7 @@
     display: none; /* Hide the hotspot snippets in mobile since there is no right pane */
   }
 
-  #guide_content .code_command > .content {
+  #guide_content .code_command > .code_block_wrapper {
     position: relative;
     border-left: 8px solid #96bc32;
     border-top: 1px solid #c8d6fb;
@@ -501,8 +501,8 @@
     margin-bottom: 18px;
   }
 
-  #guide_content .code_command > .content:after,
-  #guide_content .code_command > .content:before {
+  #guide_content .code_command > .code_block_wrapper:after,
+  #guide_content .code_command > .code_block_wrapper:before {
     display: none;
   }
 }


### PR DESCRIPTION
## What was changed and why?
CSS code was changed to apply to all copyable code blocks in guides

## Link GitHub issue
Issue #3049 

## Tested using browser:
- [X] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
