### PR TITLE
Add test results to the release builds table

### DIFF
--- a/src/main/content/_assets/css/openliberty.scss
+++ b/src/main/content/_assets/css/openliberty.scss
@@ -140,13 +140,19 @@ a {
     font-size: 20px;
 }
 
-.release_table_body tr td a.blog_release_notes {
+.release_table_body tr td a.version_sublink {
     display: block;
     font-weight: 400;
+
+    &::before {
+        content: "•";
+        font-size: 16px;
+        margin-right: 5px;
+    }
 }
 
-.release_table_body tr td a.blog_release_notes,
-.release_table_body tr td a.blog_release_notes:focus {
+.release_table_body tr td a.version_sublink,
+.release_table_body tr td a.version_sublink:focus {
     color: #5E6B8D;
 }
 
@@ -155,7 +161,7 @@ a {
     color: #CC4D19;
 }
 
-.release_table_body tr td a.blog_release_notes:hover,
+.release_table_body tr td a.version_sublink:hover,
 .orange_link_light_background:hover {
     transition: all .2s;
 }
@@ -164,7 +170,7 @@ a {
     color: #F4914D;
 }
 
-.release_table_body tr td a.blog_release_notes:hover {
+.release_table_body tr td a.version_sublink:hover {
     color: #8595BE;
 }
 

--- a/src/main/content/_assets/css/start.scss
+++ b/src/main/content/_assets/css/start.scss
@@ -606,7 +606,7 @@ html, body {
     width: 75%;
 }
 
-.releases_table .download_button_column {
+.releases_table th {
     width: 20%;
 }
 

--- a/src/main/content/_assets/css/start.scss
+++ b/src/main/content/_assets/css/start.scss
@@ -607,7 +607,7 @@ html, body {
 }
 
 .releases_table .download_button_column {
-    width: 25%;
+    width: 20%;
 }
 
 .white_table tbody tr {

--- a/src/main/content/_assets/css/start.scss
+++ b/src/main/content/_assets/css/start.scss
@@ -606,8 +606,8 @@ html, body {
     width: 75%;
 }
 
-.releases_table th {
-    width: 20%;
+.releases_table .download_button_column {
+    width: 25%;
 }
 
 .white_table tbody tr {

--- a/src/main/content/_assets/js/builds.js
+++ b/src/main/content/_assets/js/builds.js
@@ -319,7 +319,9 @@ function render_builds(builds, parent) {
                         var tests_column = $(
                             '<td headers="' +
                                 tableID +
-                                '_tests"><a href="' +
+                                '_tests" rowspan="' +
+                                num_packages + 
+                                '"><a href="' +
                                 build.tests_log +
                                 '" class="' +
                                 analytics_class_name +

--- a/src/main/content/_assets/js/builds.js
+++ b/src/main/content/_assets/js/builds.js
@@ -260,7 +260,7 @@ function render_builds(builds, parent) {
                         for (var i = 0; i < max - num_packages; i++) {
                             parent.append('<tr></tr>');
                         }
-                    }
+                    }                    
                     
                     var version_column = $(
                         '<td headers="' +
@@ -269,7 +269,12 @@ function render_builds(builds, parent) {
                             num_packages +
                             '">' +
                             build.version +
-                            (releaseBuild.releasePostLink ? '<a class="blog_release_notes" href="'+baseURL+'/blog/'+releaseBuild.releasePostLink+'">'+release_blog+'</a>' : '') +
+                            (releaseBuild.releasePostLink ? '<a class="version_sublink" href="'+baseURL+'/blog/'+releaseBuild.releasePostLink+'">'+release_blog+'</a>' : '') +
+                            (releaseBuild.tests_log ? 
+                                '<a class="version_sublink" ' +
+                                'href="'+releaseBuild.tests_log + '" ' +
+                                'title="' + releaseBuild.test_passed + '/' + releaseBuild.total_tests + ' tests passing"' +
+                                '>Test results</a>' : '') +
                             '</td>'
                     );
 
@@ -314,23 +319,7 @@ function render_builds(builds, parent) {
                             // Optional sig file download button
                             (sig_href ? '<a href="'+pem_href+'" class="'+analytics_class_name +'" rel="noopener">' + download_arrow +'PEM</a>' : '' ) +
                             '</td>'
-                        );
-
-                        var tests_column = $(
-                            '<td headers="' +
-                                tableID +
-                                '_tests" rowspan="' +
-                                num_packages + 
-                                '"><a href="' +
-                                build.tests_log +
-                                '" class="' +
-                                analytics_class_name +
-                                ' tests_passed_link" rel="noopener">' +
-                                build.test_passed +
-                                ' / ' +
-                                build.total_tests +
-                                '</a></td>'
-                        );
+                        );     
 
                         if (k === 0) {
                             row.append(version_column); // add version column for first item in package_locations
@@ -428,11 +417,6 @@ function render_builds(builds, parent) {
                                 tableID +
                                 '_package">All GA Features</td>';
                         }
-                    
-                        if (k === 0) {
-                            // Only add the tests column to the row with Version
-                            row.append(tests_column);                          
-                        }
                         row.append(package_column);
                         row.append(download_column);                        
                         row.append(verification_column);
@@ -479,6 +463,22 @@ function render_builds(builds, parent) {
                     // without checking the .sig files.
                     beta_package_locations = 
                         getAllowedBuilds('runtime_betas', beta_package_locations, version);
+
+                    var tests_column = $(
+                        '<td headers="' +
+                            tableID +
+                            '_tests" rowspan="' +
+                            num_packages + 
+                            '"><a href="' +
+                            build.tests_log +
+                            '" class="' +
+                            analytics_class_name +
+                            ' tests_passed_link" rel="noopener">' +
+                            build.test_passed +
+                            ' / ' +
+                            build.total_tests +
+                            '</a></td>'
+                    );
                     
                     var num_beta_packages = beta_package_locations.length;
                     var beta_version_column = $(
@@ -488,7 +488,7 @@ function render_builds(builds, parent) {
                             num_beta_packages +
                             '">' +
                             build.version +
-                            (betaBuild.betaPostLink ? '<a class="blog_release_notes" href="'+baseURL+'/blog/'+betaBuild.betaPostLink+'">'+release_blog+'</a>' : '') +
+                            (betaBuild.betaPostLink ? '<a class="version_sublink" href="'+baseURL+'/blog/'+betaBuild.betaPostLink+'">'+release_blog+'</a>' : '') +
                             '</td>'
                     );
             

--- a/src/main/content/_assets/js/builds.js
+++ b/src/main/content/_assets/js/builds.js
@@ -463,22 +463,6 @@ function render_builds(builds, parent) {
                     // without checking the .sig files.
                     beta_package_locations = 
                         getAllowedBuilds('runtime_betas', beta_package_locations, version);
-
-                    var tests_column = $(
-                        '<td headers="' +
-                            tableID +
-                            '_tests" rowspan="' +
-                            num_packages + 
-                            '"><a href="' +
-                            build.tests_log +
-                            '" class="' +
-                            analytics_class_name +
-                            ' tests_passed_link" rel="noopener">' +
-                            build.test_passed +
-                            ' / ' +
-                            build.total_tests +
-                            '</a></td>'
-                    );
                     
                     var num_beta_packages = beta_package_locations.length;
                     var beta_version_column = $(

--- a/src/main/content/_assets/js/builds.js
+++ b/src/main/content/_assets/js/builds.js
@@ -428,12 +428,12 @@ function render_builds(builds, parent) {
                         }
                     
                         row.append(package_column);
-                        row.append(download_column);
-                        row.append(tests_column);
+                        row.append(download_column);                        
                         row.append(verification_column);
                         if (k === 0) {
-                            // Only add the PEM button to the row with Version
-                            row.append(verification_column2);                            
+                            // Only add the PEM button and tests column to the row with Version
+                            row.append(verification_column2);  
+                            row.append(tests_column);                          
                         }
 
                         // checking if version is from the last two years before adding to table
@@ -658,7 +658,7 @@ function highlightAlternateRows() {
 
     // 1. Look for all the release Version rows and apply the styling to every other version row
     $("#runtime_releases_table_container .release_table_body tr").filter(function() { 
-        return $(this).children().length === total_releases_columns;
+        return $(this).children().length === total_releases_columns; 
     }).filter(':even').addClass('highlight_alternate_rows');
 
     // 2. Look for all the beta Version rows and apply the styling to every other version row

--- a/src/main/content/_assets/js/builds.js
+++ b/src/main/content/_assets/js/builds.js
@@ -316,6 +316,20 @@ function render_builds(builds, parent) {
                             '</td>'
                         );
 
+                        var tests_column = $(
+                            '<td headers="' +
+                                tableID +
+                                '_tests"><a href="' +
+                                build.tests_log +
+                                '" class="' +
+                                analytics_class_name +
+                                ' tests_passed_link" rel="noopener">' +
+                                build.test_passed +
+                                ' / ' +
+                                build.total_tests +
+                                '</a></td>'
+                        );
+
                         if (k === 0) {
                             row.append(version_column); // add version column for first item in package_locations
                         }
@@ -415,10 +429,11 @@ function render_builds(builds, parent) {
                     
                         row.append(package_column);
                         row.append(download_column);
+                        row.append(tests_column);
                         row.append(verification_column);
                         if (k === 0) {
                             // Only add the PEM button to the row with Version
-                            row.append(verification_column2);
+                            row.append(verification_column2);                            
                         }
 
                         // checking if version is from the last two years before adding to table

--- a/src/main/content/_assets/js/builds.js
+++ b/src/main/content/_assets/js/builds.js
@@ -429,13 +429,16 @@ function render_builds(builds, parent) {
                                 '_package">All GA Features</td>';
                         }
                     
+                        if (k === 0) {
+                            // Only add the tests column to the row with Version
+                            row.append(tests_column);                          
+                        }
                         row.append(package_column);
                         row.append(download_column);                        
                         row.append(verification_column);
                         if (k === 0) {
-                            // Only add the PEM button and tests column to the row with Version
-                            row.append(verification_column2);  
-                            row.append(tests_column);                          
+                            // Only add the PEM button to the row with Version
+                            row.append(verification_column2);              
                         }
 
                         // checking if version is from the last two years before adding to table

--- a/src/main/content/start.html
+++ b/src/main/content/start.html
@@ -276,7 +276,7 @@ seo-description: Use Maven or Gradle to create a starter application for develop
                                         <th id="runtime_releases_version" class="version_column"><a href="" data-key="version" data-descending="true" class="functional_link sort_link">{% t start.download_package_section.table_header.version %}</a></th>
                                         <th id="runtime_releases_package" class="package_name_column">{% t start.download_package_section.table_header.package %}</th>
                                         <th id="runtime_releases_download" class="download_button_column">{% t start.download_package_section.table_header.download %}</th>
-                                        <th id="runtime_releases_test_results" class="download_button_column" colspan="2">{% t start.download_package_section.table_header.tests %}</th>
+                                        <th id="runtime_releases_test_results" class="download_button_column">{% t start.download_package_section.table_header.tests %}</th>
                                         <th id="runtime_releases_verification" class="download_button_column" colspan="2">{% t start.download_package_section.table_header.verification %}</th>
                                     </tr>
                                 </thead>

--- a/src/main/content/start.html
+++ b/src/main/content/start.html
@@ -276,6 +276,7 @@ seo-description: Use Maven or Gradle to create a starter application for develop
                                         <th id="runtime_releases_version" class="version_column"><a href="" data-key="version" data-descending="true" class="functional_link sort_link">{% t start.download_package_section.table_header.version %}</a></th>
                                         <th id="runtime_releases_package" class="package_name_column">{% t start.download_package_section.table_header.package %}</th>
                                         <th id="runtime_releases_download" class="download_button_column">{% t start.download_package_section.table_header.download %}</th>
+                                        <th id="runtime_releases_test_results" class="download_button_column" colspan="2">{% t start.download_package_section.table_header.tests %}</th>
                                         <th id="runtime_releases_verification" class="download_button_column" colspan="2">{% t start.download_package_section.table_header.verification %}</th>
                                     </tr>
                                 </thead>

--- a/src/main/content/start.html
+++ b/src/main/content/start.html
@@ -274,10 +274,10 @@ seo-description: Use Maven or Gradle to create a starter application for develop
                                 <thead>
                                     <tr>
                                         <th id="runtime_releases_version" class="version_column"><a href="" data-key="version" data-descending="true" class="functional_link sort_link">{% t start.download_package_section.table_header.version %}</a></th>
+                                        <th id="runtime_releases_tests" class="download_button_column">{% t start.download_package_section.table_header.tests %}</th>
                                         <th id="runtime_releases_package" class="package_name_column">{% t start.download_package_section.table_header.package %}</th>
                                         <th id="runtime_releases_download" class="download_button_column">{% t start.download_package_section.table_header.download %}</th>                                        
                                         <th id="runtime_releases_verification" class="download_button_column" colspan="2">{% t start.download_package_section.table_header.verification %}</th>
-                                        <th id="runtime_releases_tests" class="download_button_column">{% t start.download_package_section.table_header.tests %}</th>
                                     </tr>
                                 </thead>
                                 <tbody class="release_table_body">

--- a/src/main/content/start.html
+++ b/src/main/content/start.html
@@ -275,9 +275,9 @@ seo-description: Use Maven or Gradle to create a starter application for develop
                                     <tr>
                                         <th id="runtime_releases_version" class="version_column"><a href="" data-key="version" data-descending="true" class="functional_link sort_link">{% t start.download_package_section.table_header.version %}</a></th>
                                         <th id="runtime_releases_package" class="package_name_column">{% t start.download_package_section.table_header.package %}</th>
-                                        <th id="runtime_releases_download" class="download_button_column">{% t start.download_package_section.table_header.download %}</th>
-                                        <th id="runtime_releases_test_results" class="download_button_column">{% t start.download_package_section.table_header.tests %}</th>
+                                        <th id="runtime_releases_download" class="download_button_column">{% t start.download_package_section.table_header.download %}</th>                                        
                                         <th id="runtime_releases_verification" class="download_button_column" colspan="2">{% t start.download_package_section.table_header.verification %}</th>
+                                        <th id="runtime_releases_test_results" class="download_button_column">{% t start.download_package_section.table_header.tests %}</th>
                                     </tr>
                                 </thead>
                                 <tbody class="release_table_body">

--- a/src/main/content/start.html
+++ b/src/main/content/start.html
@@ -274,7 +274,6 @@ seo-description: Use Maven or Gradle to create a starter application for develop
                                 <thead>
                                     <tr>
                                         <th id="runtime_releases_version" class="version_column"><a href="" data-key="version" data-descending="true" class="functional_link sort_link">{% t start.download_package_section.table_header.version %}</a></th>
-                                        <th id="runtime_releases_tests" class="download_button_column">{% t start.download_package_section.table_header.tests %}</th>
                                         <th id="runtime_releases_package" class="package_name_column">{% t start.download_package_section.table_header.package %}</th>
                                         <th id="runtime_releases_download" class="download_button_column">{% t start.download_package_section.table_header.download %}</th>                                        
                                         <th id="runtime_releases_verification" class="download_button_column" colspan="2">{% t start.download_package_section.table_header.verification %}</th>

--- a/src/main/content/start.html
+++ b/src/main/content/start.html
@@ -277,7 +277,7 @@ seo-description: Use Maven or Gradle to create a starter application for develop
                                         <th id="runtime_releases_package" class="package_name_column">{% t start.download_package_section.table_header.package %}</th>
                                         <th id="runtime_releases_download" class="download_button_column">{% t start.download_package_section.table_header.download %}</th>                                        
                                         <th id="runtime_releases_verification" class="download_button_column" colspan="2">{% t start.download_package_section.table_header.verification %}</th>
-                                        <th id="runtime_releases_test_results" class="download_button_column">{% t start.download_package_section.table_header.tests %}</th>
+                                        <th id="runtime_releases_tests" class="download_button_column">{% t start.download_package_section.table_header.tests %}</th>
                                     </tr>
                                 </thead>
                                 <tbody class="release_table_body">


### PR DESCRIPTION
## What was changed and why?
Add test results to each release build. Hover over shows the tests passed / total tests ran.
![image](https://github.com/OpenLiberty/openliberty.io/assets/6392944/3f1d088b-d983-49ba-9bff-4c30f7dc9188)


## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
