### PR TITLE
Copy confirmation added

### DIFF
--- a/src/main/content/_assets/css/guide-common.scss
+++ b/src/main/content/_assets/css/guide-common.scss
@@ -413,7 +413,7 @@
   display: none;
   font-size: 11px;
   color: #5e6b8d;
-  width: fit-content;
+  width: 100px;
   top: -15px;
   right: 0px;
 }

--- a/src/main/content/_assets/js/guide-multipane-static.js
+++ b/src/main/content/_assets/js/guide-multipane-static.js
@@ -890,7 +890,6 @@ $(document).ready(function () {
             $("#code_section_copied_confirmation")
                 .css({
                     top: position.top + 42,
-                    right: 25,
                 })
                 .stop()
                 .fadeIn()

--- a/src/main/content/_layouts/guide-multipane.html
+++ b/src/main/content/_layouts/guide-multipane.html
@@ -172,6 +172,7 @@ plus: 1 %} {% endif %} {% endfor %}
           alt="Copy file contents"
           title="Copy file contents"
         />
+        <div id="code_section_copied_confirmation">Copied to clipboard </div>
       </div>
     </div>
     <div id="code_column_content"></div>


### PR DESCRIPTION
Added the "Copied to clipboard" message for the copy button in code section of guides

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
