### PR TITLE
Add one more bullet to support card

### DIFF
--- a/src/main/content/_i18n/en.yml
+++ b/src/main/content/_i18n/en.yml
@@ -138,6 +138,7 @@ start:
     more_downloads_on_the_way: More downloads are on the way.
     check_back_soon: Check back soon!
 support:
+  fixes_for_previous_releases: Fixes for previous releases
   paid_support_includes: "Paid support includes:"
   you_are_not_alone: You are not alone...
   support_for_all_text: Open Liberty is open source and free to use. You can get paid support from IBM.

--- a/src/main/content/_i18n/ja.yml
+++ b/src/main/content/_i18n/ja.yml
@@ -139,6 +139,7 @@ start:
     more_downloads_on_the_way: More downloads are on the way.
     check_back_soon: Check back soon!
 support:
+  fixes_for_previous_releases: Fixes for previous releases
   paid_support_includes: "Paid support includes:"
   you_are_not_alone: You are not alone...
   support_for_all_text: Whether you're an enterprise or a smaller crew, there's Open Liberty support for all

--- a/src/main/content/_i18n/zh-Hans.yml
+++ b/src/main/content/_i18n/zh-Hans.yml
@@ -139,6 +139,7 @@ start:
     more_downloads_on_the_way: More downloads are on the way.
     check_back_soon: Check back soon!
 support:
+  fixes_for_previous_releases: Fixes for previous releases
   paid_support_includes: "Paid support includes:"
   you_are_not_alone: You are not alone...
   support_for_all_text: Whether you're an enterprise or a smaller crew, there's Open Liberty support for all

--- a/src/main/content/support.html
+++ b/src/main/content/support.html
@@ -38,6 +38,7 @@ seo-description: How to obtain community support and paid support from IBM for O
                 <li>{% t support.help %} <a href="https://www.ibm.com/support/pages/node/739151"
                         class="orange_link_light_background">{% t support.business_critical %}</a> {% t support.issues %}
                 </li>
+                <li>{% t support.fixes_for_previous_releases %}</li>
                 <li>{% t support.open_case_chat_phone %}</li>
             </ul>
             <a class="support_link" href="https://www.ibm.com/products/websphere-liberty/pricing" target="_blank" rel="noopener">{% t


### PR DESCRIPTION
## What was changed and why?

Additional bullet point
https://draft-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/support/
<img width="892" alt="image" src="https://user-images.githubusercontent.com/31117513/222825336-7c1f1ffd-b849-43eb-a969-b8b49bb64efc.png">


## Link GitHub issue
Issue #2932

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
