### PR TITLE
[Staging] Local build wrapper

### DIFF
--- a/scripts/build/build.sh
+++ b/scripts/build/build.sh
@@ -2,8 +2,10 @@
 
 timer_start=$(date +%s)
 echo "Update packages & prep environment"
+if [ "$LOCAL_BUILD" = false ]; then
 sudo apt-get update
 sudo apt-get install nodejs python3-bs4 libgdbm-dev libncurses5-dev automake libtool bison libffi-dev python3-lxml -y
+fi
 
 export BUILD_SCRIPTS_DIR=$(dirname $0)
 

--- a/scripts/build/docs_part_1.sh
+++ b/scripts/build/docs_part_1.sh
@@ -13,8 +13,10 @@ echo "npm analysis during build"
 npm ls -g --depth=0
 
 #comment out this below two line in local during build
+if [ "$LOCAL_BUILD" = false ]; then
 ln -s "$(which node)" /usr/bin/node
 ln -s "$(which npm)" /usr/bin/npm
+fi
 
 #Antora Portion of Docs
 echo "Begin building of Antora portion of docs"

--- a/scripts/build/jekyll.sh
+++ b/scripts/build/jekyll.sh
@@ -87,8 +87,10 @@ if [ "$PROD_SITE" = true ]
 fi
 
 # Temporary routine
+# Delete existing content under src/main/content/<lang> to be able to copy built content here
 # Remove all translated pages expect the ones ready for public viewing
 # Japanese
+rm -rf ja
 mv target/jekyll-webapp/ja/ .
 mkdir -p target/jekyll-webapp/ja/
 mv ja/feed.xml target/jekyll-webapp/ja/
@@ -96,6 +98,7 @@ mv ja/blog target/jekyll-webapp/ja/
 mv ja/assets target/jekyll-webapp/ja/
 
 # Simplified Chinese
+rm -rf zh-Hans
 mv target/jekyll-webapp/zh-Hans/ .
 mkdir -p target/jekyll-webapp/zh-Hans/
 mv zh-Hans/feed.xml target/jekyll-webapp/zh-Hans/

--- a/scripts/build/local_site_build.sh
+++ b/scripts/build/local_site_build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+export LOCAL_BUILD=true
+export BUILD_SCRIPTS_DIR=$(dirname $0)
+
+source $BUILD_SCRIPTS_DIR/build.sh

--- a/scripts/build/ruby_install.sh
+++ b/scripts/build/ruby_install.sh
@@ -2,7 +2,9 @@
 timer_start=$(date +%s)
 
 echo "Install Ruby & required packages/gems"
+if [ "$LOCAL_BUILD" = false ]; then
 sudo apt-get -y install gnupg build-essential
+fi
 
 cat $BUILD_SCRIPTS_DIR/../gpg/mpapis.asc | gpg --import -
 cat $BUILD_SCRIPTS_DIR/../gpg/pkuczynski.asc | gpg --import -


### PR DESCRIPTION
## What was changed and why?
Create a wrapper called ./scripts/build/local_site_build.sh around ./scripts/build/build.sh that adds an env variable to not run certain commands that don't work on a mac/local environment.

In scripts/build/jekyll.sh, i also removed existing directories if you try to re-run the site build locally that would fail before if the directory already existed.

Looks good on draft: https://draft-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
