### PR TITLE
Fix Jakarta EE feed

### DIFF
--- a/src/main/content/jakartaee.xml
+++ b/src/main/content/jakartaee.xml
@@ -13,7 +13,7 @@ permalink: /jakartaee.xml
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>
 
-    {% for post in site.tags["Jakarta EE"] %}
+    {% for post in site.tags["jakarta-ee"] %}
       <item>
         <title>{{ post.title | xml_escape }}</title>
         <description>{{ post.content | xml_escape }}</description>        


### PR DESCRIPTION
## What was changed and why?
Changed Jakarta feed to use the new tag in order to re-enable aggregation
## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
