### PR TITLE
Fixed appearance of toc in interactive guides 

### DIFF
--- a/src/main/content/_assets/js/guide-common.js
+++ b/src/main/content/_assets/js/guide-common.js
@@ -883,5 +883,8 @@ $(window).on("load", function () {
         if (location.hash) {
             handleFloatingTableOfContent();
         }
+        window.scrollTo({
+            top:1,
+        });
     });
 });


### PR DESCRIPTION
## What was changed and why?

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
