### PR TITLE
Container images were updated to latest Open Liberty version 23.0.0.5

### DIFF
--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -49,7 +49,7 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 package
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:23.0.0.2-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:23.0.0.5-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY src/main/wlp/server.xml /config/server.xml

--- a/docker/Dockerfile.draft
+++ b/docker/Dockerfile.draft
@@ -50,7 +50,7 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 package
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:23.0.0.2-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:23.0.0.5-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY src/main/wlp/server.xml /config/server.xml

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -53,7 +53,7 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 package
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:23.0.0.2-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:23.0.0.5-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY src/main/wlp/server.xml /config/server.xml

--- a/docker/Dockerfile.staging
+++ b/docker/Dockerfile.staging
@@ -50,7 +50,7 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 package
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:23.0.0.2-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:23.0.0.5-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY src/main/wlp/server.xml /config/server.xml

--- a/docker/blogs/Dockerfile.blogs.draft
+++ b/docker/blogs/Dockerfile.blogs.draft
@@ -42,7 +42,7 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 package
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:23.0.0.2-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:23.0.0.5-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY src/main/wlp/server.xml /config/server.xml

--- a/docker/blogs/Dockerfile.blogs.staging
+++ b/docker/blogs/Dockerfile.blogs.staging
@@ -42,7 +42,7 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 package
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:23.0.0.2-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:23.0.0.5-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY src/main/wlp/server.xml /config/server.xml

--- a/docker/certifications/Dockerfile.certifications.draft
+++ b/docker/certifications/Dockerfile.certifications.draft
@@ -42,7 +42,7 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 package
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:23.0.0.2-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:23.0.0.5-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY src/main/wlp/server.xml /config/server.xml

--- a/docker/certifications/Dockerfile.certifications.staging
+++ b/docker/certifications/Dockerfile.certifications.staging
@@ -42,7 +42,7 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 package
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:23.0.0.2-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:23.0.0.5-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY src/main/wlp/server.xml /config/server.xml

--- a/docker/docs/Dockerfile.docs.draft
+++ b/docker/docs/Dockerfile.docs.draft
@@ -54,7 +54,7 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 package
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:23.0.0.2-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:23.0.0.5-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY src/main/wlp/server.xml /config/server.xml

--- a/docker/docs/Dockerfile.docs.staging
+++ b/docker/docs/Dockerfile.docs.staging
@@ -54,7 +54,7 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 package
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:23.0.0.2-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:23.0.0.5-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY src/main/wlp/server.xml /config/server.xml

--- a/docker/guides/Dockerfile.guides.draft
+++ b/docker/guides/Dockerfile.guides.draft
@@ -42,7 +42,7 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 package
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:23.0.0.2-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:23.0.0.5-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY src/main/wlp/server.xml /config/server.xml

--- a/docker/guides/Dockerfile.guides.staging
+++ b/docker/guides/Dockerfile.guides.staging
@@ -42,7 +42,7 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 package
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:23.0.0.2-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:23.0.0.5-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY src/main/wlp/server.xml /config/server.xml

--- a/docker/ui-only/Dockerfile.ui-only
+++ b/docker/ui-only/Dockerfile.ui-only
@@ -41,7 +41,7 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 package
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:23.0.0.2-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:23.0.0.5-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY src/main/wlp/server.xml /config/server.xml


### PR DESCRIPTION
## What was changed and why?
Container images were updated to latest Open Liberty version 23.0.0.5


## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
