### PR TITLE
Fix not having the modules directory twice

### DIFF
--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -50,7 +50,7 @@ COPY --from=docs --chown=1001:0 /target /target
 RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 compile war:exploded
 
 COPY --from=docs --chown=1001:0 src/main/content/build/docs/site/docs/* /config/apps/openliberty.war/docs
-COPY --from=docs --chown=1001:0 src/main/content/docs-javadoc/modules /config/apps/openliberty.war/docs
+COPY --from=docs --chown=1001:0 src/main/content/docs-javadoc/modules/* /config/apps/openliberty.war/docs/modules
 
 #
 #


### PR DESCRIPTION
## What was changed and why?

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
