### PR TITLE
Revert "Upgrade to 23.0.0.12 Open Liberty driver (draft)"

### DIFF
--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -49,7 +49,7 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 compile war:exploded
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:23.0.0.12-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:23.0.0.5-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY src/main/wlp/server.xml /config/server.xml

--- a/docker/Dockerfile.draft
+++ b/docker/Dockerfile.draft
@@ -50,7 +50,7 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 compile war:exploded
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:23.0.0.12-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:23.0.0.5-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY src/main/wlp/server.xml /config/server.xml

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -68,7 +68,7 @@ COPY --from=docs --chown=1001:0 /temp-docs/docs /target/openliberty-website-1.0-
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:23.0.0.12-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:23.0.0.5-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY src/main/wlp/server.xml /config/server.xml

--- a/docker/Dockerfile.staging
+++ b/docker/Dockerfile.staging
@@ -65,7 +65,7 @@ COPY --from=docs --chown=1001:0 /temp-docs/docs /target/openliberty-website-1.0-
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:23.0.0.12-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:23.0.0.5-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY src/main/wlp/server.xml /config/server.xml

--- a/docker/blogs/Dockerfile.blogs.draft
+++ b/docker/blogs/Dockerfile.blogs.draft
@@ -42,7 +42,7 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 compile war:exploded
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:23.0.0.12-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:23.0.0.5-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY src/main/wlp/server.xml /config/server.xml

--- a/docker/blogs/Dockerfile.blogs.staging
+++ b/docker/blogs/Dockerfile.blogs.staging
@@ -42,7 +42,7 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 compile war:exploded
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:23.0.0.12-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:23.0.0.5-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY src/main/wlp/server.xml /config/server.xml

--- a/docker/certifications/Dockerfile.certifications.draft
+++ b/docker/certifications/Dockerfile.certifications.draft
@@ -42,7 +42,7 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 compile war:exploded
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:23.0.0.12-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:23.0.0.5-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY src/main/wlp/server.xml /config/server.xml

--- a/docker/certifications/Dockerfile.certifications.staging
+++ b/docker/certifications/Dockerfile.certifications.staging
@@ -42,7 +42,7 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 compile war:exploded
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:23.0.0.12-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:23.0.0.5-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY src/main/wlp/server.xml /config/server.xml

--- a/docker/docs/Dockerfile.docs.draft
+++ b/docker/docs/Dockerfile.docs.draft
@@ -54,7 +54,7 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 compile war:exploded
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:23.0.0.12-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:23.0.0.5-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY src/main/wlp/server.xml /config/server.xml

--- a/docker/docs/Dockerfile.docs.staging
+++ b/docker/docs/Dockerfile.docs.staging
@@ -54,7 +54,7 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 compile war:exploded
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:23.0.0.12-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:23.0.0.5-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY src/main/wlp/server.xml /config/server.xml

--- a/docker/guides/Dockerfile.guides.draft
+++ b/docker/guides/Dockerfile.guides.draft
@@ -42,7 +42,7 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 compile war:exploded
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:23.0.0.12-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:23.0.0.5-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY src/main/wlp/server.xml /config/server.xml

--- a/docker/guides/Dockerfile.guides.staging
+++ b/docker/guides/Dockerfile.guides.staging
@@ -42,7 +42,7 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 compile war:exploded
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:23.0.0.12-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:23.0.0.5-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY src/main/wlp/server.xml /config/server.xml

--- a/docker/ui-only/Dockerfile.ui-only
+++ b/docker/ui-only/Dockerfile.ui-only
@@ -41,7 +41,7 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 compile war:exploded
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:23.0.0.12-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:23.0.0.5-kernel-slim-java8-openj9-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY src/main/wlp/server.xml /config/server.xml


### PR DESCRIPTION
Reverts OpenLiberty/openliberty.io#3530
`configure.sh` script failed (exit code 1)

Update: there was a breaking change in the build that may have been affecting this, will try to apply these changes again once the breaking change is fixed