### PR TITLE
Add copy message to code pane in guides

### DIFF
--- a/src/main/content/_assets/css/guide-common.scss
+++ b/src/main/content/_assets/css/guide-common.scss
@@ -413,8 +413,8 @@
   display: none;
   font-size: 11px;
   color: #5e6b8d;
-  width: fit-content;
-  top: -15px;
+  width: 100px;
+  top: 40px;
   right: 0px;
 }
 

--- a/src/main/content/_assets/css/post.scss
+++ b/src/main/content/_assets/css/post.scss
@@ -150,7 +150,7 @@ body {
     margin-bottom: 8px;
 }
 
-#article_body a {
+#article_body a{
     font-weight: 500;
     color: #546FB5;
     transition: color .2s;
@@ -159,7 +159,15 @@ body {
         color: #6787D9;
     }
 }
+#article_body a.external {
+    font-weight: 500;
+    color: #CC4D19;
+    transition: color .2s;
 
+    &:hover {
+        color: #F4914D;
+    }
+  }
 .author_images_container {
     display: inline-block;
     margin-right: 6px;

--- a/src/main/content/_assets/js/post.js
+++ b/src/main/content/_assets/js/post.js
@@ -47,4 +47,15 @@ $(document).ready(function () {
     $('.code_block_wrapper').each(function (){
         $(this).prepend('<div class="copied_confirmation">Copied to clipboard</div><input type="image" class="copy_to_clipboard" src="/img/guides_copy_button.svg" alt="Copy code block" title="Copy code block"/>');
     });
+
+    $('#article_body a').each(function() {
+        var link = $(this);
+        if (link.prop('hostname') === window.location.hostname) {
+         void(0);
+        } else {
+          link.addClass('external');
+        }
+      });
 })
+
+

--- a/src/main/content/_layouts/guide-multipane.html
+++ b/src/main/content/_layouts/guide-multipane.html
@@ -167,6 +167,7 @@ plus: 1 %} {% endif %} {% endfor %}
         <ul id="code_column_tabs" class="nav" role="tablist"></ul>
       </div>
       <div class="copyFileButton" tabindex="0">
+        <div id="code_section_copied_confirmation">Copied to clipboard</div>
         <img
           src="/img/guides_copy_button.svg"
           alt="Copy file contents"


### PR DESCRIPTION
Added a copied message confirmation text to the code pane in guides
## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
