### PR TITLE
Removing GTM references

### DIFF
--- a/src/main/content/_google_analytics.yml
+++ b/src/main/content/_google_analytics.yml
@@ -1,1 +1,1 @@
-google_tag_manager:G-PXYTWCYE18
+google_tag_manager: G-PXYTWCYE18

--- a/src/main/content/_layouts/default.html
+++ b/src/main/content/_layouts/default.html
@@ -10,8 +10,6 @@ css:
 
   <body>
     
-    {% include_cached analytics.html %}
-
     {% include_cached header.html %}
 
     <main aria-label="Content">


### PR DESCRIPTION
## What was changed and why?
Link to the issue [here](https://github.com/OpenLiberty/openliberty.io/issues/3883)

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
