### PR TITLE
fix footer view when view is less than 910px

### DIFF
--- a/src/main/content/_assets/css/openliberty.scss
+++ b/src/main/content/_assets/css/openliberty.scss
@@ -584,7 +584,7 @@ footer {
 
 }
 
-@media (max-width: 767.98px) {
+@media (max-width: 910px) {
     #footer_gray_background {
         height: 131px;
     }


### PR DESCRIPTION
## What was changed and why? issue #3808
Fix small bug when resolution is less than 910px the links in the footer section look odd.

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
