### PR TITLE
Resolving font-weights bug

### DIFF
--- a/scripts/build/javadoc_modify.sh
+++ b/scripts/build/javadoc_modify.sh
@@ -8,6 +8,23 @@ modifyStylesheet () {
         font-family: "Asap";
         font-style: normal;
         font-stretch: 100%;
+        font-weight:300;
+        src: url("../../../../fonts/Asap.woff2");
+        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+    }
+    @font-face {
+        font-family: "Asap";
+        font-style: normal;
+        font-stretch: 100%;
+        font-weight:400;
+        src: url("../../../../fonts/Asap.woff2");
+        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+    }
+    @font-face {
+        font-family: "Asap";
+        font-style: normal;
+        font-stretch: 100%;
+        font-weight:500;
         src: url("../../../../fonts/Asap.woff2");
         unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
     }' | cat - "$1" > newstylesheet.css
@@ -24,6 +41,23 @@ modifyStylesheetFrameless () {
         font-family: "Asap";
         font-style: normal;
         font-stretch: 100%;
+        font-weight:300;
+        src: url("../../../../fonts/Asap.woff2");
+        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+    }
+    @font-face {
+        font-family: "Asap";
+        font-style: normal;
+        font-stretch: 100%;
+        font-weight:400;
+        src: url("../../../../fonts/Asap.woff2");
+        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+    }
+    @font-face {
+        font-family: "Asap";
+        font-style: normal;
+        font-stretch: 100%;
+        font-weight:500;
         src: url("../../../../fonts/Asap.woff2");
         unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
     }' | cat - "$1" > newstylesheet.css
@@ -40,6 +74,23 @@ modifyStylesheetFramelessSPIAPI () {
         font-family: "Asap";
         font-style: normal;
         font-stretch: 100%;
+        font-weight:300;
+        src: url("../../../../../fonts/Asap.woff2");
+        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+    }
+    @font-face {
+        font-family: "Asap";
+        font-style: normal;
+        font-stretch: 100%;
+        font-weight:400;
+        src: url("../../../../../fonts/Asap.woff2");
+        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+    }
+    @font-face {
+        font-family: "Asap";
+        font-style: normal;
+        font-stretch: 100%;
+        font-weight:500;
         src: url("../../../../../fonts/Asap.woff2");
         unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
     }' | cat - "$1" > newstylesheet.css


### PR DESCRIPTION
## What was changed and why?
A few font weights were seen changed in docs section after self hosting google-fonts. This issue is been addressed.

Link to the issue https://github.com/OpenLiberty/openliberty.io/issues/3871

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
