### PR TITLE
[Staging] Edit the docs SEO content description to account for APIs/SPIs

### DIFF
--- a/src/main/content/antora_ui/src/partials/head-meta.hbs
+++ b/src/main/content/antora_ui/src/partials/head-meta.hbs
@@ -8,7 +8,7 @@
 {{else if page.attributes.description }}
 <meta name="description" content="{{page.attributes.description}}">
 {{ else }}
-<meta name="description" content="Open Liberty documentation and reference materials for developers to build applications and for administrators and operation teams to manage DevOps and deploy workloads to clouds using open cloud-native Java. Covers Open Liberty basics, development, security, deployment, and operations topics, as well as Javadoc for Jakarta EE, MicroProfile and Java EE APIs.">
+<meta name="description" content="Open Liberty documentation and reference materials for developers to build applications and for administrators and operation teams to manage DevOps and deploy workloads to clouds using open cloud-native Java. Covers Open Liberty basics, development, security, deployment, and operations topics, as well as Javadoc for Jakarta EE APIs, MicroProfile APIs, Java EE APIs, and Open Liberty APIs/SPIs.">
 {{/if}}
 
 <meta name="twitter:card" content="summary" />
@@ -23,7 +23,7 @@
 {{else if page.attributes.description }}
 <meta name="twitter:description" content="{{ page.attributes.description }}" />
 {{ else }}
-<meta name="twitter:description" content="Open Liberty documentation and reference materials for developers to build applications and for administrators and operation teams to manage DevOps and deploy workloads to clouds using open cloud-native Java. Covers Open Liberty basics, development, security, deployment, and operations topics, as well as Javadoc for Jakarta EE, MicroProfile and Java EE APIs." />
+<meta name="twitter:description" content="Open Liberty documentation and reference materials for developers to build applications and for administrators and operation teams to manage DevOps and deploy workloads to clouds using open cloud-native Java. Covers Open Liberty basics, development, security, deployment, and operations topics, as well as Javadoc for Jakarta EE APIs, MicroProfile APIs, Java EE APIs, and Open Liberty APIs/SPIs." />
 {{/if}}
 <meta name="twitter:image" content="https://openliberty.io/img/twitter_card.jpg" />
 
@@ -39,7 +39,7 @@
 {{else if page.attributes.description }}
 <meta property="og:description" content="{{ page.attributes.description }}" />
 {{ else }}
-<meta property="og:description" content="Open Liberty documentation and reference materials for developers to build applications and for administrators and operation teams to manage DevOps and deploy workloads to clouds using open cloud-native Java. Covers Open Liberty basics, development, security, deployment, and operations topics, as well as Javadoc for Jakarta EE, MicroProfile and Java EE APIs." />
+<meta property="og:description" content="Open Liberty documentation and reference materials for developers to build applications and for administrators and operation teams to manage DevOps and deploy workloads to clouds using open cloud-native Java. Covers Open Liberty basics, development, security, deployment, and operations topics, as well as Javadoc for Jakarta EE APIs, MicroProfile APIs, Java EE APIs, and Open Liberty APIs/SPIs." />
 {{/if}}
 {{#if page.open-graph-image }} 
 <meta property="og:image" content="{{ page.open-graph-image }}" />

--- a/src/main/content/antora_ui/src/partials/head-meta.hbs
+++ b/src/main/content/antora_ui/src/partials/head-meta.hbs
@@ -8,7 +8,7 @@
 {{else if page.attributes.description }}
 <meta name="description" content="{{page.attributes.description}}">
 {{ else }}
-<meta name="description" content="Open Liberty documentation and reference materials for developers to build applications and for administrators and operation teams to manage DevOps and deploy workloads to clouds using open cloud-native Java. Covers Open Liberty basics, development, security, deployment, and operations topics, as well as Javadoc for Jakarta EE APIs, MicroProfile APIs, Java EE APIs, and Open Liberty APIs/SPIs.">
+<meta name="description" content="Open Liberty documentation and reference materials for developers to build applications and for administrators and operation teams to manage DevOps and deploy workloads to clouds by using open cloud-native Java. This content covers Open Liberty basics, development, security, deployment, and operations topics. It also includes Javadoc for Jakarta EE APIs, MicroProfile APIs, Java EE APIs, and Open Liberty APIs and SPIs.">
 {{/if}}
 
 <meta name="twitter:card" content="summary" />
@@ -23,7 +23,7 @@
 {{else if page.attributes.description }}
 <meta name="twitter:description" content="{{ page.attributes.description }}" />
 {{ else }}
-<meta name="twitter:description" content="Open Liberty documentation and reference materials for developers to build applications and for administrators and operation teams to manage DevOps and deploy workloads to clouds using open cloud-native Java. Covers Open Liberty basics, development, security, deployment, and operations topics, as well as Javadoc for Jakarta EE APIs, MicroProfile APIs, Java EE APIs, and Open Liberty APIs/SPIs." />
+<meta name="twitter:description" content="Open Liberty documentation and reference materials for developers to build applications and for administrators and operation teams to manage DevOps and deploy workloads to clouds by using open cloud-native Java. This content covers Open Liberty basics, development, security, deployment, and operations topics. It also includes Javadoc for Jakarta EE APIs, MicroProfile APIs, Java EE APIs, and Open Liberty APIs and SPIs." />
 {{/if}}
 <meta name="twitter:image" content="https://openliberty.io/img/twitter_card.jpg" />
 
@@ -39,7 +39,7 @@
 {{else if page.attributes.description }}
 <meta property="og:description" content="{{ page.attributes.description }}" />
 {{ else }}
-<meta property="og:description" content="Open Liberty documentation and reference materials for developers to build applications and for administrators and operation teams to manage DevOps and deploy workloads to clouds using open cloud-native Java. Covers Open Liberty basics, development, security, deployment, and operations topics, as well as Javadoc for Jakarta EE APIs, MicroProfile APIs, Java EE APIs, and Open Liberty APIs/SPIs." />
+<meta property="og:description" content="Open Liberty documentation and reference materials for developers to build applications and for administrators and operation teams to manage DevOps and deploy workloads to clouds by using open cloud-native Java. This content covers Open Liberty basics, development, security, deployment, and operations topics. It also includes Javadoc for Jakarta EE APIs, MicroProfile APIs, Java EE APIs, and Open Liberty APIs and SPIs." />
 {{/if}}
 {{#if page.open-graph-image }} 
 <meta property="og:image" content="{{ page.open-graph-image }}" />


### PR DESCRIPTION
## What was changed and why?
The new sentence appears on [draft](https://draft-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/docs/latest/overview.html):
<img width="904" alt="image" src="https://github.com/OpenLiberty/openliberty.io/assets/6392944/ed9c9ef9-6a17-4b62-acce-8c9bc7196a5d">


## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
