### PR TITLE
Indented command and code block in guide

### DIFF
--- a/src/main/content/_assets/css/guide-multipane-static.scss
+++ b/src/main/content/_assets/css/guide-multipane-static.scss
@@ -145,9 +145,4 @@
     padding-left: 24px;
     padding-right: 18px;
   }
-
-  .listingblock {
-    margin-left: -24px;
-    margin-right: -18px;
-  }
 }


### PR DESCRIPTION
## What was changed and why?

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
