### PR TITLE
Update Dockerfile.staging

### DIFF
--- a/docker/Dockerfile.staging
+++ b/docker/Dockerfile.staging
@@ -45,7 +45,7 @@ COPY .mvn /.mvn
 COPY pom.xml /
 COPY --from=docs --chown=1001:0 /src /src
 COPY --from=docs --chown=1001:0 /target /target
-RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 -DargLine="-Xmx8000m -XX:MaxPermSize=4000m" compile war:exploded
+RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 compile -DargLine="-Xmx4096m -XX:MaxPermSize=512m" war:exploded
 
 #
 #


### PR DESCRIPTION
move command line args in front of maven war plugin call instead of the compile section

## What was changed and why?

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)
