### PR TITLE
Remove issue section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,5 @@
 ## What was changed and why?
 
-
-## Link GitHub issue
-Issue #
-
 ## Tested using browser:
 - [ ] Firefox (Desktop)
 - [ ] Safari (Desktop)


### PR DESCRIPTION
- Favor using the `Development` section in a pull request to link to an issue. This linkage will also show up in GitHub Projects.

- If the pull request needs to link to issue in another repository, the author will need to fallback to using the issue description containing a full URL to the issue.

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
