### PR TITLE
remove extra copy button

### DIFF
--- a/src/main/content/_layouts/guide-multipane.html
+++ b/src/main/content/_layouts/guide-multipane.html
@@ -158,13 +158,6 @@ plus: 1 %} {% endif %} {% endfor %}
       <!-- Guide content section -->
       {{ content }}
     </div>
-    <div id="guide_section_copied_confirmation">{% t guides.copied_to_clipboard %}</div>
-    <img
-      id="copy_to_clipboard"
-      src="/img/guides_copy_button.svg"
-      alt="Copy code block"
-      title="Copy code block"
-    />
   </div>
 
   <!-- Code section -->

--- a/src/main/content/_layouts/guide.html
+++ b/src/main/content/_layouts/guide.html
@@ -156,13 +156,6 @@ plus: 1 %} {% endif %} {% endfor %}
         <!-- Guide content section -->
         {{ content }}
       </div>
-      <div id="guide_section_copied_confirmation">{% t guides.copied_to_clipboard %}</div>
-      <img
-        id="copy_to_clipboard"
-        src="/img/guides_copy_button.svg"
-        alt="Copy code block"
-        title="Copy code block"
-      />
     </div>
   </div>
 </div>

--- a/src/main/content/_layouts/iguide-multipane.html
+++ b/src/main/content/_layouts/iguide-multipane.html
@@ -158,13 +158,6 @@ plus: 1 %} {% endif %} {% endfor %}
       <!-- Guide content section -->
       {{ content }}
     </div>
-    <div id="guide_section_copied_confirmation">{% t guides.copied_to_clipboard %}</div>
-    <img
-      id="copy_to_clipboard"
-      src="/img/guides_copy_button.svg"
-      alt="Copy code block"
-      title="Copy code block"
-    />
   </div>
 
   <!-- Code section -->


### PR DESCRIPTION
## What was changed and why?
removed extra copy buttons from layout templates

## Link GitHub issue
Issue #3049 

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
