### PR TITLE
updated font-size to 16px from 14px

### DIFF
--- a/src/main/content/_assets/css/post.scss
+++ b/src/main/content/_assets/css/post.scss
@@ -543,3 +543,7 @@ iframe{
         }
     }
 }
+
+div.sectionbody div.ulist > ul > li p{
+    font-size: 16px;
+}


### PR DESCRIPTION
## What was changed and why?
Text inside List continuation had font-size of 14px. This font-size was updated to 16px.

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
