### PR TITLE
Revert "do not copy source files from docs to maven"

### DIFF
--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -42,7 +42,7 @@ FROM icr.io/appcafe/open-liberty-devfile-stack:22.0.0.1 as war
 COPY mvnw /
 COPY .mvn /.mvn
 COPY pom.xml /
-# COPY --from=docs --chown=1001:0 /src /src
+COPY --from=docs --chown=1001:0 /src /src
 COPY --from=docs --chown=1001:0 /target /target
 RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 compile war:exploded
 


### PR DESCRIPTION
## What was changed and why?

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
