### PR TITLE
Version links of Releases table in get started page

### DIFF
--- a/src/main/content/_assets/js/builds.js
+++ b/src/main/content/_assets/js/builds.js
@@ -263,10 +263,7 @@ function render_builds(builds, parent) {
                             tableID +
                             '_version" rowspan="' +
                             num_packages +
-                            '">' + '<a href="#' +
-                            version_id +
-                            '">' +
-                            "</a>" +
+                            '">' + 
                             build.version +
                             (releaseBuild.releasePostLink ? '<a class="version_sublink" href="'+baseURL+'/blog/'+releaseBuild.releasePostLink+'">'+release_blog+'</a>' : '') +
                             (releaseBuild.tests_log ? 

--- a/src/main/content/_assets/js/builds.js
+++ b/src/main/content/_assets/js/builds.js
@@ -217,6 +217,7 @@ function render_builds(builds, parent) {
         }
     });
 
+    let flag=0;
     builds.forEach(function (build) {
         if (parent.hasClass('release_table_body')) {
             if (build.version.indexOf('-RC') > -1) {
@@ -253,13 +254,19 @@ function render_builds(builds, parent) {
                             parent.append('<tr></tr>');
                         }
                     }                    
-                    
+                    var version_id = flag == 0 ? "latest" : build.version.replace(/\./g, "-");
+                    flag = 1;
                     var version_column = $(
-                        '<td headers="' +
+                        '<td id="' + 
+                            version_id + 
+                            '" headers="' +
                             tableID +
                             '_version" rowspan="' +
                             num_packages +
+                            '">' + '<a href="#' +
+                            version_id +
                             '">' +
+                            "</a>" +
                             build.version +
                             (releaseBuild.releasePostLink ? '<a class="version_sublink" href="'+baseURL+'/blog/'+releaseBuild.releasePostLink+'">'+release_blog+'</a>' : '') +
                             (releaseBuild.tests_log ? 


### PR DESCRIPTION
## What was changed and why?
Links to each versions in _Releases table_ is provided. Link to the issue [here](https://github.com/OpenLiberty/openliberty.io/issues/3520)

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
