### PR TITLE
Update add-to-projects.yml

### DIFF
--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -5,9 +5,6 @@ on:
     types:
       - opened
       - transferred
-  pull_request:
-    types:
-      - opened
 
 jobs:
   add-to-project:


### PR DESCRIPTION
Stop adding opened pull requests to GH Projects Kanban board

## What was changed and why?

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
