### PR TITLE
Add "Get Started" and "Guides" links in footer

### DIFF
--- a/src/main/content/_assets/css/openliberty.scss
+++ b/src/main/content/_assets/css/openliberty.scss
@@ -556,7 +556,7 @@ footer {
         float: left;
     }
 
-    #footer_support_link, #footer_blog_link {
+    #footer_support_link, #footer_blog_link, #footer_docs_link, #footer_guides_link  {
         margin-left: 28px;
     }
 
@@ -584,7 +584,7 @@ footer {
 
 }
 
-@media (max-width: 767.98px) {
+@media (max-width: 910px) {
     #footer_gray_background {
         height: 131px;
     }

--- a/src/main/content/_includes/footer.html
+++ b/src/main/content/_includes/footer.html
@@ -31,9 +31,11 @@
             <a id="footer_logos_link" href="https://github.com/OpenLiberty/logos" target="_blank" rel="noopener" class="left_footer_link">{% t footer.logos %}</a>
         </div>
         <div id="footer_bottom_right_section">
+            <a id="footer_get_started_link" href="/start" aria-label="Open Liberty Docs" class="right_footer_link blue_link_light_background">{% t pages.start %}</a>
+            <a id="footer_guides_link" href="/guides" aria-label="Open Liberty Docs" class="right_footer_link blue_link_light_background">{% t pages.guides %}</a>
             <a id="footer_docs_link" href="/docs" aria-label="Open Liberty Docs" class="right_footer_link blue_link_light_background">{% t pages.docs %}</a>
-            <a id="footer_blog_link" href="/blog" aria-label="Open Liberty Blog" class="right_footer_link blue_link_light_background">{% t pages.blog %}</a>
             <a id="footer_support_link" href="/support" aria-label="Open Liberty Support" class="right_footer_link blue_link_light_background">{% t pages.support %}</a>
+            <a id="footer_blog_link" href="/blog" aria-label="Open Liberty Blog" class="right_footer_link blue_link_light_background">{% t pages.blog %}</a>
         </div>
     </div>
 </footer>

--- a/src/main/content/antora_ui/src/partials/footer-content.hbs
+++ b/src/main/content/antora_ui/src/partials/footer-content.hbs
@@ -25,10 +25,11 @@
             <a id="footer_logos_link" href="https://github.com/OpenLiberty/logos" target="_blank" rel="noopener" class="left_footer_link">Logos</a>
         </div>      
         <div id="footer_bottom_right_section">
+            <a id="footer_get_started_link" href="/start" aria-label="Open Liberty Docs" class="right_footer_link blue_link_light_background">Get Started</a>
+            <a id="footer_guides_link" href="/guides" aria-label="Open Liberty Docs" class="right_footer_link blue_link_light_background">Guides</a>
             <a id="footer_docs_link" href="/docs" aria-label="Open Liberty Docs" class="right_footer_link blue_link_light_background">Docs</a>
+            <a id="footers_support_link" href="/support" aria-label="Open Liberty Support" class="right_footer_link blue_link_light_background">Support</a>
             <a id="footer_blog_link" href="/blog" aria-label="Open Liberty Blog" class="right_footer_link blue_link_light_background">Blog</a>
-            <a id="footer_support_link" href="/support" aria-label="Open Liberty Support" class="right_footer_link blue_link_light_background">Support</a>
-        </div>
     </div>
 </footer>
 

--- a/src/main/content/antora_ui/src/partials/footer-content.hbs
+++ b/src/main/content/antora_ui/src/partials/footer-content.hbs
@@ -30,6 +30,7 @@
             <a id="footer_docs_link" href="/docs" aria-label="Open Liberty Docs" class="right_footer_link blue_link_light_background">Docs</a>
             <a id="footers_support_link" href="/support" aria-label="Open Liberty Support" class="right_footer_link blue_link_light_background">Support</a>
             <a id="footer_blog_link" href="/blog" aria-label="Open Liberty Blog" class="right_footer_link blue_link_light_background">Blog</a>
+        </div>
     </div>
 </footer>
 


### PR DESCRIPTION
## What was changed and why? issue #3808 
- Added "Get Started" & "Guides" links in footer.
- Modified the order of the links to maintain consistency with header.

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [x] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
