### PR TITLE
[Staging] Fix showing what versions of OL documentation have the API/SPI pages

### DIFF
--- a/src/main/content/antora_ui/src/js/09-noversion.js
+++ b/src/main/content/antora_ui/src/js/09-noversion.js
@@ -34,8 +34,8 @@ $(window).on("load", function() {
           preceed1 === "javadoc" ||
           preceed1 === "config" ||
           preceed1 === "command" ||
-          preceed1 === "api" ||
-          preceed1 === "spi"
+          preceed1 === "javadoc/api" ||
+          preceed1 === "javadoc/spi"
         ) {
           folder = "reference";
           dir = "/" + preceed1;

--- a/src/main/content/antora_ui/src/js/09-noversion.js
+++ b/src/main/content/antora_ui/src/js/09-noversion.js
@@ -30,7 +30,9 @@ $(window).on("load", function() {
           preceed1 === "feature" ||
           preceed1 === "javadoc" ||
           preceed1 === "config" ||
-          preceed1 === "command"
+          preceed1 === "command" ||
+          preceed1 === "api" ||
+          preceed1 === "spi"
         ) {
           folder = "reference";
           dir = "/" + preceed1;

--- a/src/main/content/antora_ui/src/js/09-noversion.js
+++ b/src/main/content/antora_ui/src/js/09-noversion.js
@@ -23,6 +23,9 @@ $(window).on("load", function() {
 
       var preceed1 = attempted.substring(0, attempted.lastIndexOf("/"));
       preceed1 = preceed1.substring(preceed1.lastIndexOf("/") + 1);
+      if(preceed1 === "api" || preceed1 === "spi"){
+        preceed1 = "javadoc/" + preceed1;
+      }
       if (preceed1 === "reference") {
         folder = "reference";
       } else {


### PR DESCRIPTION
## What was changed and why?
Fix showing what versions of OL documentation have the API/SPI pages when navigating to a OL version without it.
We can't view it on draft, because the draft playbook doesn't build anything but the draft branch of docs-generated, and we chose to not have the api/spis in draft. Works on demo1 website: https://demo1-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/docs/23.0.0.1/noversion.html?ref=/docs/latest/reference/javadoc/api/restConnector-2.0.com.ibm.websphere.filetransfer.html

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)
