### PR TITLE
Update production

### DIFF
--- a/src/main/content/_assets/css/guide-card.css
+++ b/src/main/content/_assets/css/guide-card.css
@@ -93,9 +93,9 @@
 }
 
 .guide_deprecated_container{
-    border: 1px solid #4F660A;
+    border: 1px solid #24253A;
 }
 
 .guide_deprecated{
-    color: #4F660A;
+    color: #24253A;
 }

--- a/src/main/content/_assets/css/guide-card.css
+++ b/src/main/content/_assets/css/guide-card.css
@@ -84,7 +84,7 @@
     letter-spacing: 0;
 }
 
-.guide_interactive, .guide_new, .guide_updated, .guide_run_in_cloud {
+.guide_interactive, .guide_new, .guide_updated, .guide_run_in_cloud, .guide_deprecated {
     font-family: BunueloBold, Arial Narrow, Helvetica, Arial;
     font-size: 13px;
     color: #CC4D19;

--- a/src/main/content/_assets/css/guide-card.css
+++ b/src/main/content/_assets/css/guide-card.css
@@ -64,7 +64,7 @@
     line-height: 21px;
 }
 
-.guide_interactive_container, .new_guide_container, .updated_guide_container, .guide_run_in_cloud_container {
+.guide_interactive_container, .new_guide_container, .updated_guide_container, .guide_run_in_cloud_container, .guide_deprecated_container {
     border: 1px solid #CC4D19;
     border-radius: 100px;
     float: right;

--- a/src/main/content/_assets/css/guide-card.css
+++ b/src/main/content/_assets/css/guide-card.css
@@ -91,3 +91,11 @@
     letter-spacing: 0;
     text-transform: uppercase;
 }
+
+.guide_deprecated_container{
+    border: 1px solid #4F660A;
+}
+
+.guide_deprecated{
+    color: #4F660A;
+}

--- a/src/main/content/_assets/css/guide-common.scss
+++ b/src/main/content/_assets/css/guide-common.scss
@@ -547,6 +547,7 @@
     margin-top: 2px;
     font-size: 16px;
     text-align: center;
+    margin-left: -5px;
 
     em{
       font-style: normal;
@@ -565,6 +566,6 @@
   height: 12px;
   width: auto;
   position: absolute;
-  left: 0;
+  right: 10px;
   top: 0;
 }

--- a/src/main/content/_assets/css/guide-common.scss
+++ b/src/main/content/_assets/css/guide-common.scss
@@ -530,7 +530,7 @@
 }
 
 #deprecated_notification{
-  background: #F4914D;
+  background: #E6EDA8;
   height: 50px;
   width: 100%;
   position: relative;
@@ -538,10 +538,12 @@
   padding: 10px;
   display: flex;
   align-items: center;
-  font-family: BunueloBold, Arial Narrow, Helvetica, Arial;
+  font-weight: 600;
+  // font-family: BunueloBold, Arial Narrow, Helvetica, Arial;
+  border-bottom: 2px solid #96BC32;
   p {
+    margin-bottom: -3px;
     padding: 20px;
-    margin: 0;
     font-size: 18px;
 
     em{

--- a/src/main/content/_assets/css/guide-common.scss
+++ b/src/main/content/_assets/css/guide-common.scss
@@ -378,9 +378,11 @@
 }
 
 #guide_content > .sect1 {
-  -webkit-box-shadow: 0px 5px 11px -3px rgba(0, 0, 0, 0.27);
-  -moz-box-shadow: 0px 5px 11px -3px rgba(0, 0, 0, 0.27);
-  box-shadow: 0px 5px 11px -3px rgba(0, 0, 0, 0.27);
+  @media (max-width: 1170px){
+    -webkit-box-shadow: 0px 5px 11px -3px rgba(0, 0, 0, 0.27);
+    -moz-box-shadow: 0px 5px 11px -3px rgba(0, 0, 0, 0.27);
+    box-shadow: 0px 5px 11px -3px rgba(0, 0, 0, 0.27);
+  }
 }
 
 #all_guides_link {

--- a/src/main/content/_assets/css/guide-common.scss
+++ b/src/main/content/_assets/css/guide-common.scss
@@ -536,12 +536,12 @@
   width: 100%;
   position: relative;
   z-index: 8;
-  padding: 10px;
+  padding-top: 10px;
   border-bottom: 2px solid #96BC32;
   border-top: 2px solid #96BC32;
   p {
     font-weight: 500;
-    margin: 0;
+    margin-top: 2px;
     font-size: 16px;
     text-align: center;
 
@@ -558,10 +558,10 @@
 .notification_x{
   cursor: pointer;
   z-index: 8;
-  margin: 7px 7px 0px 0px;
+  margin: 7px 0px 0px 7px;
   height: 12px;
   width: auto;
   position: absolute;
-  right: 0;
+  left: 0;
   top: 0;
 }

--- a/src/main/content/_assets/css/guide-common.scss
+++ b/src/main/content/_assets/css/guide-common.scss
@@ -543,7 +543,7 @@
     font-weight: 600;
     margin-bottom: -3px;
     padding: 20px;
-    font-size: 14px;
+    font-size: 16px;
 
     em{
       font-style: normal;

--- a/src/main/content/_assets/css/guide-common.scss
+++ b/src/main/content/_assets/css/guide-common.scss
@@ -360,7 +360,7 @@
   min-height: 600px;
   background-repeat: no-repeat;
   margin-bottom: 100px;
-  overflow: hidden;
+  // overflow: hidden;
 }
 
 #toc_inner {
@@ -532,10 +532,12 @@
 // deprecated guide css
 #deprecated_notification{
   background: #E6EDA8;
-  height: 50px;
+  height: auto;
   width: 100%;
-  position: relative;
-  z-index: 8;
+  position: sticky;
+  top: 0;
+  z-index: 6;
+  transition: top .3s ease-in-out;
   padding-top: 10px;
   border-bottom: 2px solid #96BC32;
   border-top: 2px solid #96BC32;

--- a/src/main/content/_assets/css/guide-common.scss
+++ b/src/main/content/_assets/css/guide-common.scss
@@ -541,6 +541,11 @@
   p {
     padding: 20px;
     margin: 0;
+
+    em{
+      font-style: normal;
+      font-weight: bolder;
+    }
   }
   a {
     text-decoration: underline !important;

--- a/src/main/content/_assets/css/guide-common.scss
+++ b/src/main/content/_assets/css/guide-common.scss
@@ -543,14 +543,10 @@
   border-top: 2px solid #96BC32;
   p {
     font-weight: 500;
-    margin-top: 2px;
-    font-size: 16px;
     text-align: center;
-    margin-left: -5px;
-    @media (min-width: 1440px){
-      width: 90%;
-    }
-
+    margin: auto;
+    width: 90%;
+    padding-bottom: 10px;
     em{
       font-style: normal;
     }

--- a/src/main/content/_assets/css/guide-common.scss
+++ b/src/main/content/_assets/css/guide-common.scss
@@ -530,7 +530,7 @@
 }
 
 #deprecated_notification{
-  background: #E6EDA8;
+  background: #F7FFB3;
   height: 50px;
   width: 100%;
   position: relative;
@@ -538,13 +538,16 @@
   padding: 10px;
   display: flex;
   align-items: center;
+  font-family: BunueloLight, Arial Narrow, Helvetica, Arial;
   p {
     padding: 20px;
     margin: 0;
+    font-size: 18px;
+    font-weight: 600;
 
     em{
       font-style: normal;
-      font-weight: bolder;
+      font-weight: 800;
     }
   }
   a {

--- a/src/main/content/_assets/css/guide-common.scss
+++ b/src/main/content/_assets/css/guide-common.scss
@@ -528,3 +528,27 @@
     width: 394px;
   }
 }
+
+#deprecated_notification{
+  background: #e6eda8;
+  height: 50px;
+  width: 100%;
+  position: relative;
+  z-index: 8;
+  padding: 10px;
+  display: flex;
+  align-items: center;
+  p {
+    padding: 20px;
+    margin: 0;
+  }
+  a {
+    text-decoration: underline !important;
+    color: #24243B;
+  }
+}
+
+.notification_x{
+  cursor: pointer;
+  margin-left: 20px;
+}

--- a/src/main/content/_assets/css/guide-common.scss
+++ b/src/main/content/_assets/css/guide-common.scss
@@ -530,7 +530,7 @@
 }
 
 #deprecated_notification{
-  background: #F7FFB3;
+  background: #F4914D;
   height: 50px;
   width: 100%;
   position: relative;
@@ -538,16 +538,14 @@
   padding: 10px;
   display: flex;
   align-items: center;
-  font-family: BunueloLight, Arial Narrow, Helvetica, Arial;
+  font-family: BunueloBold, Arial Narrow, Helvetica, Arial;
   p {
     padding: 20px;
     margin: 0;
     font-size: 18px;
-    font-weight: 600;
 
     em{
       font-style: normal;
-      font-weight: 800;
     }
   }
   a {

--- a/src/main/content/_assets/css/guide-common.scss
+++ b/src/main/content/_assets/css/guide-common.scss
@@ -360,7 +360,6 @@
   min-height: 600px;
   background-repeat: no-repeat;
   margin-bottom: 100px;
-  // overflow: hidden;
 }
 
 #toc_inner {

--- a/src/main/content/_assets/css/guide-common.scss
+++ b/src/main/content/_assets/css/guide-common.scss
@@ -529,6 +529,7 @@
   }
 }
 
+// deprecated guide css
 #deprecated_notification{
   background: #E6EDA8;
   height: 50px;
@@ -536,14 +537,13 @@
   position: relative;
   z-index: 8;
   padding: 10px;
