### PR TITLE
Line under tabs in /start is wider #3263

### DIFF
--- a/src/main/content/_assets/css/start.scss
+++ b/src/main/content/_assets/css/start.scss
@@ -477,6 +477,8 @@ html, body {
 .tabs_container {
     border-bottom: 4px solid rgba(200, 210, 210, 0.41);
     margin-bottom: 41px;
+    margin-left:unset;
+    margin-right: unset;
     & .nav-tabs {
         border-bottom: 1px solid #FFFFFF;
         & > .nav-item > .nav-link {


### PR DESCRIPTION
## What was changed and why?
The line under the tabs in /start is wider then its parent elements #3263

To solve this margin left and margin right under tabs_container was updated to `unset`.

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
