### PR TITLE
Lowercase 'Eclipse developer tools'

### DIFF
--- a/src/main/content/_i18n/en.yml
+++ b/src/main/content/_i18n/en.yml
@@ -114,7 +114,7 @@ start:
     eclipse_link: Eclipse IDE
     intellij_link: IntelliJ IDEA
     vscode_link: Visual Studio Code
-    section_text3: The classic Eclipse Developer Tools can be found in
+    section_text3: The classic Eclipse developer tools can be found in
     public_dhe_link: 'this repository, '
     section_text4: and you can find
     github_link: instructions on how to install the classic tools here.

--- a/src/main/content/_i18n/ja.yml
+++ b/src/main/content/_i18n/ja.yml
@@ -112,7 +112,7 @@ start:
     development_builds: Development builds
     betas: Betas
     nightly_builds: Nightly Builds
-    eclipse_developer_tools: Eclipse Developer Tools
+    eclipse_developer_tools: Eclipse developer tools
     table_header:
       version: Version
       package: Package

--- a/src/main/content/_i18n/zh-Hans.yml
+++ b/src/main/content/_i18n/zh-Hans.yml
@@ -112,7 +112,7 @@ start:
     development_builds: Development builds
     betas: Betas
     nightly_builds: Nightly Builds
-    eclipse_developer_tools: Eclipse Developer Tools
+    eclipse_developer_tools: Eclipse developer tools
     table_header:
       version: Version
       package: Package


### PR DESCRIPTION
## What was changed and why?

This doesn't seem like it should be capitalized.  We had names like: 
Open Liberty Tools, WebSphere Developer Tools, etc.
but we never had an "Eclipse Developer Tools" right?

@yeekangc would you agree?

I didn't do any testing by the way, just find/replace.