-  display: flex;
-  align-items: center;
   border-bottom: 2px solid #96BC32;
   border-top: 2px solid #96BC32;
   p {
     font-weight: 500;
-    margin-bottom: -1px;
+    margin: 0;
     font-size: 16px;
+    text-align: center;
 
     em{
       font-style: normal;
@@ -557,8 +557,11 @@
 
 .notification_x{
   cursor: pointer;
-  margin-right: 10px;
-  height: 10px;
+  z-index: 8;
+  margin: 7px 7px 0px 0px;
+  height: 12px;
   width: auto;
-  padding-left: 5px;
+  position: absolute;
+  right: 0;
+  top: 0;
 }

--- a/src/main/content/_assets/css/guide-common.scss
+++ b/src/main/content/_assets/css/guide-common.scss
@@ -563,9 +563,9 @@
   cursor: pointer;
   z-index: 8;
   margin: 7px 0px 0px 7px;
-  height: 12px;
+  height: 18px;
   width: auto;
   position: absolute;
   right: 10px;
-  top: 0;
+  top: 5px;
 }

--- a/src/main/content/_assets/css/guide-common.scss
+++ b/src/main/content/_assets/css/guide-common.scss
@@ -547,6 +547,9 @@
     font-size: 16px;
     text-align: center;
     margin-left: -5px;
+    @media (min-width: 1440px){
+      width: 90%;
+    }
 
     em{
       font-style: normal;

--- a/src/main/content/_assets/css/guide-common.scss
+++ b/src/main/content/_assets/css/guide-common.scss
@@ -540,9 +540,8 @@
   align-items: center;
   border-bottom: 2px solid #96BC32;
   p {
-    font-weight: 600;
-    margin-bottom: -3px;
-    padding: 20px;
+    font-weight: 500;
+    margin-bottom: -1px;
     font-size: 16px;
 
     em{
@@ -557,5 +556,8 @@
 
 .notification_x{
   cursor: pointer;
-  margin-left: 10px;
+  margin-right: 10px;
+  height: 10px;
+  width: auto;
+  padding-left: 5px;
 }

--- a/src/main/content/_assets/css/guide-common.scss
+++ b/src/main/content/_assets/css/guide-common.scss
@@ -538,13 +538,12 @@
   padding: 10px;
   display: flex;
   align-items: center;
-  font-weight: 600;
-  // font-family: BunueloBold, Arial Narrow, Helvetica, Arial;
   border-bottom: 2px solid #96BC32;
   p {
+    font-weight: 600;
     margin-bottom: -3px;
     padding: 20px;
-    font-size: 18px;
+    font-size: 14px;
 
     em{
       font-style: normal;
@@ -558,5 +557,5 @@
 
 .notification_x{
   cursor: pointer;
-  margin-left: 20px;
+  margin-left: 10px;
 }

--- a/src/main/content/_assets/css/guide-common.scss
+++ b/src/main/content/_assets/css/guide-common.scss
@@ -530,7 +530,7 @@
 }
 
 #deprecated_notification{
-  background: #e6eda8;
+  background: #E6EDA8;
   height: 50px;
   width: 100%;
   position: relative;

--- a/src/main/content/_assets/css/guide-common.scss
+++ b/src/main/content/_assets/css/guide-common.scss
@@ -366,6 +366,7 @@
 #toc_inner {
   width: 274px;
   transition: margin-top 0.3s ease-out;
+  transition: top 0.3s ease-out;
 }
 
 #title_row {

--- a/src/main/content/_assets/css/guide-common.scss
+++ b/src/main/content/_assets/css/guide-common.scss
@@ -539,6 +539,7 @@
   display: flex;
   align-items: center;
   border-bottom: 2px solid #96BC32;
+  border-top: 2px solid #96BC32;
   p {
     font-weight: 500;
     margin-bottom: -1px;

--- a/src/main/content/_assets/css/toc-multipane-static.scss
+++ b/src/main/content/_assets/css/toc-multipane-static.scss
@@ -96,6 +96,8 @@
     z-index: 7;
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.21);
     transition: top .3s ease-out;
+    height: 100vh;
+    overflow-y: auto;
 
     &.open {
         width: 280px;

--- a/src/main/content/_assets/css/toc.scss
+++ b/src/main/content/_assets/css/toc.scss
@@ -97,6 +97,8 @@
     z-index: 7; /* to override the z-index valued of 4 and 6 for code mirror in interactive guide */
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.21);
     transition: top .3s ease-out;
+    height: 100vh;
+    overflow-y: auto;
 
     &.open {
         width: 280px;

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -856,14 +856,15 @@ $(document).ready(function () {
         dep = false;
         dep_closed = true;      // used in scroll event to reposition columns
         $(this).parent().remove();
-        if($("#nav_bar").hasClass("hide_nav")){
-            $("#code_column").css({"position":"fixed", "top": "0"})
-            $("#toc_inner").css("top", "0")
-        }
-        else if($(window).scrollTop() <= 60){
-            var nav_height = $("#nav_bar").outerHeight();
-            $("#code_column").css({"position":"fixed", "top": nav_height+"px"})
-        }
+        $(window).trigger("scroll")
+        // if($("#nav_bar").hasClass("hide_nav")){
+        //     $("#code_column").css({"position":"fixed", "top": "0"})
+        //     $("#toc_inner").css("top", "0")
+        // }
+        // else if($(window).scrollTop() <= 60){
+        //     var nav_height = $("#nav_bar").outerHeight();
+        //     $("#code_column").css({"position":"fixed", "top": nav_height+"px"})
+        // }
         return false;
     })
 });

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -533,8 +533,8 @@ $(document).ready(function () {
         handleFloatingCodeColumn();
 
         // handle positioning on scroll based on dep and visibility of nav bar
+        // if the top navigation bar is showing
         if(!($("#nav_bar").hasClass("hide_nav"))){
-            // if the top navigation bar is showing
             if(dep){
                 if (inSingleColumnView()) {
                     if($(window).scrollTop() > $(".scroller_anchor").offset().top && (($("#background_container").offset().top + $("#background_container").outerHeight()) > $(window).scrollTop())){
@@ -556,11 +556,7 @@ $(document).ready(function () {
                 $("#toc_inner").css("top", nav_height+"px");
                 $("#code_column").css({"position":"fixed", "top": nav_height+"px"})
                 if(inSingleColumnView()){
-                    if((($("#background_container").offset().top + $("#background_container").outerHeight()) < $(window).scrollTop())){
-                        $("#mobile_toc_accordion_container").css("margin-top", "0px");
-                    }else {
-                        $("#mobile_toc_accordion_container").css("margin-top", nav_height+"px");
-                    }
+                    $("#mobile_toc_accordion_container").css("margin-top", "0px");
                 }
             }
         } else{
@@ -584,6 +580,7 @@ $(document).ready(function () {
                 $("#toc_inner").css("top", notif_height+"px");
                 $("#code_column").css({"position":"fixed", "top": notif_height+"px"});
             } else if (dep_closed){
+                // if the deprecated notification was closed
                 $("#code_column").css({"position":"fixed", "top": nav_height+"px"})
                 $("#toc_inner").css("top", nav_height+"px")
                 if (inSingleColumnView()) {
@@ -866,14 +863,6 @@ $(document).ready(function () {
         dep_closed = true;      // used in scroll event to reposition columns
         $(this).parent().remove();
         $(window).trigger("scroll");
-        // if($("#nav_bar").hasClass("hide_nav")){
-        //     $("#code_column").css({"position":"fixed", "top": "0"})
-        //     $("#toc_inner").css("top", "0")
-        // }
-        // else if($(window).scrollTop() <= 60){
-        //     var nav_height = $("#nav_bar").outerHeight();
-        //     $("#code_column").css({"position":"fixed", "top": nav_height+"px"})
-        // }
         return false;
     })
 });

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -460,33 +460,7 @@ function getTags(callback) {
 $(document).ready(function () {
     getTags(function () {
         $("#tags_container:empty").prev().hide();
-
-        // handle positioning of guide sections
-        var notif_height = 0;
-        if(dep){
-            notif_height = $("#deprecated_notification").outerHeight();
-        }
-        var nav_height = $("#nav_bar").outerHeight();
-        if(window.location.hash && dep){
-            accessContentsFromHash(window.location.hash)
-        } else if(!window.location.hash){
-            $("#deprecated_notification").css("top", nav_height+"px");
-            $("#toc_inner").css("top", (nav_height+notif_height)+"px");
-            $("#code_column").css("top", (nav_height+notif_height)+"px");
-        } else if(($("#nav_bar").hasClass("fixed_top"))){
-            if(dep){
-                $("#deprecated_notification").css("top", nav_height+"px");
-                $("#toc_inner").css("top", (nav_height+notif_height)+"px");
-                $("#code_column").css("top", (nav_height+notif_height)+"px");
-            } else{
-                $("#toc_inner").css("top", nav_height+"px");
-                $("#code_column").css("top", nav_height+"px");
-            }
-        } else{
-            $("#deprecated_notification").css("top", "0");
-            $("#toc_inner").css("top", nav_height+"px");
-            $("#code_column").css("top", nav_height+"px");
-        }
+        $(window).trigger("scroll");
     });
 
     $("#feedback_ratings img").on("mouseenter", function (event) {

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -514,9 +514,6 @@ $(document).ready(function () {
         resizeGuideSections();
         handleFloatingCodeColumn();
         if(dep){
-            // var h = $("#deprecated_notification").outerHeight();
-            // $("#deprecated_notification").css("top", "0");
-            // $("#code_column").css("top", h+"px");
             $(window).trigger("scroll")
             var notif_height = $("#deprecated_notification").outerHeight();
             var nav_height = $("#nav_bar").outerHeight();
@@ -531,32 +528,31 @@ $(document).ready(function () {
             notif_height = $("#deprecated_notification").outerHeight();
         }
         var nav_height = $("#nav_bar").outerHeight();
-        if (!inSingleColumnView()) {
-            // at the top of the browser window in multi-column view
-            if(dep){
-                $("#code_column").css({"position":"fixed", "top": nav_height+"px"})
-                $("#toc_inner").css({"position":"fixed", "top": nav_height+"px"})
-
-            } else{
-                $("#code_column").css({"position":"fixed", "top":"0px"})
-                $("#toc_inner").css({"position":"fixed", "top":"0px"})
-            }
-        } else {
-            // below the hotspot in single column view
-            $("#code_column").css("position", "fixed");
-        } 
         handleFloatingTOCAccordion();
         handleStickyHeader();
-        handleFloatingTableOfContent();
         handleFloatingCodeColumn();
 
         // handle positioning on scroll based on dep and visibility of nav bar
-        if(($("#nav_bar").hasClass("fixed_top"))){
+        if(!($("#nav_bar").hasClass("hide_nav"))){
             if(dep){
                 if (inSingleColumnView()) {
                     $("#deprecated_notification").css("top", nav_height+"px");
-                    $("#toc_column").css("top", (nav_height + notif_height)+"px");
-                    $("#code_column").css({"position":"fixed", "top": (nav_height + notif_height)+"px"})
+                    $("#toc_column").css("top", "40px");
+                    if($(window).scrollTop() > $(".scroller_anchor").offset().top){
+                        $("#mobile_toc_accordion_container").css("margin-top", notif_height +"px");
+                        $("#mobile_toc_accordion_container").css("z-index", "5");
+                    } else {
+                        $("#mobile_toc_accordion_container").css("margin-top", "0px");
+                    }
+                    
+                    if($(window).scrollTop() === 0){
+                        $("#toc_column").css("margin-top", "0px");
+                    }
+                    else if($(window).scrollTop() < $(".scroller_anchor").offset().top){
+                        $("#toc_column").css("margin-top", notif_height+"px");
+                    } else {
+                        $("#toc_column").css("margin-top", 40+notif_height+"px");
+                    }
                 } else {
                     $("#deprecated_notification").css("top", nav_height+"px");
                     $("#toc_inner").css("top", (nav_height + notif_height)+"px");
@@ -570,11 +566,26 @@ $(document).ready(function () {
             if(dep){
                 if(inSingleColumnView()){
                     $("#deprecated_notification").css("top", "0");
-                    $("#toc_column").css("top", notif_height+"px");
-                    $("#code_column").css({"position":"fixed", "top": notif_height+"px"})
+                    $("#toc_inner").css("top", notif_height+40+"px");
+                    // $("#code_column").css({"position":"fixed", "top": notif_height+"px"})
+                    if($(window).scrollTop() > $(".scroller_anchor").offset().top){
+                        $("#mobile_toc_accordion_container").css("margin-top", notif_height +"px");
+                        $("#mobile_toc_accordion_container").css("z-index", "5");
+                    } else {
+                        $("#mobile_toc_accordion_container").css("margin-top", "0px");
+                    }
+                    
+                    if($(window).scrollTop() === 0){
+                        $("#toc_column").css("margin-top", "0px");
+                    }
+                    else if($(window).scrollTop() < $(".scroller_anchor").offset().top){
+                        $("#toc_column").css("margin-top", notif_height+"px");
+                    } else {
+                        $("#toc_column").css("margin-top", 40+notif_height+"px");
+                    }
                 } else {
                     $("#deprecated_notification").css("top", "0");
-                    $("#toc_column").css("top", notif_height+"px");
+                    $("#toc_inner").css("top", notif_height+"px");
                     $("#code_column").css({"position":"fixed", "top": notif_height+"px"})
                 }
             } else if (dep_closed){
@@ -852,7 +863,6 @@ $(document).ready(function () {
         else if($(window).scrollTop() <= 60){
             var nav_height = $("#nav_bar").outerHeight();
             $("#code_column").css({"position":"fixed", "top": nav_height+"px"})
-            $("#toc_inner").css("top", nav_height+"px")
         }
         return false;
     })

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -503,8 +503,6 @@ $(document).ready(function () {
         $(this).prepend('<div class="copied_confirmation">Copied to clipboard</div><input type="image" class="copy_to_clipboard" src="/img/guides_copy_button.svg" alt="Copy code block" title="Copy code block"/>');
     });
 
-    // look for way to check when nav is on screen
-
     $(window).on("resize", function () {
         if (!inSingleColumnView()){
             $("#code_column").css("top", "0px");

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -12,6 +12,7 @@
 var backgroundSizeAdjustment = 200;
 var twoColumnBreakpoint = 1170;
 var threeColumnBreakpoint = 1440;
+var dep = false;
 
 // update twoColumnBreakpoint for the only single pane guide
 if (window.location.href.indexOf("cloud-ibm") > -1) {
@@ -436,8 +437,9 @@ function getTags(callback) {
             else if(tag.name === "deprecated"){
                 for(var i = 0; i < tag.details.length; i++){
                     if(tag.details[i].old === project_id){
-                        $("header").append('<div id="deprecated_notification"><p>This guide is now <em>deprecated</em> and will be <em>removed</em> from the Open Liberty website '+(tag.details[i].date ? 'in '+tag.details[i].date : 'in the future')+'. Check out <a href="/guides/'+tag.details[i].new+'.html">this alternative guide</a>, which uses more up-to-date technology.</p><input type="image" class="notification_x" src="/img/toc_close_navy.svg" alt="Close notification"/></div>');
+                        $("#background_container").prepend('<div id="deprecated_notification"><p>This guide is now <em>deprecated</em> and will be <em>removed</em> from the Open Liberty website '+(tag.details[i].date ? 'in '+tag.details[i].date : 'in the future')+'. Check out <a href="/guides/'+tag.details[i].new+'.html">this alternative guide</a>, which uses more up-to-date technology.</p><input type="image" class="notification_x" src="/img/toc_close_navy.svg" alt="Close notification"/></div>');
                         $("#code_column").css("top", "110px")
+                        dep = true;
                     }
                 }
             }
@@ -471,6 +473,14 @@ $(document).ready(function () {
         $(this).prepend('<div class="copied_confirmation">Copied to clipboard</div><input type="image" class="copy_to_clipboard" src="/img/guides_copy_button.svg" alt="Copy code block" title="Copy code block"/>');
     });
 
+    if($("#nav_bar").hasClass("fixed_top")){
+        $("#deprecated_notification").css("top", "60px");
+        $("#toc_inner").css("top", "60px");
+    } else{
+        $("#deprecated_notification").css("top", "0");
+        $("#toc_inner").css("top", "0");
+    }
+
     $(window).on("resize", function () {
         if (!inSingleColumnView()){
             $("#code_column").css("top", "0px");
@@ -485,7 +495,12 @@ $(document).ready(function () {
         //handles where the top of the code column should be
         if (!inSingleColumnView()) {
             //at the top of the browser window in multi-column view
-            $("#code_column").css({"position":"fixed", "top":"0px"})
+            if(dep){
+                var t = $("#deprecated_notification").outerHeight();
+                $("#code_column").css({"position":"fixed", "top": t+"px"})
+            } else{
+                $("#code_column").css({"position":"fixed", "top":"0px"})
+            }
         } else {
             //below the hotspot in single column view
             $("#code_column").css("position", "fixed");
@@ -494,6 +509,13 @@ $(document).ready(function () {
         handleStickyHeader();
         handleFloatingTableOfContent();
         handleFloatingCodeColumn();
+        if($("#nav_bar").hasClass("fixed_top")){
+            $("#deprecated_notification").css("top", "60px");
+            $("#toc_inner").css("top", "60px");
+        } else{
+            $("#deprecated_notification").css("top", "0");
+            $("#toc_inner").css("top", "0");
+        }
     });
 
     window.addEventListener("hashchange", function (e) {

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -438,7 +438,7 @@ function getTags(callback) {
                 }
             }
             // if guide is deprecated, add notification under navigation
-            else if(tag.name === "deprecated"){
+            else if(tag.name === "deprecated" && tag.guides.includes(project_id)){
                 if(tag.alt_links[project_id]){
                     $("#background_container").prepend('<div id="deprecated_notification"><p>This guide is now <em>deprecated</em> and will be <em>removed</em> from the Open Liberty website in the future. Check out <a href="/guides/'+tag.alt_links[project_id]+'.html">this alternative guide</a>, which uses more up-to-date technology.</p><input type="image" class="notification_x" src="/img/toc_close_navy.svg" alt="Close notification"/></div>');
                 }

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -514,7 +514,10 @@ $(document).ready(function () {
         resizeGuideSections();
         handleFloatingCodeColumn();
         if(dep){
-            $("#deprecated_notification").css("top", "0");
+            // var h = $("#deprecated_notification").outerHeight();
+            // $("#deprecated_notification").css("top", "0");
+            // $("#code_column").css("top", h+"px");
+            $(window).trigger("scroll");
         }
     });
 

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -554,7 +554,11 @@ $(document).ready(function () {
                 $("#toc_inner").css("top", nav_height+"px");
                 $("#code_column").css({"position":"fixed", "top": nav_height+"px"})
                 if(inSingleColumnView()){
-                    $("#mobile_toc_accordion_container").css("margin-top", "0px");
+                    if($("#mobile_toc_accordion_container").css("position") !== "fixed"){
+                        $("#mobile_toc_accordion_container").css("margin-top", "0px");
+                    } else {
+                        $("#mobile_toc_accordion_container").css("margin-top", nav_height+"px");
+                    }
                 }
             }
         } else{
@@ -860,6 +864,9 @@ $(document).ready(function () {
         dep = false;
         dep_closed = true;      // used in scroll event to reposition columns
         $(this).parent().remove();
+        if(inSingleColumnView()){
+            $("#mobile_toc_accordion_container").css("margin-top", nav_height+"px");
+        }
         $(window).trigger("scroll");
         return false;
     })

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -517,7 +517,10 @@ $(document).ready(function () {
             // var h = $("#deprecated_notification").outerHeight();
             // $("#deprecated_notification").css("top", "0");
             // $("#code_column").css("top", h+"px");
-            $(window).trigger("scroll");
+            $(window).trigger("scroll")
+            var notif_height = $("#deprecated_notification").outerHeight();
+            var nav_height = $("#nav_bar").outerHeight();
+            $("#toc_indicator").css({'position': 'fixed', 'top': notif_height+nav_height+'px'})
         }
     });
 
@@ -550,18 +553,30 @@ $(document).ready(function () {
         // handle positioning on scroll based on dep and visibility of nav bar
         if(($("#nav_bar").hasClass("fixed_top"))){
             if(dep){
-                $("#deprecated_notification").css("top", nav_height+"px");
-                $("#toc_inner").css("top", (nav_height + notif_height)+"px");
-                $("#code_column").css({"position":"fixed", "top": (nav_height + notif_height)+"px"})
+                if (inSingleColumnView()) {
+                    $("#deprecated_notification").css("top", nav_height+"px");
+                    $("#toc_column").css("top", (nav_height + notif_height)+"px");
+                    $("#code_column").css({"position":"fixed", "top": (nav_height + notif_height)+"px"})
+                } else {
+                    $("#deprecated_notification").css("top", nav_height+"px");
+                    $("#toc_inner").css("top", (nav_height + notif_height)+"px");
+                    $("#code_column").css({"position":"fixed", "top": (nav_height + notif_height)+"px"})
+                }
             } else {
                 $("#toc_inner").css("top", nav_height+"px");
                 $("#code_column").css({"position":"fixed", "top": nav_height+"px"})
             }
         } else{
             if(dep){
-                $("#deprecated_notification").css("top", "0");
-                $("#toc_inner").css("top", notif_height+"px");
-                $("#code_column").css({"position":"fixed", "top": notif_height+"px"})
+                if(inSingleColumnView()){
+                    $("#deprecated_notification").css("top", "0");
+                    $("#toc_column").css("top", notif_height+"px");
+                    $("#code_column").css({"position":"fixed", "top": notif_height+"px"})
+                } else {
+                    $("#deprecated_notification").css("top", "0");
+                    $("#toc_column").css("top", notif_height+"px");
+                    $("#code_column").css({"position":"fixed", "top": notif_height+"px"})
+                }
             } else if (dep_closed){
                 $("#code_column").css({"position":"fixed", "top": nav_height+"px"})
                 $("#toc_inner").css("top", nav_height+"px")

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -435,7 +435,7 @@ function getTags(callback) {
             else if(tag.name === "deprecated"){
                 for(var i = 0; i < tag.details.length; i++){
                     if(tag.details[i].old === project_id){
-                        $("header").append('<div id="deprecated_notification"><input type="image" class="notification_x" src="/img/toc_close_navy.svg" /><p>This guide is now <em>deprecated</em> and will be <em>removed</em> from the Open Liberty website '+(tag.details[i].date ? 'on '+tag.details[i].date : 'in the future')+'. The new version of this guide can be found <a href="/guides/'+tag.details[i].new+'.html">here.</a></p></div>');
+                        $("header").append('<div id="deprecated_notification"><input type="image" class="notification_x" src="/img/toc_close_navy.svg" /><p>This guide is now <em>deprecated</em> and will be <em>removed</em> from the Open Liberty website '+(tag.details[i].date ? 'on '+tag.details[i].date : 'in the future')+'. Check out <a href="/guides/'+tag.details[i].new+'.html">this alternative guide</a> that covers the same objectives, but uses more up-to-date technology.</p></div>');
                         $("#code_column").css("top", "110px")
                     }
                 }

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -456,6 +456,15 @@ function getTags(callback) {
 $(document).ready(function () {
     getTags(function () {
         // If there are no tags for the guide, hide the tags title
+        var sections = $(
+            ".sect1:not(#guide_meta):not(#related-guides), .sect2"
+        );
+        sections.each(function(i){
+            if($(this).has("h2")){
+                console.log("main")
+                console.log($(this).find("h2").attr("id"))
+            }
+        })
         $("#tags_container:empty").prev().hide();
         if(window.location.hash && dep){
             console.log(window.location.hash)

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -433,9 +433,9 @@ function getTags(callback) {
                 }
             }
             else if(tag.name === "deprecated"){
-                for(var i = 0; i < tag.redirects.length; i++){
-                    if(tag.redirects[i].old === project_id){
-                        $("header").append('<div id="deprecated_notification"><input type="image" class="notification_x" src="/img/toc_close_navy.svg" /><p>This guide is now deprecated and will be removed from the Open Liberty website in the future. The new version of this guide can be found <a href="/guides/'+tag.redirects[i].new+'.html">here.</a></p></div>');
+                for(var i = 0; i < tag.details.length; i++){
+                    if(tag.details[i].old === project_id){
+                        $("header").append('<div id="deprecated_notification"><input type="image" class="notification_x" src="/img/toc_close_navy.svg" /><p>This guide is now deprecated and will be removed from the Open Liberty website in the future. The new version of this guide can be found <a href="/guides/'+tag.details[i].new+'.html">here.</a></p></div>');
                         $("#code_column").css("top", "110px")
                     }
                 }

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -457,23 +457,38 @@ $(document).ready(function () {
     getTags(function () {
         // If there are no tags for the guide, hide the tags title
         $("#tags_container:empty").prev().hide();
-        if(!($("#nav_bar").hasClass("hide_nav"))){
-            if(dep){
-                $("#deprecated_notification").css("top", "60px");
-                $("#toc_inner").css("top", "110px");
-                $("#code_column").css("top", "110px");
-                console.log(4)
-            } else{
-                $("#toc_inner").css("top", "60px");
-                $("#code_column").css("top", "60px");
-                console.log(5)
-            }
+        if(!window.location.hash){
+            $("#deprecated_notification").css("top", "60px");
+            $("#toc_inner").css("top", "110px");
+            $("#code_column").css("top", "110px");
         } else{
-            $("#deprecated_notification").css("top", "0");
-            $("#toc_inner").css("top", "50px");
-            $("#code_column").css("top", "50px");
-            console.log(6)
+            $(window).trigger("scroll")
         }
+        // if(window.location.hash && dep){
+        //     console.log(window.location.hash)
+        //     $(window).trigger("scroll")
+        //     // $("#nav_bar").addClass("hide_nav")
+        //     // $("#deprecated_notification").css("top", "0");
+        //     // $("#toc_inner").css({"position":"fixed", "top":"60px"})
+        //     // $("#code_column").css("top", "60px");
+        // }
+        // else if(($("#nav_bar").hasClass("fixed_top"))){
+        //     if(dep){
+        //         $("#deprecated_notification").css("top", "60px");
+        //         $("#toc_inner").css("top", "110px");
+        //         $("#code_column").css("top", "110px");
+        //         console.log(4)
+        //     } else{
+        //         $("#toc_inner").css("top", "60px");
+        //         $("#code_column").css("top", "60px");
+        //         console.log(5)
+        //     }
+        // } else{
+        //     $("#deprecated_notification").css("top", "0");
+        //     $("#toc_inner").css("top", "60px");
+        //     $("#code_column").css("top", "60px");
+        //     console.log(6)
+        // }
     });
 
     $("#feedback_ratings img").on("mouseenter", function (event) {
@@ -493,9 +508,9 @@ $(document).ready(function () {
     // look for way to check when nav is on screen
 
     $(window).on("resize", function () {
-        if (!inSingleColumnView()){
-            $("#code_column").css("top", "0px");
-        }
+        // if (!inSingleColumnView()){
+        //     $("#code_column").css("top", "0px");
+        // }
         handleFloatingTableOfContent(); // Handle table of content view changes.
         handleFloatingTOCAccordion();
         resizeGuideSections();
@@ -507,35 +522,40 @@ $(document).ready(function () {
         if (!inSingleColumnView()) {
             //at the top of the browser window in multi-column view
             // if(dep){
-            //     var t = $("#deprecated_notification").outerHeight();
-            //     $("#code_column").css({"position":"fixed", "top": t+"px"})
+            //     // var t = $("#deprecated_notification").outerHeight();
+            //     $("#code_column").css({"position":"fixed", "top": "60px"})
+            //     $("#toc_inner").css({"position":"fixed", "top": "60px"})
+
             // } else{
             //     $("#code_column").css({"position":"fixed", "top":"0px"})
+            //     $("#toc_inner").css({"position":"fixed", "top":"0px"})
             // }
         } else {
-            //below the hotspot in single column view
-            // $("#code_column").css("position", "fixed");
+            // below the hotspot in single column view
+            $("#code_column").css("position", "fixed");
         } 
         handleFloatingTOCAccordion();
         handleStickyHeader();
         handleFloatingTableOfContent();
         handleFloatingCodeColumn();
-        if(!($("#nav_bar").hasClass("hide_nav"))){
+        if(($("#nav_bar").hasClass("fixed_top"))){
             if(dep){
                 $("#deprecated_notification").css("top", "60px");
                 $("#toc_inner").css("top", "110px");
                 $("#code_column").css({"position":"fixed", "top": "110px"})
                 console.log(1)
-            } else{
+            } else {
                 $("#toc_inner").css("top", "60px");
                 $("#code_column").css({"position":"fixed", "top": "60px"})
                 console.log(2)
             }
         } else{
-            $("#deprecated_notification").css("top", "0");
-            $("#toc_inner").css("top", "50px");
-            $("#code_column").css({"position":"fixed", "top": "50px"})
-            console.log(3)
+            if(dep){
+                $("#deprecated_notification").css("top", "0");
+                $("#toc_inner").css("top", "50px");
+                $("#code_column").css({"position":"fixed", "top": "50px"})
+                console.log(3)
+            } 
         }
     });
 
@@ -794,17 +814,24 @@ $(document).ready(function () {
     });
     
     // adjust css when deprecation notification is closed
-    $(document).on("click", ".notification_x", function(){
-        $(this).parent().parent().siblings("main").find("#code_column").css("top", "60px");
-        $(this).parent().remove();
+    $(document).on("click", ".notification_x", function(e){
+        // $(this).parent().parent().siblings("main").find("#code_column").css("top", "60px");
+        // e.stopPropagation()
         dep = false;
+        console.log("here")
         if($("#nav_bar").hasClass("fixed_top")){
-            $("#toc_inner").css("top", "60px");
+        $(this).parent().parent().find("#toc_inner").css("top", "60px");
+        $(this).parent().parent().find("#code_column").css("top", "60px");
         } else{
-            $("#toc_inner").css("top", "0");
+            $(this).parent().parent().find("#toc_inner").css("top", "0");
+            $(this).parent().parent().find("#code_column").css("top", "0");
         }
+        //scroll to position after close to realign columns
+        $(this).parent().remove();
+        // $(sel).get(0).scrollIntoView({behavior: 'smooth'});
     
     })
+
 });
 
 function addGuideRatingsListener() {

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -432,10 +432,11 @@ function getTags(callback) {
                     $("#tags_container").append(tag_html);
                 }
             }
+            // if guide is deprecated, add notification under navigation
             else if(tag.name === "deprecated"){
                 for(var i = 0; i < tag.details.length; i++){
                     if(tag.details[i].old === project_id){
-                        $("header").append('<div id="deprecated_notification"><input type="image" class="notification_x" src="/img/toc_close_navy.svg" /><p>This guide is now <em>deprecated</em> and will be <em>removed</em> from the Open Liberty website '+(tag.details[i].date ? 'in '+tag.details[i].date : 'in the future')+'. Check out <a href="/guides/'+tag.details[i].new+'.html">this alternative guide</a>, which uses more up-to-date technology.</p></div>');
+                        $("header").append('<div id="deprecated_notification"><p>This guide is now <em>deprecated</em> and will be <em>removed</em> from the Open Liberty website '+(tag.details[i].date ? 'in '+tag.details[i].date : 'in the future')+'. Check out <a href="/guides/'+tag.details[i].new+'.html">this alternative guide</a>, which uses more up-to-date technology.</p><input type="image" class="notification_x" src="/img/toc_close_navy.svg" alt="Close notification"/></div>');
                         $("#code_column").css("top", "110px")
                     }
                 }
@@ -749,6 +750,7 @@ $(document).ready(function () {
         }
     });
     
+    // adjust css when deprecation notification is closed
     $(document).on("click", ".notification_x", function(){
         $(this).parent().parent().siblings("main").find("#code_column").css("top", "60px");
         $(this).parent().remove();

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -457,38 +457,27 @@ $(document).ready(function () {
     getTags(function () {
         // If there are no tags for the guide, hide the tags title
         $("#tags_container:empty").prev().hide();
-        if(!window.location.hash){
+        if(window.location.hash && dep){
+            console.log(window.location.hash)
+            $(window).trigger("scroll")
+        } else if(!window.location.hash){
             $("#deprecated_notification").css("top", "60px");
             $("#toc_inner").css("top", "110px");
             $("#code_column").css("top", "110px");
+        } else if(($("#nav_bar").hasClass("fixed_top"))){
+            if(dep){
+                $("#deprecated_notification").css("top", "60px");
+                $("#toc_inner").css("top", "110px");
+                $("#code_column").css("top", "110px");
+            } else{
+                $("#toc_inner").css("top", "60px");
+                $("#code_column").css("top", "60px");
+            }
         } else{
-            $(window).trigger("scroll")
+            $("#deprecated_notification").css("top", "0");
+            $("#toc_inner").css("top", "60px");
+            $("#code_column").css("top", "60px");
         }
-        // if(window.location.hash && dep){
-        //     console.log(window.location.hash)
-        //     $(window).trigger("scroll")
-        //     // $("#nav_bar").addClass("hide_nav")
-        //     // $("#deprecated_notification").css("top", "0");
-        //     // $("#toc_inner").css({"position":"fixed", "top":"60px"})
-        //     // $("#code_column").css("top", "60px");
-        // }
-        // else if(($("#nav_bar").hasClass("fixed_top"))){
-        //     if(dep){
-        //         $("#deprecated_notification").css("top", "60px");
-        //         $("#toc_inner").css("top", "110px");
-        //         $("#code_column").css("top", "110px");
-        //         console.log(4)
-        //     } else{
-        //         $("#toc_inner").css("top", "60px");
-        //         $("#code_column").css("top", "60px");
-        //         console.log(5)
-        //     }
-        // } else{
-        //     $("#deprecated_notification").css("top", "0");
-        //     $("#toc_inner").css("top", "60px");
-        //     $("#code_column").css("top", "60px");
-        //     console.log(6)
-        // }
     });
 
     $("#feedback_ratings img").on("mouseenter", function (event) {
@@ -508,9 +497,9 @@ $(document).ready(function () {
     // look for way to check when nav is on screen
 
     $(window).on("resize", function () {
-        // if (!inSingleColumnView()){
-        //     $("#code_column").css("top", "0px");
-        // }
+        if (!inSingleColumnView()){
+            $("#code_column").css("top", "0px");
+        }
         handleFloatingTableOfContent(); // Handle table of content view changes.
         handleFloatingTOCAccordion();
         resizeGuideSections();
@@ -519,17 +508,18 @@ $(document).ready(function () {
 
     $(window).on("scroll", function () {
         //handles where the top of the code column should be
+        debugger;
         if (!inSingleColumnView()) {
             //at the top of the browser window in multi-column view
-            // if(dep){
-            //     // var t = $("#deprecated_notification").outerHeight();
-            //     $("#code_column").css({"position":"fixed", "top": "60px"})
-            //     $("#toc_inner").css({"position":"fixed", "top": "60px"})
+            if(dep){
+                // var t = $("#deprecated_notification").outerHeight();
+                $("#code_column").css({"position":"fixed", "top": "60px"})
+                $("#toc_inner").css({"position":"fixed", "top": "60px"})
 
-            // } else{
-            //     $("#code_column").css({"position":"fixed", "top":"0px"})
-            //     $("#toc_inner").css({"position":"fixed", "top":"0px"})
-            // }
+            } else{
+                $("#code_column").css({"position":"fixed", "top":"0px"})
+                $("#toc_inner").css({"position":"fixed", "top":"0px"})
+            }
         } else {
             // below the hotspot in single column view
             $("#code_column").css("position", "fixed");
@@ -543,18 +533,15 @@ $(document).ready(function () {
                 $("#deprecated_notification").css("top", "60px");
                 $("#toc_inner").css("top", "110px");
                 $("#code_column").css({"position":"fixed", "top": "110px"})
-                console.log(1)
             } else {
                 $("#toc_inner").css("top", "60px");
                 $("#code_column").css({"position":"fixed", "top": "60px"})
-                console.log(2)
             }
         } else{
             if(dep){
                 $("#deprecated_notification").css("top", "0");
                 $("#toc_inner").css("top", "50px");
                 $("#code_column").css({"position":"fixed", "top": "50px"})
-                console.log(3)
             } 
         }
     });
@@ -815,21 +802,17 @@ $(document).ready(function () {
     
     // adjust css when deprecation notification is closed
     $(document).on("click", ".notification_x", function(e){
-        // $(this).parent().parent().siblings("main").find("#code_column").css("top", "60px");
-        // e.stopPropagation()
         dep = false;
-        console.log("here")
-        if($("#nav_bar").hasClass("fixed_top")){
-        $(this).parent().parent().find("#toc_inner").css("top", "60px");
-        $(this).parent().parent().find("#code_column").css("top", "60px");
-        } else{
-            $(this).parent().parent().find("#toc_inner").css("top", "0");
-            $(this).parent().parent().find("#code_column").css("top", "0");
-        }
+        // if($("#nav_bar").hasClass("fixed_top")){
+        //     $(this).parent().parent().find("#toc_inner").css("top", "60px");
+        //     $(this).parent().parent().find("#code_column").css("top", "60px");
+        // } else {
+        //     $(this).parent().parent().find("#toc_inner").css("top", "0");
+        //     $(this).parent().parent().find("#code_column").css("top", "0");
+        // }
         //scroll to position after close to realign columns
         $(this).parent().remove();
-        // $(sel).get(0).scrollIntoView({behavior: 'smooth'});
-    
+        $(window).trigger("scroll");
     })
 
 });

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -435,7 +435,7 @@ function getTags(callback) {
             else if(tag.name === "deprecated"){
                 for(var i = 0; i < tag.details.length; i++){
                     if(tag.details[i].old === project_id){
-                        $("header").append('<div id="deprecated_notification"><input type="image" class="notification_x" src="/img/toc_close_navy.svg" /><p>This guide is now deprecated and will be removed from the Open Liberty website in the future. The new version of this guide can be found <a href="/guides/'+tag.details[i].new+'.html">here.</a></p></div>');
+                        $("header").append('<div id="deprecated_notification"><input type="image" class="notification_x" src="/img/toc_close_navy.svg" /><p>This guide is now <em>deprecated</em> and will be <em>removed</em> from the Open Liberty website '+(tag.details[i].date ? 'on '+tag.details[i].date : 'in the future')+'. The new version of this guide can be found <a href="/guides/'+tag.details[i].new+'.html">here.</a></p></div>');
                         $("#code_column").css("top", "110px")
                     }
                 }

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -534,12 +534,18 @@ $(document).ready(function () {
 
         // handle positioning on scroll based on dep and visibility of nav bar
         if(!($("#nav_bar").hasClass("hide_nav"))){
+            // if the top navigation bar is showing
             if(dep){
                 if (inSingleColumnView()) {
-                    if($(window).scrollTop() > $(".scroller_anchor").offset().top){
+                    if($(window).scrollTop() > $(".scroller_anchor").offset().top && (($("#background_container").offset().top + $("#background_container").outerHeight()) > $(window).scrollTop())){
+                         // if above the first section of the guide
                         $("#mobile_toc_accordion_container").css("margin-top", (notif_height + nav_height)+"px");
                         $("#mobile_toc_accordion_container").css("z-index", "5");
-                    } else {
+                    } else if((($("#background_container").offset().top + $("#background_container").outerHeight()) < $(window).scrollTop())){
+                         // if below the last section of the guide
+                        $("#mobile_toc_accordion_container").css("margin-top", nav_height+"px");
+                    }
+                    else {
                         $("#mobile_toc_accordion_container").css("margin-top", "0px");
                     }
                 }
@@ -550,16 +556,27 @@ $(document).ready(function () {
                 $("#toc_inner").css("top", nav_height+"px");
                 $("#code_column").css({"position":"fixed", "top": nav_height+"px"})
                 if(inSingleColumnView()){
-                    $("#mobile_toc_accordion_container").css("margin-top", nav_height+"px");
+                    if((($("#background_container").offset().top + $("#background_container").outerHeight()) < $(window).scrollTop())){
+                        $("#mobile_toc_accordion_container").css("margin-top", "0px");
+                    }else {
+                        $("#mobile_toc_accordion_container").css("margin-top", nav_height+"px");
+                    }
                 }
             }
         } else{
+            // if the top navigation bar is hidden
             if(dep){
+                // if the guide is deprecated
                 if(inSingleColumnView()){
-                    if($(window).scrollTop() > $(".scroller_anchor").offset().top){
+                    if($(window).scrollTop() > $(".scroller_anchor").offset().top && (($("#background_container").offset().top + $("#background_container").outerHeight()) > $(window).scrollTop())){
+                        // if above the first section of the guide
                         $("#mobile_toc_accordion_container").css("margin-top", notif_height +"px");
                         $("#mobile_toc_accordion_container").css("z-index", "5");
-                    } else {
+                    } else if(($("#background_container").offset().top + $("#background_container").outerHeight() < $(window).scrollTop())){
+                        // if below the last section of the guide
+                        $("#mobile_toc_accordion_container").css("margin-top", "0px");
+                    }
+                    else {
                         $("#mobile_toc_accordion_container").css("margin-top", "0px");
                     }
                 }
@@ -570,7 +587,12 @@ $(document).ready(function () {
                 $("#code_column").css({"position":"fixed", "top": nav_height+"px"})
                 $("#toc_inner").css("top", nav_height+"px")
                 if (inSingleColumnView()) {
-                    $("#mobile_toc_accordion_container").css("margin-top", nav_height+"px");
+                    if(($("#background_container").offset().top + $("#background_container").outerHeight() < $(window).scrollTop())){
+                        // if below the last section of the guide
+                        $("#mobile_toc_accordion_container").css("margin-top", "0px");
+                    } else {
+                        $("#mobile_toc_accordion_container").css("margin-top", nav_height+"px");
+                    }
                 }
                 dep_closed = false;
             } else {

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -349,7 +349,7 @@ function shiftWindow() {
 function accessContentsFromHash(hash, callback) {
     var currentScrollTop = $(document).scrollTop();
     var $focusSection = $(hash);
-
+    debugger;
     // If section is found, scroll to it
     if ($focusSection.length > 0) {
         // Update the TOC
@@ -367,6 +367,9 @@ function accessContentsFromHash(hash, callback) {
         // if new scroll spot is above current scroll position, subtract nav bar height from scroll spot
         if (scrollSpot < currentScrollTop) {
             scrollSpot -= $("#nav_bar").outerHeight();
+        }
+        if(dep){
+            scrollSpot -= $("#deprecated_notification").outerHeight();
         }
         $("body").data("scrolling", true); // Prevent the default window scroll from triggering until the animation is done.
         $("html, body").animate({ scrollTop: scrollSpot }, 400, function () {
@@ -455,20 +458,9 @@ function getTags(callback) {
 
 $(document).ready(function () {
     getTags(function () {
-        // If there are no tags for the guide, hide the tags title
-        var sections = $(
-            ".sect1:not(#guide_meta):not(#related-guides), .sect2"
-        );
-        sections.each(function(i){
-            if($(this).has("h2")){
-                console.log("main")
-                console.log($(this).find("h2").attr("id"))
-            }
-        })
         $("#tags_container:empty").prev().hide();
         if(window.location.hash && dep){
-            console.log(window.location.hash)
-            $(window).trigger("scroll")
+            accessContentsFromHash(window.location.hash)
         } else if(!window.location.hash){
             $("#deprecated_notification").css("top", "60px");
             $("#toc_inner").css("top", "110px");
@@ -517,7 +509,6 @@ $(document).ready(function () {
 
     $(window).on("scroll", function () {
         //handles where the top of the code column should be
-        debugger;
         if (!inSingleColumnView()) {
             //at the top of the browser window in multi-column view
             if(dep){
@@ -812,18 +803,9 @@ $(document).ready(function () {
     // adjust css when deprecation notification is closed
     $(document).on("click", ".notification_x", function(e){
         dep = false;
-        // if($("#nav_bar").hasClass("fixed_top")){
-        //     $(this).parent().parent().find("#toc_inner").css("top", "60px");
-        //     $(this).parent().parent().find("#code_column").css("top", "60px");
-        // } else {
-        //     $(this).parent().parent().find("#toc_inner").css("top", "0");
-        //     $(this).parent().parent().find("#code_column").css("top", "0");
-        // }
-        //scroll to position after close to realign columns
         $(this).parent().remove();
         $(window).trigger("scroll");
     })
-
 });
 
 function addGuideRatingsListener() {

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -435,7 +435,7 @@ function getTags(callback) {
             else if(tag.name === "deprecated"){
                 for(var i = 0; i < tag.details.length; i++){
                     if(tag.details[i].old === project_id){
-                        $("header").append('<div id="deprecated_notification"><input type="image" class="notification_x" src="/img/toc_close_navy.svg" /><p>This guide is now <em>deprecated</em> and will be <em>removed</em> from the Open Liberty website '+(tag.details[i].date ? 'on '+tag.details[i].date : 'in the future')+'. Check out <a href="/guides/'+tag.details[i].new+'.html">this alternative guide</a> that covers the same objectives, but uses more up-to-date technology.</p></div>');
+                        $("header").append('<div id="deprecated_notification"><input type="image" class="notification_x" src="/img/toc_close_navy.svg" /><p>This guide is now <em>deprecated</em> and will be <em>removed</em> from the Open Liberty website '+(tag.details[i].date ? 'in '+tag.details[i].date : 'in the future')+'. Check out <a href="/guides/'+tag.details[i].new+'.html">this alternative guide</a>, which uses more up-to-date technology.</p></div>');
                         $("#code_column").css("top", "110px")
                     }
                 }

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -457,6 +457,23 @@ $(document).ready(function () {
     getTags(function () {
         // If there are no tags for the guide, hide the tags title
         $("#tags_container:empty").prev().hide();
+        if(!($("#nav_bar").hasClass("hide_nav"))){
+            if(dep){
+                $("#deprecated_notification").css("top", "60px");
+                $("#toc_inner").css("top", "110px");
+                $("#code_column").css("top", "110px");
+                console.log(4)
+            } else{
+                $("#toc_inner").css("top", "60px");
+                $("#code_column").css("top", "60px");
+                console.log(5)
+            }
+        } else{
+            $("#deprecated_notification").css("top", "0");
+            $("#toc_inner").css("top", "50px");
+            $("#code_column").css("top", "50px");
+            console.log(6)
+        }
     });
 
     $("#feedback_ratings img").on("mouseenter", function (event) {
@@ -473,13 +490,7 @@ $(document).ready(function () {
         $(this).prepend('<div class="copied_confirmation">Copied to clipboard</div><input type="image" class="copy_to_clipboard" src="/img/guides_copy_button.svg" alt="Copy code block" title="Copy code block"/>');
     });
 
-    if($("#nav_bar").hasClass("fixed_top")){
-        $("#deprecated_notification").css("top", "60px");
-        $("#toc_inner").css("top", "60px");
-    } else{
-        $("#deprecated_notification").css("top", "0");
-        $("#toc_inner").css("top", "0");
-    }
+    // look for way to check when nav is on screen
 
     $(window).on("resize", function () {
         if (!inSingleColumnView()){
@@ -495,26 +506,36 @@ $(document).ready(function () {
         //handles where the top of the code column should be
         if (!inSingleColumnView()) {
             //at the top of the browser window in multi-column view
-            if(dep){
-                var t = $("#deprecated_notification").outerHeight();
-                $("#code_column").css({"position":"fixed", "top": t+"px"})
-            } else{
-                $("#code_column").css({"position":"fixed", "top":"0px"})
-            }
+            // if(dep){
+            //     var t = $("#deprecated_notification").outerHeight();
+            //     $("#code_column").css({"position":"fixed", "top": t+"px"})
+            // } else{
+            //     $("#code_column").css({"position":"fixed", "top":"0px"})
+            // }
         } else {
             //below the hotspot in single column view
-            $("#code_column").css("position", "fixed");
+            // $("#code_column").css("position", "fixed");
         } 
         handleFloatingTOCAccordion();
         handleStickyHeader();
         handleFloatingTableOfContent();
         handleFloatingCodeColumn();
-        if($("#nav_bar").hasClass("fixed_top")){
-            $("#deprecated_notification").css("top", "60px");
-            $("#toc_inner").css("top", "60px");
+        if(!($("#nav_bar").hasClass("hide_nav"))){
+            if(dep){
+                $("#deprecated_notification").css("top", "60px");
+                $("#toc_inner").css("top", "110px");
+                $("#code_column").css({"position":"fixed", "top": "110px"})
+                console.log(1)
+            } else{
+                $("#toc_inner").css("top", "60px");
+                $("#code_column").css({"position":"fixed", "top": "60px"})
+                console.log(2)
+            }
         } else{
             $("#deprecated_notification").css("top", "0");
-            $("#toc_inner").css("top", "0");
+            $("#toc_inner").css("top", "50px");
+            $("#code_column").css({"position":"fixed", "top": "50px"})
+            console.log(3)
         }
     });
 
@@ -776,6 +797,13 @@ $(document).ready(function () {
     $(document).on("click", ".notification_x", function(){
         $(this).parent().parent().siblings("main").find("#code_column").css("top", "60px");
         $(this).parent().remove();
+        dep = false;
+        if($("#nav_bar").hasClass("fixed_top")){
+            $("#toc_inner").css("top", "60px");
+        } else{
+            $("#toc_inner").css("top", "0");
+        }
+    
     })
 });
 

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -567,7 +567,6 @@ $(document).ready(function () {
                 if(inSingleColumnView()){
                     $("#deprecated_notification").css("top", "0");
                     $("#toc_inner").css("top", notif_height+40+"px");
-                    // $("#code_column").css({"position":"fixed", "top": notif_height+"px"})
                     if($(window).scrollTop() > $(".scroller_anchor").offset().top){
                         $("#mobile_toc_accordion_container").css("margin-top", notif_height +"px");
                         $("#mobile_toc_accordion_container").css("z-index", "5");
@@ -592,6 +591,9 @@ $(document).ready(function () {
                 $("#code_column").css({"position":"fixed", "top": nav_height+"px"})
                 $("#toc_inner").css("top", nav_height+"px")
                 dep_closed = false;
+            } else {
+                $("#code_column").css({"position":"fixed", "top": "0px"})
+                $("#toc_inner").css("top", "0px")
             }
         }
     });

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -13,6 +13,7 @@ var backgroundSizeAdjustment = 200;
 var twoColumnBreakpoint = 1170;
 var threeColumnBreakpoint = 1440;
 var dep = false;
+var dep_closed = false;
 
 // update twoColumnBreakpoint for the only single pane guide
 if (window.location.href.indexOf("cloud-ibm") > -1) {
@@ -509,12 +510,15 @@ $(document).ready(function () {
 
     $(window).on("scroll", function () {
         //handles where the top of the code column should be
+        var notif_height = $("#deprecated_notification").height();
+        console.log(notif_height)
+        var nav_height = $("#nav_bar").height();
+        console.log(nav_height);
         if (!inSingleColumnView()) {
             //at the top of the browser window in multi-column view
             if(dep){
-                // var t = $("#deprecated_notification").outerHeight();
-                $("#code_column").css({"position":"fixed", "top": "60px"})
-                $("#toc_inner").css({"position":"fixed", "top": "60px"})
+                $("#code_column").css({"position":"fixed", "top": nav_height+"px"})
+                $("#toc_inner").css({"position":"fixed", "top": nav_height+"px"})
 
             } else{
                 $("#code_column").css({"position":"fixed", "top":"0px"})
@@ -542,7 +546,11 @@ $(document).ready(function () {
                 $("#deprecated_notification").css("top", "0");
                 $("#toc_inner").css("top", "50px");
                 $("#code_column").css({"position":"fixed", "top": "50px"})
-            } 
+            } else if (dep_closed){
+                $("#code_column").css({"position":"fixed", "top": "60px"})
+                $("#toc_inner").css("top", "60px")
+                dep_closed = false;
+            }
         }
     });
 
@@ -800,11 +808,16 @@ $(document).ready(function () {
         }
     });
     
-    // adjust css when deprecation notification is closed
+    // remove notification when X is clicked, dep should no longer be true
+    // if the page is refreshed, dep will become true again and the notification will appear
     $(document).on("click", ".notification_x", function(e){
         dep = false;
+        dep_closed = true;
         $(this).parent().remove();
-        $(window).trigger("scroll");
+        if($(window).scrollTop() <= 60 || !($("#nav_bar").hasClass("hide_nav"))){
+            $("#code_column").css({"position":"fixed", "top": "60px"})
+            $("#toc_inner").css("top", "60px")
+        }
     })
 });
 

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -417,10 +417,10 @@ function getTags(callback) {
     $.getJSON("../../guides/guides-common/guide_tags.json", function (data) {
         $.each(data.guide_tags, function (i, tag) {
             // Check if tag is visible before adding it
+            var project_id = window.location.pathname
+                .replace("/guides/", "")
+                .replace(".html", "");
             if (tag.visible == "true") {
-                project_id = window.location.pathname
-                    .replace("/guides/", "")
-                    .replace(".html", "");
                 // Add tag to tags_container if the guide's project id is in the array for that tag
                 if (tag.guides.indexOf(project_id) > -1) {
                     tag_html =
@@ -430,6 +430,14 @@ function getTags(callback) {
                         tag.name +
                         "</a>";
                     $("#tags_container").append(tag_html);
+                }
+            }
+            else if(tag.name === "deprecated"){
+                for(var i = 0; i < tag.redirects.length; i++){
+                    if(tag.redirects[i].old === project_id){
+                        $("header").append('<div id="deprecated_notification"><input type="image" class="notification_x" src="/img/toc_close_navy.svg" /><p>This guide is now deprecated and will be removed from the Open Liberty website in the future. The new version of this guide can be found <a href="/guides/'+tag.redirects[i].new+'.html">here.</a></p></div>');
+                        $("#code_column").css("top", "110px")
+                    }
                 }
             }
             else {
@@ -740,6 +748,11 @@ $(document).ready(function () {
             }
         }
     });
+    
+    $(document).on("click", ".notification_x", function(){
+        $(this).parent().parent().siblings("main").find("#code_column").css("top", "60px");
+        $(this).parent().remove();
+    })
 });
 
 function addGuideRatingsListener() {
@@ -764,6 +777,7 @@ $(window).on("load", function () {
             $(this).find("code").contents().unwrap();
             newPlacement.prepend($(this));
         });
+    
     $.ready.then(function () {
         // Both ready and loaded
         addGuideRatingsListener();

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -528,7 +528,7 @@ $(document).ready(function () {
             notif_height = $("#deprecated_notification").outerHeight();
         }
         var nav_height = $("#nav_bar").outerHeight();
-        // handleFloatingTOCAccordion();
+        handleFloatingTOCAccordion();
         handleStickyHeader();
         handleFloatingCodeColumn();
 
@@ -536,64 +536,49 @@ $(document).ready(function () {
         if(!($("#nav_bar").hasClass("hide_nav"))){
             if(dep){
                 if (inSingleColumnView()) {
-                    $("#deprecated_notification").css("top", nav_height+"px");
-                    $("#toc_column").css("top", "40px");
                     if($(window).scrollTop() > $(".scroller_anchor").offset().top){
-                        $("#mobile_toc_accordion_container").css("margin-top", notif_height +"px");
+                        $("#mobile_toc_accordion_container").css("margin-top", (notif_height + nav_height)+"px");
                         $("#mobile_toc_accordion_container").css("z-index", "5");
                     } else {
                         $("#mobile_toc_accordion_container").css("margin-top", "0px");
                     }
-                    
-                    if($(window).scrollTop() === 0){
-                        $("#toc_column").css("margin-top", "0px");
-                    }
-                    else if($(window).scrollTop() < $(".scroller_anchor").offset().top){
-                        $("#toc_column").css("margin-top", notif_height+"px");
-                    } else {
-                        $("#toc_column").css("margin-top", 40+notif_height+"px");
-                    }
-                } else {
-                    $("#deprecated_notification").css("top", nav_height+"px");
-                    $("#toc_inner").css("top", (nav_height + notif_height)+"px");
-                    $("#code_column").css({"position":"fixed", "top": (nav_height + notif_height)+"px"})
                 }
+                $("#deprecated_notification").css("top", nav_height+"px");
+                $("#toc_inner").css("top", (nav_height + notif_height)+"px");
+                $("#code_column").css({"position":"fixed", "top": (nav_height + notif_height)+"px"})
             } else {
                 $("#toc_inner").css("top", nav_height+"px");
                 $("#code_column").css({"position":"fixed", "top": nav_height+"px"})
+                if(inSingleColumnView()){
+                    $("#mobile_toc_accordion_container").css("margin-top", nav_height+"px");
+                }
             }
         } else{
             if(dep){
                 if(inSingleColumnView()){
-                    $("#deprecated_notification").css("top", "0");
-                    $("#toc_inner").css("top", notif_height+40+"px");
                     if($(window).scrollTop() > $(".scroller_anchor").offset().top){
                         $("#mobile_toc_accordion_container").css("margin-top", notif_height +"px");
                         $("#mobile_toc_accordion_container").css("z-index", "5");
                     } else {
                         $("#mobile_toc_accordion_container").css("margin-top", "0px");
                     }
-                    
-                    if($(window).scrollTop() === 0){
-                        $("#toc_column").css("margin-top", "0px");
-                    }
-                    else if($(window).scrollTop() < $(".scroller_anchor").offset().top){
-                        $("#toc_column").css("margin-top", notif_height+"px");
-                    } else {
-                        $("#toc_column").css("margin-top", 40+notif_height+"px");
-                    }
-                } else {
-                    $("#deprecated_notification").css("top", "0");
-                    $("#toc_inner").css("top", notif_height+"px");
-                    $("#code_column").css({"position":"fixed", "top": notif_height+"px"})
                 }
+                $("#deprecated_notification").css("top", "0");
+                $("#toc_inner").css("top", notif_height+"px");
+                $("#code_column").css({"position":"fixed", "top": notif_height+"px"});
             } else if (dep_closed){
                 $("#code_column").css({"position":"fixed", "top": nav_height+"px"})
                 $("#toc_inner").css("top", nav_height+"px")
+                if (inSingleColumnView()) {
+                    $("#mobile_toc_accordion_container").css("margin-top", nav_height+"px");
+                }
                 dep_closed = false;
             } else {
                 $("#code_column").css({"position":"fixed", "top": "0px"})
                 $("#toc_inner").css("top", "0px")
+                if(inSingleColumnView()){
+                    $("#mobile_toc_accordion_container").css("margin-top", "0px");
+                }
             }
         }
     });
@@ -858,7 +843,7 @@ $(document).ready(function () {
         dep = false;
         dep_closed = true;      // used in scroll event to reposition columns
         $(this).parent().remove();
-        $(window).trigger("scroll")
+        $(window).trigger("scroll");
         // if($("#nav_bar").hasClass("hide_nav")){
         //     $("#code_column").css({"position":"fixed", "top": "0"})
         //     $("#toc_inner").css("top", "0")

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -528,7 +528,7 @@ $(document).ready(function () {
             notif_height = $("#deprecated_notification").outerHeight();
         }
         var nav_height = $("#nav_bar").outerHeight();
-        handleFloatingTOCAccordion();
+        // handleFloatingTOCAccordion();
         handleStickyHeader();
         handleFloatingCodeColumn();
 

--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -439,13 +439,14 @@ function getTags(callback) {
             }
             // if guide is deprecated, add notification under navigation
             else if(tag.name === "deprecated"){
-                for(var i = 0; i < tag.details.length; i++){
-                    if(tag.details[i].old === project_id){
-                        $("#background_container").prepend('<div id="deprecated_notification"><p>This guide is now <em>deprecated</em> and will be <em>removed</em> from the Open Liberty website '+(tag.details[i].date ? 'in '+tag.details[i].date : 'in the future')+'. Check out <a href="/guides/'+tag.details[i].new+'.html">this alternative guide</a>, which uses more up-to-date technology.</p><input type="image" class="notification_x" src="/img/toc_close_navy.svg" alt="Close notification"/></div>');
-                        $("#code_column").css("top", "110px")
-                        dep = true;
-                    }
+                if(tag.alt_links[project_id]){
+                    $("#background_container").prepend('<div id="deprecated_notification"><p>This guide is now <em>deprecated</em> and will be <em>removed</em> from the Open Liberty website in the future. Check out <a href="/guides/'+tag.alt_links[project_id]+'.html">this alternative guide</a>, which uses more up-to-date technology.</p><input type="image" class="notification_x" src="/img/toc_close_navy.svg" alt="Close notification"/></div>');
                 }
+                else {
+                    $("#background_container").prepend('<div id="deprecated_notification"><p>This guide is now <em>deprecated</em> and will be <em>removed</em> from the Open Liberty website in the future. Check out our other guides, which use more up-to-date technology.</p><input type="image" class="notification_x" src="/img/toc_close_navy.svg" alt="Close notification"/></div>');
+                }
+                $("#code_column").css("top", "110px")
+                dep = true;
             }
             else {
                 if (tag.visible == "false") {

--- a/src/main/content/_assets/js/guides.js
+++ b/src/main/content/_assets/js/guides.js
@@ -538,7 +538,7 @@ $(document).ready(function () {
                 //add before "NEW" orange pill so "NEW" pill shows first because float: right; reverses element order
                 $(this).children(".new_guide_container").remove();
               }
-              $('<div class="guide_deprecated_container"><span class="guide_run_in_cloud">Deprecated</span></div>').insertAfter($(this).children().last());
+              $('<div class="guide_deprecated_container"><span class="guide_deprecated">Deprecated</span></div>').insertAfter($(this).children().last());
             }
           }
         });

--- a/src/main/content/_assets/js/guides.js
+++ b/src/main/content/_assets/js/guides.js
@@ -516,7 +516,15 @@ $(document).ready(function () {
             } else {
               $(this).data("tags", tag_name.toLowerCase());
             }
-            if (tag.visible == "true") {
+            if(tag.name === "deprecated"){
+              if ($(this).children().last().hasClass("guide_run_in_cloud")) {
+                //add before "NEW" orange pill so "NEW" pill shows first because float: right; reverses element order
+                $('<div class="guide_run_in_cloud_container"><span class="guide_run_in_cloud">Deprecated</span></div>').insertBefore($(this).children().last());
+              } else {
+                $('<div class="guide_run_in_cloud_container"><span class="guide_run_in_cloud">Deprecated</span></div>').insertAfter($(this).children().last());
+              }
+            }
+            else if (tag.visible == "true") {
               //add "RUN IN CLOUD" orange pill to applicable guides
               if (tag_name.toLowerCase() == "run in cloud") {
                 //add to last child element in .guide_item element

--- a/src/main/content/_assets/js/guides.js
+++ b/src/main/content/_assets/js/guides.js
@@ -516,15 +516,7 @@ $(document).ready(function () {
             } else {
               $(this).data("tags", tag_name.toLowerCase());
             }
-            if(tag.name === "deprecated"){
-              if ($(this).children().last().hasClass("guide_run_in_cloud")) {
-                //add before "NEW" orange pill so "NEW" pill shows first because float: right; reverses element order
-                $('<div class="guide_run_in_cloud_container"><span class="guide_run_in_cloud">Deprecated</span></div>').insertBefore($(this).children().last());
-              } else {
-                $('<div class="guide_run_in_cloud_container"><span class="guide_run_in_cloud">Deprecated</span></div>').insertAfter($(this).children().last());
-              }
-            }
-            else if (tag.visible == "true") {
+            if (tag.visible == "true") {
               //add "RUN IN CLOUD" orange pill to applicable guides
               if (tag_name.toLowerCase() == "run in cloud") {
                 //add to last child element in .guide_item element

--- a/src/main/content/_assets/js/guides.js
+++ b/src/main/content/_assets/js/guides.js
@@ -499,7 +499,7 @@ $(document).ready(function () {
           }
         }
         tag_name = tag.name + search_terms_string;
-
+        var dep = false;
         $(".guide_item").each(function (j, guide_item) {
           project_id = $(this)
           .attr("href")
@@ -518,7 +518,7 @@ $(document).ready(function () {
             }
             if (tag.visible == "true") {
               //add "RUN IN CLOUD" orange pill to applicable guides
-              if (tag_name.toLowerCase() == "run in cloud") {
+              if (tag_name.toLowerCase() == "run in cloud" && !dep) {
                 //add to last child element in .guide_item element
                 if ($(this).children().last().hasClass("new_guide_container")) {
                   //add before "NEW" orange pill so "NEW" pill shows first because float: right; reverses element order
@@ -527,6 +527,18 @@ $(document).ready(function () {
                   $('<div class="guide_run_in_cloud_container"><span class="guide_run_in_cloud">Run in cloud</span></div>').insertAfter($(this).children().last());
                 }
               }
+            }
+            if(tag_name.toLowerCase() === "deprecated"){
+              dep = true;
+              if ($(this).has(".guide_run_in_cloud_container").length) {
+                //add before "NEW" orange pill so "NEW" pill shows first because float: right; reverses element order
+                $(this).children(".guide_run_in_cloud_container").remove();
+              }
+              if ($(this).has(".new_guide_container").length) {
+                //add before "NEW" orange pill so "NEW" pill shows first because float: right; reverses element order
+                $(this).children(".new_guide_container").remove();
+              }
+              $('<div class="guide_deprecated_container"><span class="guide_run_in_cloud">Deprecated</span></div>').insertAfter($(this).children().last());
             }
           }
         });

--- a/src/main/content/_assets/js/guides.js
+++ b/src/main/content/_assets/js/guides.js
@@ -517,7 +517,7 @@ $(document).ready(function () {
               $(this).data("tags", tag_name.toLowerCase());
             }
             if (tag.visible == "true") {
-              //add "RUN IN CLOUD" orange pill to applicable guides
+              //add "RUN IN CLOUD" orange pill to applicable guides if the guide is not deprecated
               if (tag_name.toLowerCase() == "run in cloud" && !dep) {
                 //add to last child element in .guide_item element
                 if ($(this).children().last().hasClass("new_guide_container")) {
@@ -528,14 +528,16 @@ $(document).ready(function () {
                 }
               }
             }
+            // deprecated pill label should be prioritized over others
+            // we want users to use the up-to-date guide
             if(tag_name.toLowerCase() === "deprecated"){
               dep = true;
               if ($(this).has(".guide_run_in_cloud_container").length) {
-                //add before "NEW" orange pill so "NEW" pill shows first because float: right; reverses element order
+                //remove additional pills
                 $(this).children(".guide_run_in_cloud_container").remove();
               }
               if ($(this).has(".new_guide_container").length) {
-                //add before "NEW" orange pill so "NEW" pill shows first because float: right; reverses element order
+                //remove additional pills
                 $(this).children(".new_guide_container").remove();
               }
               $('<div class="guide_deprecated_container"><span class="guide_deprecated">Deprecated</span></div>').insertAfter($(this).children().last());

--- a/src/main/content/_assets/js/openliberty.js
+++ b/src/main/content/_assets/js/openliberty.js
@@ -32,7 +32,7 @@ var openliberty = (function() {
                 }
             }
             else {
-                $("#code_column").css({"position": "absolute", "top": ""});
+                // $("#code_column").css({"position": "absolute", "top": ""});
                 $(".toolbar").css({"position": "static", "top": ""});
                 $(".nav").css("top", "");
             }
@@ -82,7 +82,7 @@ var openliberty = (function() {
             $("#toc_inner").css("margin-top", nav_height + "px");
         }
         $("#toc_indicator").css("margin-top", nav_height + "px");
-        $("#code_column").css({"position": "fixed", "top": nav_height + "px"});
+        // $("#code_column").css({"position": "fixed", "top": nav_height + "px"});
 
         // add margin-top to body so page doesn't jump when nav slides into view
         $('body').css("margin-top", nav_height + "px");

--- a/src/main/content/_assets/js/openliberty.js
+++ b/src/main/content/_assets/js/openliberty.js
@@ -32,7 +32,6 @@ var openliberty = (function() {
                 }
             }
             else {
-                // $("#code_column").css({"position": "absolute", "top": ""});
                 $(".toolbar").css({"position": "static", "top": ""});
                 $(".nav").css("top", "");
             }
@@ -82,7 +81,6 @@ var openliberty = (function() {
             $("#toc_inner").css("margin-top", nav_height + "px");
         }
         $("#toc_indicator").css("margin-top", nav_height + "px");
-        // $("#code_column").css({"position": "fixed", "top": nav_height + "px"});
 
         // add margin-top to body so page doesn't jump when nav slides into view
         $('body').css("margin-top", nav_height + "px");

--- a/src/main/content/_assets/js/openliberty.js
+++ b/src/main/content/_assets/js/openliberty.js
@@ -77,9 +77,6 @@ var openliberty = (function() {
 
         // push toc column, toc indicator and code column down below nav bar
         $("#toc_column").css("top", nav_height + "px");
-        if (window.innerWidth > 1440) {
-            $("#toc_inner").css("margin-top", nav_height + "px");
-        }
         $("#toc_indicator").css("margin-top", nav_height + "px");
 
         // add margin-top to body so page doesn't jump when nav slides into view
@@ -112,9 +109,6 @@ var openliberty = (function() {
         
         // reset toc column, toc indicator and code column position
         $("#toc_column").css("top", "0px");
-        if (window.innerWidth > 1440) {
-            $("#toc_inner").css("margin-top", "0px");
-        }
         $("#toc_indicator").css("margin-top", "0px");
 
         // reset body margin-top

--- a/src/main/content/_assets/js/openliberty.js
+++ b/src/main/content/_assets/js/openliberty.js
@@ -86,9 +86,9 @@ var openliberty = (function() {
         $('body').css("margin-top", nav_height + "px");
 
         // in guides, if mobile toc accodion is fixed to top of screen, move toc accordion below fixed nav bar
-        if ($("#mobile_toc_accordion_container").hasClass("fixed_toc_accordion")) {
-            $("#mobile_toc_accordion_container").css("top", nav_height + "px");
-        }
+        // if ($("#mobile_toc_accordion_container").hasClass("fixed_toc_accordion")) {
+        //     $("#mobile_toc_accordion_container").css("top", nav_height + "px");
+        // }
 
         // on /guides, if tablet toc accordion is fixed to top of screen, move toc accordion below fixed nav bar
         if ($("#tablet_toc_accordion_container").css("position") === "fixed") {
@@ -126,7 +126,7 @@ var openliberty = (function() {
         $('body').css("margin-top", "0px");
 
         // fix mobile and tablet toc accordion to top of screen again
-        $("#mobile_toc_accordion_container").css("top", "0px");
+        // $("#mobile_toc_accordion_container").css("top", "0px");
         $("#tablet_toc_accordion_container").css("top", "0px");
 
         // adjust docs toolbar and nav position

--- a/src/main/content/_assets/js/openliberty.js
+++ b/src/main/content/_assets/js/openliberty.js
@@ -85,11 +85,6 @@ var openliberty = (function() {
         // add margin-top to body so page doesn't jump when nav slides into view
         $('body').css("margin-top", nav_height + "px");
 
-        // in guides, if mobile toc accodion is fixed to top of screen, move toc accordion below fixed nav bar
-        // if ($("#mobile_toc_accordion_container").hasClass("fixed_toc_accordion")) {
-        //     $("#mobile_toc_accordion_container").css("top", nav_height + "px");
-        // }
-
         // on /guides, if tablet toc accordion is fixed to top of screen, move toc accordion below fixed nav bar
         if ($("#tablet_toc_accordion_container").css("position") === "fixed") {
             $("#tablet_toc_accordion_container").css("top", nav_height + "px");
@@ -126,7 +121,6 @@ var openliberty = (function() {
         $('body').css("margin-top", "0px");
 
         // fix mobile and tablet toc accordion to top of screen again
-        // $("#mobile_toc_accordion_container").css("top", "0px");
         $("#tablet_toc_accordion_container").css("top", "0px");
 
         // adjust docs toolbar and nav position

--- a/src/main/content/_assets/js/toc.js
+++ b/src/main/content/_assets/js/toc.js
@@ -11,6 +11,7 @@
 
 // make TOC indicator fixed once nav bar scrolls off screen
 $(window).on('scroll', function(event) {
+    console.log("toc")
     var nav_bottom = $('#nav_bar').outerHeight(true);
     if ($(this).scrollTop() > nav_bottom){
         $('#toc_indicator').css({'position': 'fixed', 'top': '0px'});
@@ -33,7 +34,7 @@ function handleFloatingTableOfContent() {
             // The entire viewport is filled with the background, so
             // do not need to worry about the TOC flowing out of the background.
             if ($(window).scrollTop() > 60) {
-                enableFloatingTOC();
+                // enableFloatingTOC();
             }
             expandTOCIndicator();
         }

--- a/src/main/content/_assets/js/toc.js
+++ b/src/main/content/_assets/js/toc.js
@@ -420,11 +420,6 @@ $(document).ready(function() {
             $("#toc_indicator").css("margin-top", $("#nav_bar").outerHeight());
         }
 
-        // in guides, if mobile toc accodion is fixed to top of screen, move toc accordion below fixed nav bar
-        if ($("#mobile_toc_accordion_container").hasClass("fixed_toc_accordion")  && $("#nav_bar").hasClass("fixed_top")) {
-            $("#mobile_toc_accordion_container").css("top", $("#nav_bar").outerHeight() + "px");
-        }
-
         // update width with new width after resizing
         if ($(this).innerWidth() != width) {
             width = $(this).innerWidth();

--- a/src/main/content/_assets/js/toc.js
+++ b/src/main/content/_assets/js/toc.js
@@ -24,7 +24,6 @@ $(window).on('scroll', function(event) {
     if ($(this).scrollTop() > nav_bottom){
         if($("#deprecated_notification").length){
             $('#toc_indicator').css({'position': 'fixed', 'top': $("#deprecated_notification").outerHeight()+'px'});
-            // $('#toc_line').css({'position': 'fixed', 'top': $("#deprecated_notification").outerHeight()+'px', 'height':$("#end_of_guide").offset().top});
         } else {
             $('#toc_indicator').css({'position': 'fixed', 'top': '0px'});
         }
@@ -122,7 +121,6 @@ function handleFloatingTOCAccordion() {
         accordion.removeClass('fixed_toc_accordion');
         $('.scroller_anchor').css('height', 0);
         // Restore toc location.
-        // $('#toc_column').css('margin-top', '0px');
     };
     var disableFloatingTOCAccordion = function(){
         // Change the height of the scroller_anchor to that of the accordion

--- a/src/main/content/_assets/js/toc.js
+++ b/src/main/content/_assets/js/toc.js
@@ -16,8 +16,20 @@ $(window).on('scroll', function(event) {
         $('#toc_indicator').css({'position': 'fixed', 'top': '0px'});
 
         if (window.innerWidth < 1440) {
-            $('#toc_column').css({'position': 'fixed', 'top': '0px'});
+            if($("#deprecated_notification").length){
+                var h = $("#deprecated_notification").outerHeight();
+                $('#toc_column').css({'position': 'fixed', 'top': h+'px'});
+
+            } else {
+                $('#toc_column').css({'position': 'fixed', 'top': '0px'});
+            }
         }
+    }
+    var scroller_anchor = $(".scroller_anchor").offset().top;
+    if ($("#mobile_toc_accordion_container").hasClass("fixed_toc_accordion") && $("#deprecated_notification").length && $(window).scrollTop() > scroller_anchor) {
+        $("#mobile_toc_accordion_container").css("top", $("#deprecated_notification").outerHeight() + "px");
+        $("#mobile_toc_accordion_container").css("z-index", "5");
+        event.stopImmediatePropogation();
     }
 });
 
@@ -130,7 +142,11 @@ function handleFloatingTOCAccordion() {
           //mobile_toc_accordion blocks the top part of the TOC column, need to add margin so that 'X' in TOC is visible
           var tocDistanceFromTop = $('#toc_column').offset().top;
           if ($(this).scrollTop() >= tocDistanceFromTop) {
-            $('#toc_column').css('margin-top', '40px');
+            if($("#deprecated_notification").length){
+                $('#toc_column').css('margin-top', $("#deprecated_notification").outerHeight()+'px');
+            } else {
+                $('#toc_column').css('margin-top', '40px');
+            }
           }
         }
     }
@@ -409,6 +425,10 @@ $(document).ready(function() {
         // in guides, if mobile toc accodion is fixed to top of screen, move toc accordion below fixed nav bar
         if ($("#mobile_toc_accordion_container").hasClass("fixed_toc_accordion")  && $("#nav_bar").hasClass("fixed_top")) {
             $("#mobile_toc_accordion_container").css("top", $("#nav_bar").outerHeight() + "px");
+        }
+
+        if ($("#mobile_toc_accordion_container").hasClass("fixed_toc_accordion")  && $("#deprecated_notification").length) {
+            $("#mobile_toc_accordion_container").css("top", $("#deprecated_notification").outerHeight() + "px");
         }
 
         // update width with new width after resizing

--- a/src/main/content/_assets/js/toc.js
+++ b/src/main/content/_assets/js/toc.js
@@ -39,6 +39,7 @@ $(window).on('scroll', function(event) {
                 "top": "0px",
                 "height": calculateTOCHeight()
             })
+            $('#mobile_toc_accordion_container').css({'position':'', 'top':'0px'})
         }
     }
 });

--- a/src/main/content/_assets/js/toc.js
+++ b/src/main/content/_assets/js/toc.js
@@ -13,23 +13,15 @@
 $(window).on('scroll', function(event) {
     var nav_bottom = $('#nav_bar').outerHeight(true);
     if ($(this).scrollTop() > nav_bottom){
-        $('#toc_indicator').css({'position': 'fixed', 'top': '0px'});
+        if($("#deprecated_notification").length){
+            $('#toc_indicator').css({'position': 'fixed', 'top': $("#deprecated_notification").outerHeight()+'px'});
+        } else {
+            $('#toc_indicator').css({'position': 'fixed', 'top': '0px'});
+        }
 
         if (window.innerWidth < 1440) {
-            if($("#deprecated_notification").length){
-                var h = $("#deprecated_notification").outerHeight();
-                $('#toc_column').css({'position': 'fixed', 'top': h+'px'});
-
-            } else {
-                $('#toc_column').css({'position': 'fixed', 'top': '0px'});
-            }
+            $('#toc_column').css({'position': 'fixed', 'top': '0px'});
         }
-    }
-    var scroller_anchor = $(".scroller_anchor").offset().top;
-    if ($("#mobile_toc_accordion_container").hasClass("fixed_toc_accordion") && $("#deprecated_notification").length && $(window).scrollTop() > scroller_anchor) {
-        $("#mobile_toc_accordion_container").css("top", $("#deprecated_notification").outerHeight() + "px");
-        $("#mobile_toc_accordion_container").css("z-index", "5");
-        event.stopImmediatePropogation();
     }
 });
 
@@ -112,7 +104,7 @@ function handleFloatingTOCAccordion() {
         accordion.removeClass('fixed_toc_accordion');
         $('.scroller_anchor').css('height', 0);
         // Restore toc location.
-        $('#toc_column').css('margin-top', '0px');
+        // $('#toc_column').css('margin-top', '0px');
     };
     var disableFloatingTOCAccordion = function(){
         // Change the height of the scroller_anchor to that of the accordion
@@ -138,19 +130,9 @@ function handleFloatingTOCAccordion() {
             // When the user scrolls back up past the scroller_anchor, put the
             // accordion back into the page and remove the scroller_anchor <div>.
             enableFloatingTOCAccordion();
-        } else {
-          //mobile_toc_accordion blocks the top part of the TOC column, need to add margin so that 'X' in TOC is visible
-          var tocDistanceFromTop = $('#toc_column').offset().top;
-          if ($(this).scrollTop() >= tocDistanceFromTop) {
-            if($("#deprecated_notification").length){
-                $('#toc_column').css('margin-top', $("#deprecated_notification").outerHeight()+'px');
-            } else {
-                $('#toc_column').css('margin-top', '40px');
-            }
-          }
         }
     }
-    else{
+    else {
         enableFloatingTOCAccordion();
     }
 }
@@ -425,10 +407,6 @@ $(document).ready(function() {
         // in guides, if mobile toc accodion is fixed to top of screen, move toc accordion below fixed nav bar
         if ($("#mobile_toc_accordion_container").hasClass("fixed_toc_accordion")  && $("#nav_bar").hasClass("fixed_top")) {
             $("#mobile_toc_accordion_container").css("top", $("#nav_bar").outerHeight() + "px");
-        }
-
-        if ($("#mobile_toc_accordion_container").hasClass("fixed_toc_accordion")  && $("#deprecated_notification").length) {
-            $("#mobile_toc_accordion_container").css("top", $("#deprecated_notification").outerHeight() + "px");
         }
 
         // update width with new width after resizing

--- a/src/main/content/_assets/js/toc.js
+++ b/src/main/content/_assets/js/toc.js
@@ -39,7 +39,6 @@ $(window).on('scroll', function(event) {
                 "top": "0px",
                 "height": calculateTOCHeight()
             })
-            $('#mobile_toc_accordion_container').css({'position':'', 'top':'0px'})
         }
     }
 });

--- a/src/main/content/_assets/js/toc.js
+++ b/src/main/content/_assets/js/toc.js
@@ -11,16 +11,34 @@
 
 // make TOC indicator fixed once nav bar scrolls off screen
 $(window).on('scroll', function(event) {
+    $.fn.isInViewport = function () {
+        var elementTop = $(this).offset().top;
+        var elementBottom = elementTop + $(this).outerHeight();
+    
+        var viewportTop = $(window).scrollTop();
+        var viewportBottom = viewportTop + $(window).height();
+    
+        return elementBottom > viewportTop && elementTop < viewportBottom;
+    };
     var nav_bottom = $('#nav_bar').outerHeight(true);
     if ($(this).scrollTop() > nav_bottom){
         if($("#deprecated_notification").length){
             $('#toc_indicator').css({'position': 'fixed', 'top': $("#deprecated_notification").outerHeight()+'px'});
+            // $('#toc_line').css({'position': 'fixed', 'top': $("#deprecated_notification").outerHeight()+'px', 'height':$("#end_of_guide").offset().top});
         } else {
             $('#toc_indicator').css({'position': 'fixed', 'top': '0px'});
         }
 
         if (window.innerWidth < 1440) {
             $('#toc_column').css({'position': 'fixed', 'top': '0px'});
+        }
+
+        if(!($("#end_of_guide").isInViewport())){
+            $('#toc_line').css({
+                "position": "absolute",
+                "top": "0px",
+                "height": calculateTOCHeight()
+            })
         }
     }
 });
@@ -50,7 +68,7 @@ function disableFloatingTOC() {
 }
 
 function calculateTOCHeight(){
-    var endOfGuidePosition = $("#end_of_guide")[0].getClientRects()[0].top;
+    var endOfGuidePosition = $("#end_of_guide").offset().top;
     return endOfGuidePosition;
 }
 

--- a/src/main/content/_assets/js/toc.js
+++ b/src/main/content/_assets/js/toc.js
@@ -11,7 +11,6 @@
 
 // make TOC indicator fixed once nav bar scrolls off screen
 $(window).on('scroll', function(event) {
-    console.log("toc")
     var nav_bottom = $('#nav_bar').outerHeight(true);
     if ($(this).scrollTop() > nav_bottom){
         $('#toc_indicator').css({'position': 'fixed', 'top': '0px'});
@@ -33,9 +32,6 @@ function handleFloatingTableOfContent() {
         } else {
             // The entire viewport is filled with the background, so
             // do not need to worry about the TOC flowing out of the background.
-            if ($(window).scrollTop() > 60) {
-                // enableFloatingTOC();
-            }
             expandTOCIndicator();
         }
     } else {
@@ -47,10 +43,6 @@ function handleFloatingTableOfContent() {
 
 function disableFloatingTOC() {
     $('#toc_inner').width("").css({"position": "", "top": ""});
-}
-
-function enableFloatingTOC() {
-    $('#toc_inner').css({"position":"fixed", "top":"0px"});
 }
 
 function calculateTOCHeight(){


### PR DESCRIPTION
## What was changed and why?
Links to example dep guides on staging:
https://staging-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/guides/microshed-testing.html
https://staging-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/guides/microprofile-opentracing.html

Only the opentracing guide should have an alt-guide link in the notification.

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
