### PR TITLE
fixing test for ee10 and mp6

### DIFF
--- a/src/test/cypressjs/cypress.env.json
+++ b/src/test/cypressjs/cypress.env.json
@@ -1,8 +1,8 @@
 {
-  "default_website_url": "https://staging-openlibertyio.mybluemix.net",
+  "default_website_url": "https://staging-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud",
   "default_jdk": "11",
-  "jdk_17_home": "/Library/Java/JavaVirtualMachines/ibm-semeru-open-17.jdk/Contents/Home",
-  "jdk_11_home": "/Library/Java/JavaVirtualMachines/ibm-semeru-open-11.jdk/Contents/Home",
+  "jdk_17_home": "/Library/Java/JavaVirtualMachines/ibm-semeru-certified-17.jdk/Contents/Home",
+  "jdk_11_home": "/Library/Java/JavaVirtualMachines/ibm-semeru-certified-11.jdk/Contents/Home",
   "jdk_8_home": "/Library/Java/JavaVirtualMachines/jdk1.8.0_311.jdk/Contents/Home",
   "redirects_url": "https://raw.githubusercontent.com/OpenLiberty/docs-playbook/prod/doc-redirects.properties"
 }

--- a/src/test/cypressjs/cypress/integration/testRuntimeReleaseVersions.js
+++ b/src/test/cypressjs/cypress/integration/testRuntimeReleaseVersions.js
@@ -8,19 +8,35 @@ describe('Test that all runtime release versions are in the correct custom order
         let packages = [];
         let listOfPackLists = [[]];
         let currInd = 0;
+
+        // This list has to be updated whenever new levels are added, basically just make sure that
+        // the order represents the top to bottom order in terms of what would be listed first
+        // for example Jakarta EE 8 is never listed higher than Web Profile 9 and MicroProfile 5 but always 
+        // higher than MicroProfile 4 and Web Profile 8
+        
         let orderGuide = [
-            "Jakarta EE 9",
-            "Web Profile 9",
+            "Jakarta EE 10",
+            "Jakarta EE 9",          
+            "Web Profile 10",
+            "Web Profile 9",           
+            "MicroProfile 6",
             "MicroProfile 5",
             "Jakarta EE 8",
-            "Java EE 8",
-            "Web Profile 8",
+            "Web Profile 8",            
             "MicroProfile 4",
-            "MicroProfile 3",
             "Kernel",
             "All GA Features"]
         cy.get("td[headers='runtime_releases_package']").each((elm, i) => {
-            packages.push(elm.text());
+            if (elm.text().includes("Jakarta EE 10")) {              
+                packages.push("Jakarta EE 10");
+            } else {
+               if (elm.text().includes("Jakarta EE 8")) {               
+                packages.push("Jakarta EE 8");
+               } else {
+                packages.push(elm.text());
+               }
+            }   
+           
             if(elm.text() === "All GA Features"){
                 ind.push(i);
             }
@@ -34,7 +50,7 @@ describe('Test that all runtime release versions are in the correct custom order
             }
             listOfPackLists.pop()
         }).then(() => {
-            listOfPackLists.forEach((item) => {
+             listOfPackLists.forEach((item) => {
                 for(let i = 0; i < item.length-1; i++){
                     let itemIndex = orderGuide.indexOf(item[i]);
                     let nextItemIndex = orderGuide.indexOf(item[i+1]);


### PR DESCRIPTION
## What was changed and why?

Test needed to be updated since the releases now include EE10 and MP6. I had to modify slightly because the two new releases include an informational icon that screws up the string for cypress. I also updated the cypress.env.json file to point to the correct staging site on codeengine. 

## Tested using browser:

- [ ] Chrome (Desktop)
