### PR TITLE
Blockquotes

### DIFF
--- a/src/main/content/_assets/css/post.scss
+++ b/src/main/content/_assets/css/post.scss
@@ -541,3 +541,27 @@ iframe{
 div.sectionbody div.ulist > ul > li p{
     font-size: 16px;
 }
+
+.quoteblock{
+    display: table;
+    margin: auto;
+    blockquote{
+        &:before{
+            content: "\201c";
+            float: left;
+            font-family: Arial, Helvetica, sans-serif;
+            font-size: 2.5em;
+            font-weight: 700;
+            line-height: .6em;
+            margin-left: -.6em;
+        }
+        margin-left: 22px;
+        margin-right: 0;
+        text-align: justify;
+    }
+    .attribution{
+        text-align: right;
+        font-style: italic;
+        margin-right: 0.5ex;
+    }
+}

--- a/src/main/content/_assets/js/tabs.js
+++ b/src/main/content/_assets/js/tabs.js
@@ -73,7 +73,6 @@ $(document).ready(function() {
                 var tab_class = "." + class_name;
             }
         }
-
         // show content of clicked tab and add active class to clicked tab
         $(this).parent().find('.tab_content' + tab_content).show();
         $(this).parent().find('.tab_link' + tab_class).addClass("active");

--- a/src/main/content/_assets/js/tabs.js
+++ b/src/main/content/_assets/js/tabs.js
@@ -67,13 +67,12 @@ $(document).ready(function() {
         // get class of clicked tab and class of its respective content section
         var class_list = this.classList;
         for (var i = 0; i < class_list.length; i++) {
-            var class_name = class_list[i];
+            class_name = class_list[i];
             if (class_name !== "tab_link" && class_name.indexOf("_link") > -1) {
                 var tab_content = "." + class_name.replace("link", "section");
                 var tab_class = "." + class_name;
             }
         }
-
         // show content of clicked tab and add active class to clicked tab
         $(this).parent().find('.tab_content' + tab_content).show();
         $(this).parent().find('.tab_link' + tab_class).addClass("active");

--- a/src/main/content/_assets/js/tabs.js
+++ b/src/main/content/_assets/js/tabs.js
@@ -67,12 +67,13 @@ $(document).ready(function() {
         // get class of clicked tab and class of its respective content section
         var class_list = this.classList;
         for (var i = 0; i < class_list.length; i++) {
-            class_name = class_list[i];
+            var class_name = class_list[i];
             if (class_name !== "tab_link" && class_name.indexOf("_link") > -1) {
                 var tab_content = "." + class_name.replace("link", "section");
                 var tab_class = "." + class_name;
             }
         }
+
         // show content of clicked tab and add active class to clicked tab
         $(this).parent().find('.tab_content' + tab_content).show();
         $(this).parent().find('.tab_link' + tab_class).addClass("active");

--- a/src/main/content/_assets/js/tabs.js
+++ b/src/main/content/_assets/js/tabs.js
@@ -73,6 +73,7 @@ $(document).ready(function() {
                 var tab_class = "." + class_name;
             }
         }
+
         // show content of clicked tab and add active class to clicked tab
         $(this).parent().find('.tab_content' + tab_content).show();
         $(this).parent().find('.tab_link' + tab_class).addClass("active");


### PR DESCRIPTION
## What was changed and why?
made changes in post.scss for blockquotes within blogs posts to render correctly.

Also adding screenshots of existing blockquotes behaviour in guides and docs pages.

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
<img width="1312" alt="Screenshot 2024-06-04 at 12 23 35 PM" src="https://github.com/OpenLiberty/openliberty.io/assets/142485870/98da519a-fe60-4f3e-854f-7274b1686d5b">
<img width="1312" alt="Screenshot 2024-06-04 at 12 24 24 PM" src="https://github.com/OpenLiberty/openliberty.io/assets/142485870/2eebc7c0-cc6e-4f4f-a237-ea7065e5e06a">
<img width="531" alt="Screenshot 2024-06-07 at 12 20 57 PM" src="https://github.com/OpenLiberty/openliberty.io/assets/142485870/d9248c6d-58d6-4581-a77c-61a160b354a9">
<img width="1309" alt="Screenshot 2024-06-11 at 6 12 35 PM" src="https://github.com/OpenLiberty/openliberty.io/assets/142485870/5c2a344d-c9d6-4c1b-b286-f1f005d311ab">

