### PR TITLE
3045 sig key

### DIFF
--- a/src/main/content/_i18n/en.yml
+++ b/src/main/content/_i18n/en.yml
@@ -120,8 +120,7 @@ start:
       tests: Tests
       logs: Logs
     releases_content1: New releases will be announced on the Open Liberty
-    releases_content2: In version 22.0.0.1 and later, to verify the authenticity and integrity of an Open Liberty release package, use the provided signature file (SIG) and
-    public_key: public key.
+    releases_content2: In version 22.0.0.1 and later, to verify the authenticity and integrity of an Open Liberty release package, use the provided signature file (SIG) and public key (PEM).
     more_information: For more information, see
     verify_oio_release_packages: Verifying Open Liberty release packages.
     beta_content1: Try out new features in our betas and let us know
@@ -129,7 +128,7 @@ start:
     beta_content3: We publish beta releases to share and obtain early feedback on what the Open Liberty team is actively developing. 
                   Beta content is subject to change and inclusion in a beta does not guarantee inclusion in a GA release. For details about what each beta release includes, check out the 
     beta_content4: beta blog posts.
-    beta_content5: To verify the authenticity and integrity of an Open Liberty release package, use the provided signature file (SIG) and
+    beta_content5: To verify the authenticity and integrity of an Open Liberty release package, use the provided signature file (SIG) and public key (PEM).
     nightly_builds_content: Nightly builds contain in-development features, have not gone through the full release process and are potentially unstable.
     eclipse_developer_tools_content1: We recommend IDE tools based on Eclipse since it gives you an integrated environment right out of the box.
     eclipse_developer_tools_content2: Learn how to install the tools here.

--- a/src/main/content/start.html
+++ b/src/main/content/start.html
@@ -230,10 +230,7 @@ seo-description: Use Maven or Gradle to create a starter application for develop
                             {% t global.and %} <a href="https://twitter.com/OpenLibertyIO" target="_blank" rel="noopener" class="orange_link_light_background">{% t global.twitter %}</a>.
                             <br/>
                             <br/>
-                            {% t start.download_package_section.releases_content2 %} 
-                            <a href="https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/sign/public_keys/WebSphereLiberty_06-02-2021.pem" class="orange_link_light_background">
-                                {% t start.download_package_section.public_key %}
-                            </a>
+                            {% t start.download_package_section.releases_content2 %}
                             {% t start.download_package_section.more_information %} 
                             <a href="{{baseURL}}/docs/latest/verifying-package-signatures.html"
                             class="blue_link_light_background_external">{% t start.download_package_section.verify_oio_release_packages %}</a>
@@ -270,10 +267,7 @@ seo-description: Use Maven or Gradle to create a starter application for develop
                             <a href="{{baseURL}}/blog/?search=beta&key=tag" class="blue_link_light_background_external">{% t start.download_package_section.beta_content4 %}</a>
                             <br/>
                             <br/>
-                            {% t start.download_package_section.beta_content5 %} 
-                            <a href="https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/sign/public_keys/WebSphereLiberty_06-02-2021.pem" class="orange_link_light_background">
-                                {% t start.download_package_section.public_key %}
-                            </a>
+                            {% t start.download_package_section.beta_content5 %}
                             {% t start.download_package_section.more_information %} 
                             <a href="{{baseURL}}/docs/latest/verifying-package-signatures.html"
                             class="blue_link_light_background_external">{% t start.download_package_section.verify_oio_release_packages %}</a>

--- a/src/main/content/start.html
+++ b/src/main/content/start.html
@@ -242,7 +242,7 @@ seo-description: Use Maven or Gradle to create a starter application for develop
                                         <th id="runtime_releases_version" class="version_column"><a href="" data-key="version" data-descending="true" class="functional_link sort_link">{% t start.download_package_section.table_header.version %}</a></th>
                                         <th id="runtime_releases_package" class="package_name_column">{% t start.download_package_section.table_header.package %}</th>
                                         <th id="runtime_releases_download" class="download_button_column">{% t start.download_package_section.table_header.download %}</th>
-                                        <th id="runtime_releases_verification" class="download_button_column">{% t start.download_package_section.table_header.verification %}</th>
+                                        <th id="runtime_releases_verification" class="download_button_column" colspan="2">{% t start.download_package_section.table_header.verification %}</th>
                                     </tr>
                                 </thead>
                                 <tbody class="release_table_body">
@@ -279,7 +279,7 @@ seo-description: Use Maven or Gradle to create a starter application for develop
                                         <th id="runtime_betas_version" class="version_column"><a href="" data-key="version" data-descending="true" class="functional_link sort_link">{% t start.download_package_section.table_header.version %}</a></th>
                                         <th id="runtime_betas_package" class="package_name_column">{% t start.download_package_section.table_header.package %}</th>
                                         <th id="runtime_betas_download" class="download_button_column">{% t start.download_package_section.table_header.download %}</th>
-                                        <th id="runtime_betas_verification" class="download_button_column">{% t start.download_package_section.table_header.verification %}</th>
+                                        <th id="runtime_betas_verification" class="download_button_column" colspan="2">{% t start.download_package_section.table_header.verification %}</th>
                                     </tr>
                                 </thead>
                                 <tbody class="release_table_body">


### PR DESCRIPTION
## What was changed and why?

There is a new public key used for signing builds starting with 23.0.0.2 and onwards. We need to continue providing the public key for builds older than 23.0.0.2.

## Link GitHub issue
Issue #3045

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
