### PR TITLE
Fixed  the appearance of TOC in interactive guides

### DIFF
--- a/src/main/content/_assets/js/openliberty.js
+++ b/src/main/content/_assets/js/openliberty.js
@@ -45,9 +45,9 @@ var openliberty = (function() {
 
             // make toc scroll off of screen at Nice Work section in guides
             if (typeof isBackgroundBottomVisible === "function") {
-                if(isBackgroundBottomVisible()) {
+                setTimeout( () => { if(isBackgroundBottomVisible()) {
                     handleTOCScrolling();
-                }
+                } }, 2000);
             }
 
             prevScrollTop = currScrollTop;

--- a/src/main/content/_assets/js/openliberty.js
+++ b/src/main/content/_assets/js/openliberty.js
@@ -8,7 +8,8 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-var openliberty = (function() {
+setTimeout(() => {
+     var openliberty = (function() {
     $(document).ready(function() {
         var scrollAllowed = true;
         var prevScrollTop = 0;
@@ -45,9 +46,9 @@ var openliberty = (function() {
 
             // make toc scroll off of screen at Nice Work section in guides
             if (typeof isBackgroundBottomVisible === "function") {
-                setTimeout( () => { if(isBackgroundBottomVisible()) {
+                 if(isBackgroundBottomVisible()) {
                     handleTOCScrolling();
-                } }, 2000);
+                } 
             }
 
             prevScrollTop = currScrollTop;
@@ -179,4 +180,4 @@ var openliberty = (function() {
         allowScrolling: allowScrolling,
         copy_element_to_clipboard: copy_element_to_clipboard
     };
-})();
+})() },1000);


### PR DESCRIPTION
The interactive guides initially loads up with end of window shown and hence the TOC gets its top value updated to negative number. On setting a delay of 1 sec in triggering the function, this issue was resolved

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
