### PR TITLE
Width of modal of guides code column in singlepane updated

### DIFF
--- a/src/main/content/_assets/js/guide-multipane-static.js
+++ b/src/main/content/_assets/js/guide-multipane-static.js
@@ -788,6 +788,7 @@ $(document).ready(function () {
                 top: mobile_toc_height + hotspot_height + 5 + "px",
                 left: "0px",
                 height: "100vh",
+                width: "100vw"
             });
         }
     });


### PR DESCRIPTION
## What was changed and why?
Link to the issue [here](https://github.com/OpenLiberty/openliberty.io/issues/1360)
## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
