### PR TITLE
updated font-size to 16px from 14px

### DIFF
--- a/src/main/content/_assets/css/post.scss
+++ b/src/main/content/_assets/css/post.scss
@@ -543,3 +543,7 @@ iframe{
         }
     }
 }
+
+div.sectionbody div.ulist > ul > li p{
+    font-size: 16px;
+}


### PR DESCRIPTION
## What was changed and why?
List continuation text had smaller font size than principal text on blog posts. So this font size was updated from 14px to 16px on post.scss .

Details of issue: [https://github.com/OpenLiberty/openliberty.io/issues/3076](url)

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
