### PR TITLE
let draft site use the staging starter to avoid backports

### DIFF
--- a/src/main/content/_assets/js/builds.js
+++ b/src/main/content/_assets/js/builds.js
@@ -21,7 +21,7 @@ var versArr = [];
 
 var builds_url = '/api/builds/data';
 var starter_domain = 
-    isStagingSite() ? 'https://starter-staging.rh9j6zz75er.us-east.codeengine.appdomain.cloud' : 'https://start.openliberty.io';
+    isNotProdSite() ? 'https://starter-staging.rh9j6zz75er.us-east.codeengine.appdomain.cloud' : 'https://start.openliberty.io';
 var starter_info_url = starter_domain + '/api/start/info';
 var starter_submit_url = starter_domain + '/api/start';
 var failed_builds_request = false;
@@ -83,9 +83,14 @@ if (site_lang != 'en') {
     baseURL = '/'+site_lang;
 }
 
-function isStagingSite() {
+function isNotProdSite() {
+    // both staging and draft will point to the staging branch of the starter repo
     var host = window.location.hostname;
-    return host.indexOf('staging') > -1;
+    if ((host.indexOf('staging') > -1) || (host.indexOf('draft') > -1)) {
+        return true;
+    } else {
+        return false;
+    }
 }
 
 /**


### PR DESCRIPTION
change draft site to use the staging starter to avoid situations where we would have to backport to draft to make things match after testing them in staging