### PR TITLE
bug fix for guides copy button

### DIFF
--- a/src/main/content/_assets/js/openliberty.js
+++ b/src/main/content/_assets/js/openliberty.js
@@ -62,7 +62,7 @@ var openliberty = (function() {
 
         $(document).on('click', '.copy_to_clipboard', function (event) {
             event.preventDefault();
-            target = $(this).siblings('pre, codeblock');
+            target = $(this).parent().find('pre, codeblock, div.content pre, div.content codeblock');
             openliberty.copy_element_to_clipboard(target, function () {});
             $(this).prev().fadeIn().delay(500).fadeOut()
         });


### PR DESCRIPTION
## What was changed and why?


## Link GitHub issue
Issue #3049 

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
