### PR TITLE
Indented command and code block in guides

### DIFF
--- a/src/main/content/_assets/css/guide-multipane-static.scss
+++ b/src/main/content/_assets/css/guide-multipane-static.scss
@@ -145,9 +145,4 @@
     padding-left: 24px;
     padding-right: 18px;
   }
-
-  .listingblock {
-    margin-left: -24px;
-    margin-right: -18px;
-  }
 }


### PR DESCRIPTION
## Removed the .listingblock under @media(max-width: 899.98px) in guide-multipage-static.scss 

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
