### PR TITLE
set max height for code block

### DIFF
--- a/src/main/content/antora_ui/src/css/doc.css
+++ b/src/main/content/antora_ui/src/css/doc.css
@@ -496,8 +496,9 @@
   /* box-shadow: inset 0 0 1.75px var(--pre-border-color); */
   /* border: 1px solid silver; */
   display: block;
-  overflow-x: auto;
+  overflow: auto;
   padding: 0.75rem;
+  max-height: 500px;
 }
 
 /* NOTE assume pre.highlight contains code[data-lang] */


### PR DESCRIPTION
## What was changed and why?
Implemented a maximum height for code blocks in docs to prevent source blocks from taking up too much vertical space

## Tested using browser:
- [X] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
