### PR TITLE
Fix docs directory to copy from

### DIFF
--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -49,7 +49,7 @@ COPY --from=docs --chown=1001:0 /src /src
 COPY --from=docs --chown=1001:0 /target /target
 RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 compile war:exploded
 
-COPY --from=docs --chown=1001:0 src/main/content/build/docs/site/docs/* /config/apps/openliberty.war/docs
+COPY --from=docs --chown=1001:0 src/main/content/docs/build/site/docs/* /config/apps/openliberty.war/docs
 COPY --from=docs --chown=1001:0 src/main/content/docs-javadoc/modules /config/apps/openliberty.war/docs
 
 #


### PR DESCRIPTION
## What was changed and why?

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
