### PR TITLE
Scroll behaviour of docs in smaller screen sizes

### DIFF
--- a/src/main/content/antora_ui/src/sass/nav.scss
+++ b/src/main/content/antora_ui/src/sass/nav.scss
@@ -76,7 +76,7 @@ html.is-clipped--nav {
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  height: var(--nav-panel-height);
+  height: calc(var(--nav-panel-height) - 4rem);
   top: var(--drawer-height);
 }
 
@@ -128,7 +128,7 @@ html.is-clipped--nav {
 
 /* Styling for the first level nav list */
 .nav-menu > .nav-list {
-  padding-bottom: 50px;
+  padding-bottom: 100px;
   padding-left: 0;
   padding-right: 10px;
   margin: 0 0 0.5rem 0;


### PR DESCRIPTION
## What was changed and why?
Link to the issue [here](https://github.com/OpenLiberty/openliberty.io/issues/3841).

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
