### PR TITLE
Updates to add MP 6.1 to starter

### DIFF
--- a/src/main/content/_assets/js/builds.js
+++ b/src/main/content/_assets/js/builds.js
@@ -886,7 +886,7 @@ function validate_java_eeAndmp_levels() {
     )
     .find(':selected')
     .text(); 
-    if ((mpVersion === '6.0') || (eeVersion == '10.0')) {
+    if ((mpVersion === '6.0') || (eeVersion == '10.0') || (mpVersion === "6.1")) {
         javaVersion = $(
             '.starter_field[data-starter-field=\'j\'] select'
         )
@@ -900,7 +900,7 @@ function validate_java_eeAndmp_levels() {
            });
          $(javaOptions).prop('selected', true);
          var message = $(
-         '<p> MicroProfile Version 6.0 and Java EE/Jakarta EE Version 10.0 require a minimum of Java SE Version 11.</p>' 
+         '<p> MicroProfile Version '+mpVersion+' and Java EE/Jakarta EE Version 10.0 require a minimum of Java SE Version 11.</p>' 
          );
          displayMessage(message,true);
          valid = true;


### PR DESCRIPTION
## What was changed and why?
Looks good on draft: https://draft-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/start/#_create_a_starter_application
## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
