### PR TITLE
Blog authors without github id made unclickable

### DIFF
--- a/src/main/content/_layouts/post.html
+++ b/src/main/content/_layouts/post.html
@@ -50,8 +50,8 @@ js: post
                     {% if page.author_github %}
                         <a class="author_name" href="{{ page.author_github }}" target="_blank" rel="noopener">{{ page.author }}</a>
                     {% else %}
-                        <span class="author_name">{{ page.author }}</span>
-                    {% endif %}
+                        <span class="author_name">{{ page.author }}</span>  
+                    {% endif %}           
                     {% for author in page.additional_authors %}
                         {% if additional_author_count == 1 %}
                             <span>{% t global.and %}</span>

--- a/src/main/content/blog.html
+++ b/src/main/content/blog.html
@@ -219,12 +219,14 @@ i18n-seo-description: seo.blogs
             {% endfor %}
          </div>
          {% if post.author_github %}
-            <a class="blog_post_author_name" href="{{ post.author_github }}" rel="noopener" target="_blank">
-            {{ post.author }}
-            </a>
+         <a class="blog_post_author_name" href="{{ post.author_github }}" rel="noopener" target="_blank">
+          {{ post.author }}
+         </a>
          {% else %}
-            <span class="blog_post_author_name">{{ post.author }}</span>
-         {% endif %}  
+         <span class="blog_post_author_name">
+          {{ post.author }}
+         </span>
+         {% endif %}
          {% for author in post.additional_authors %}
                                                 {% if additional_author_count == 1 %}
          <span>
@@ -325,20 +327,28 @@ i18n-seo-description: seo.blogs
             {% endfor %}
          </div>
          {% if post.author_github %}
-            <a class="blog_post_author_name" href="{{ post.author_github }}" rel="noopener" target="_blank">
-            {{ post.author }}
-            </a>
-        {% else %}
-            <span class="blog_post_author_name">{{ post.author }}</span>
-        {% endif %}
+         <a class="blog_post_author_name" href="{{ post.author_github }}" rel="noopener" target="_blank">
+          {{ post.author }}
+         </a>
+         {% else %}
+         <span class="blog_post_author_name">
+          {{ post.author }}
+         </span>
+         {% endif %}
          {% for author in post.additional_authors %}
                                                 {% if additional_author_count == 1 %}
          <span>
           and
          </span>
+         {% if author.github %}
          <a class="blog_post_author_name" href="{{ author.github }}" rel="noopener" target="_blank">
           {{ author.name }}
          </a>
+         {% else %}
+         <span class="blog_post_author_name">
+            {{ author.name }}
+         </span>
+         {% endif %}
          {% else %}
          <span>
           and {{ additional_author_count }} others

--- a/src/main/content/index.html
+++ b/src/main/content/index.html
@@ -257,7 +257,15 @@ css:
                             {% for author in post.additional_authors %}
                                 {% if additional_author_count == 1 %}
                                     <span>and </span>
-                                    <a class="blog_post_author_name" href="{{ author.github }}" target="_blank" rel="noopener">{{ author.name }}</a>
+                                    {% if author.github %}
+                                    <a class="blog_post_author_name" href="{{ author.github }}" rel="noopener" target="_blank">
+                                    {{ author.name }}
+                                    </a>
+                                    {% else %}
+                                    <span class="blog_post_author_name">
+                                        {{ author.name }}
+                                    </span>
+                                    {% endif %}
                                 {% else %}
                                     <span>and {{ additional_author_count }} others</span>
                                     {% break %}
@@ -320,7 +328,15 @@ css:
                             {% for author in post.additional_authors %}
                                 {% if additional_author_count == 1 %}
                                     <span>and </span>
-                                    <a class="blog_post_author_name" href="{{ author.github }}" target="_blank" rel="noopener">{{ author.name }}</a>
+                                    {% if author.github %}
+                                        <a class="blog_post_author_name" href="{{ author.github }}" rel="noopener" target="_blank">
+                                        {{ author.name }}
+                                        </a>
+                                    {% else %}
+                                        <span class="blog_post_author_name">
+                                            {{ author.name }}
+                                        </span>
+                                    {% endif %}
                                 {% else %}
                                     <span>and {{ additional_author_count }} others</span>
                                     {% break %}


### PR DESCRIPTION
## What was changed and why?

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
