### PR TITLE
Fix the war excludes for javadocs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
 								<directory>target/jekyll-webapp</directory>
 							</resource>
 						</webResources>
-						<warSourceExcludes>src/main/content/docs-javadocs/*</warSourceExcludes>
+						<warSourceExcludes>src/main/content/docs-javadoc/*</warSourceExcludes>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
## What was changed and why?

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
