### PR TITLE
Dynamic change of toc line enabled

### DIFF
--- a/src/main/content/_assets/css/toc-multipane-static.scss
+++ b/src/main/content/_assets/css/toc-multipane-static.scss
@@ -181,8 +181,7 @@
         display: inline-block;
         left: 0;
         width: 6px;
-        position: fixed;
-
+        position: absolute;
         &.open {
             left: 394px; // 400px minus the width of 6 px
             background-color: rgb(255, 216, 191);


### PR DESCRIPTION
## What was changed and why?
To ensure dynamic change of toc line in guides page.
## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
