### PR TITLE
asciidocs blockquotes to render correctly

### DIFF
--- a/src/main/content/_assets/css/guide-common.scss
+++ b/src/main/content/_assets/css/guide-common.scss
@@ -569,3 +569,18 @@
   right: 10px;
   top: 5px;
 }
+
+.quoteblock {
+  background: #fafafa;
+  color: #5d5d5d;
+  padding: .25rem 2rem 1.25rem;
+  blockquote {
+    margin-top: 1rem;
+  }
+  .attribution {
+    color: #8e8e8e;
+  }
+  .paragraph {
+    font-style: italic;
+  }
+}

--- a/src/main/content/_assets/css/post.scss
+++ b/src/main/content/_assets/css/post.scss
@@ -541,3 +541,27 @@ iframe{
 div.sectionbody div.ulist > ul > li p{
     font-size: 16px;
 }
+
+.quoteblock{
+    display: table;
+    margin: auto;
+    blockquote{
+        &:before{
+            content: "\201c";
+            float: left;
+            font-family: Arial, Helvetica, sans-serif;
+            font-size: 2.5em;
+            font-weight: 700;
+            line-height: .6em;
+            margin-left: -.6em;
+        }
+        margin-left: 22px;
+        margin-right: 0;
+        text-align: justify;
+    }
+    .attribution{
+        text-align: right;
+        font-style: italic;
+        margin-right: 0.5ex;
+    }
+}    

--- a/src/main/content/antora_ui/src/css/doc.css
+++ b/src/main/content/antora_ui/src/css/doc.css
@@ -320,7 +320,6 @@
 
 .doc .quoteblock {
   background: var(--quote-background);
-  border-left: 5px solid var(--quote-border-color);
   color: var(--quote-font-color);
   padding: 0.25rem 2rem 1.25rem;
 }


### PR DESCRIPTION
## What was changed and why?
Link to issue [here](https://github.com/OpenLiberty/openliberty.io/issues/3154)
## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
