### PR TITLE
scroll behaviour of docs-toc in mobile phones

### DIFF
--- a/src/main/content/antora_ui/src/sass/nav.scss
+++ b/src/main/content/antora_ui/src/sass/nav.scss
@@ -330,7 +330,6 @@ html.is-clipped--nav {
   max-height: calc(50% + var(--drawer-height));
   padding-top: 20px;
   padding-bottom: 20px;
-  background-attachment:fixed;
 }
 
 .hide-after:after {

--- a/src/main/content/antora_ui/src/sass/nav.scss
+++ b/src/main/content/antora_ui/src/sass/nav.scss
@@ -128,7 +128,7 @@ html.is-clipped--nav {
 
 /* Styling for the first level nav list */
 .nav-menu > .nav-list {
-  padding-bottom: 50px;
+  padding-bottom: 80px;
   padding-left: 0;
   padding-right: 10px;
   margin: 0 0 0.5rem 0;


### PR DESCRIPTION
## What was changed and why?
Link to the issue [here](https://github.com/OpenLiberty/openliberty.io/issues/3841)
## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
