### PR TITLE
Update Dockerfile.staging - Test skipping war bundling step

### DIFF
--- a/docker/Dockerfile.staging
+++ b/docker/Dockerfile.staging
@@ -45,7 +45,7 @@ COPY .mvn /.mvn
 COPY pom.xml /
 COPY --from=docs --chown=1001:0 /src /src
 COPY --from=docs --chown=1001:0 /target /target
-RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 package
+RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 compile war:exploded
 
 #
 #


### PR DESCRIPTION
The container images already use the exploded war. Skip over the war bundling step.

## What was changed and why?
For #1550 

Tested using `ui-only` container image on local machine. Website renders fine.

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
