### PR TITLE
Fix csp and horizontal scroll toc

### DIFF
--- a/src/main/content/antora_ui/src/sass/nav.scss
+++ b/src/main/content/antora_ui/src/sass/nav.scss
@@ -83,10 +83,13 @@ html.is-clipped--nav {
 .nav-panel-menu::-webkit-scrollbar,
 .nav-panel-explore .components::-webkit-scrollbar {
   width: 0.25rem;
+  height: 0.25rem;
 }
 
 .nav-panel-menu::-webkit-scrollbar-thumb,
-.nav-panel-explore .components::-webkit-scrollbar-thumb {
+.nav-panel-menu::-webkit-scrollbar-thumb:horizontal,
+.nav-panel-explore .components::-webkit-scrollbar-thumb,
+.nav-panel-explore .components::-webkit-scrollbar-thumb:horizontal {
   background-color: var(--nav-border-color);
 }
 

--- a/src/main/java/io/openliberty/website/TLSFilter.java
+++ b/src/main/java/io/openliberty/website/TLSFilter.java
@@ -71,7 +71,7 @@ public class TLSFilter implements Filter {
             response.setHeader("X-Content-Type-Options", "nosniff");
              // Mitigating cross site scripting (XSS) from other domains.
             response.setHeader("Content-Security-Policy",
-                    "default-src 'self' 'unsafe-inline' 'unsafe-eval' cdn.jsdelivr.net fonts.googleapis.com ajax.googleapis.com code.jquery.com fonts.gstatic.com  *.githubusercontent.com api.github.com www.googletagmanager.com tagmanager.google.com www.google-analytics.com cdnjs.cloudflare.com data: buttons.github.io www.youtube.com *.twitter.com *.twimg.com video.ibm.com https://start.openliberty.io/ gitlab.com starter-staging.rh9j6zz75er.us-east.codeengine.appdomain.cloud");
+                    "default-src 'self' 'unsafe-inline' 'unsafe-eval' cdn.jsdelivr.net fonts.googleapis.com ajax.googleapis.com code.jquery.com fonts.gstatic.com  *.githubusercontent.com api.github.com www.googletagmanager.com tagmanager.google.com www.google-analytics.com cdnjs.cloudflare.com data: buttons.github.io www.youtube.com *.twitter.com *.twimg.com video.ibm.com https://start.openliberty.io/ gitlab.com starter-staging.rh9j6zz75er.us-east.codeengine.appdomain.cloud https://docs.oracle.com/javase/8/docs/api/");
 
             // Limits the information sent cross-domain and does not send the origin name.
             response.setHeader("Referrer-Policy", "no-referrer");


### PR DESCRIPTION
this fix in api/spi javadocs
1. Update CSP to allow links out to oracle's javadocs for Java SE classes/methods
![image](https://github.com/OpenLiberty/openliberty.io/assets/30509453/59ee556b-b9c7-4a2f-bbcd-0792b447a69e)

2. Make the horizonal scroll bar the same width as the vertical bar in the TOC
![image](https://github.com/OpenLiberty/openliberty.io/assets/30509453/6c6e0d58-6e83-4e10-92b8-d95d8f029564)

