### PR TITLE
Update production - New public key for verifying signatures

### DIFF
--- a/src/main/content/_assets/js/builds.js
+++ b/src/main/content/_assets/js/builds.js
@@ -131,7 +131,7 @@ function getPublicKeyURL(liberty_version) {
     "https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/sign/public_keys/WebSphereLiberty_06-02-2021.pem";
     
     const pem_2023_href =
-    "https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/sign/public_keys/WebSphereLiberty_02-13-2023.pem";
+    "https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/sign/public_keys/OpenLiberty_02-13-2023.pem";
 
     if(liberty_versions_using_2021_pem.indexOf(liberty_version) > -1) {
         return pem_2021_href;


### PR DESCRIPTION
## What was changed and why?

Use new public key for verifying signatures for 23.0.0.2 and newer. No longer use file extension `.cosign.sig` for signature files. Use `.sig`

Tested on 
- https://ui-draft-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/start/
- https://ui-staging-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/start/

## Link GitHub issue
Issue #3089 

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
