### PR TITLE
Fixed cutting of interactive guide toc content

### DIFF
--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -464,6 +464,10 @@ function getTags(callback) {
 }
 
 $(document).ready(function () {
+    window.scrollTo({
+        top: 1,
+      });
+      
     getTags(function () {
         $("#tags_container:empty").prev().hide();
         $(window).trigger("scroll");


### PR DESCRIPTION
## What was changed and why?

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
