### PR TITLE
Faraday update

### DIFF
--- a/scripts/build/ruby_install.sh
+++ b/scripts/build/ruby_install.sh
@@ -30,6 +30,7 @@ gem install jekyll -v 3.8.6
 gem install jekyll-assets -v 2.4.0
 gem install jekyll-multiple-languages-plugin
 gem install bundler -v 2.4.22
+gem install faraday-net_http -v 3.0.2
 gem install jekyll-feed jekyll-asciidoc jekyll-include-cache coderay octokit
 
 timer_end=$(date +%s)

--- a/src/main/content/_i18n/en.yml
+++ b/src/main/content/_i18n/en.yml
@@ -263,7 +263,7 @@ blog:
     docker: docker
     gradle: gradle
     metrics: metrics
-    jakarta-ee: jakartaee
+    jakarta-ee: jakarta-ee
     kubernetes: kubernetes
     community: community
     test: test

--- a/src/main/content/_i18n/ja.yml
+++ b/src/main/content/_i18n/ja.yml
@@ -252,7 +252,7 @@ blog:
     part3: フィードを購読します。
   tags:
     announcements: 発表
-    microprofile: MicroProfile
+    microprofile: microprofile
     java-ee: java-ee
     java-se: java-se
     release: リリース
@@ -263,7 +263,7 @@ blog:
     docker: docker
     gradle: gradle
     metrics: メトリック
-    jakarta-ee: jakartaee
+    jakarta-ee: jakarta-ee
     kubernetes: kubernetes
     community: コミュニティ
     test: テスト


### PR DESCRIPTION
## What was changed and why?
Update `faraday-net_http` to be compatible with our version of ruby

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
