### PR TITLE
Edited breakpoint to trigger 3 guide cards in a row

### DIFF
--- a/src/main/content/_assets/css/guides.scss
+++ b/src/main/content/_assets/css/guides.scss
@@ -47,7 +47,7 @@ $blue-grey-color: #5d6a8e;
 }
 
 // override bootstrap breakpoint to trigger 3 guides per row earlier
-@media (min-width: 1150px) and (max-width: 1400px) {
+@media (min-width: 1150px) and (max-width: 1450px) {
   .guide_column.col-lg-3 {
     width: 33.33333333%;
     max-width: 33.333333%;


### PR DESCRIPTION
## What was changed and why?

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
