### PR TITLE
3099 gitter link fix

### DIFF
--- a/src/main/content/support.html
+++ b/src/main/content/support.html
@@ -97,7 +97,7 @@ seo-description: How to obtain community support and paid support from IBM for O
                 </div>
 
                 <div class="col-md-6 col-lg-3 card_column">
-                    <a href="https://gitter.im/OpenLiberty/" class="card" target="_blank" rel="noopener">
+                    <a href="https://app.gitter.im/#/room/#OpenLiberty_development:gitter.im" class="card" target="_blank" rel="noopener">
                         <figure aria-labelledby="gitter_logo" id="gitter_logo_background" class="card_gradient_background">
                             <img id="gitter_logo" src="/img/gitter_logo.svg" class="d-block mx-auto" alt="gitter">
                         </figure>


### PR DESCRIPTION
## What was changed and why?
Looks good on draft: https://ui-draft-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/support/

## Link GitHub issue
Issue #3099 

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
