### PR TITLE
Added 7.0 in compatibility in starter tool

### DIFF
--- a/src/main/content/_assets/js/builds.js
+++ b/src/main/content/_assets/js/builds.js
@@ -912,7 +912,7 @@ function validate_java_eeAndmp_levels() {
     )
     .find(':selected')
     .text(); 
-    if ((mpVersion === '6.0') || (eeVersion == '10.0') || (mpVersion === "6.1")) {
+    if ((mpVersion === '6.0') || (eeVersion == '10.0') || (mpVersion === "6.1") || (mpVersion === "7.0")) {
         javaVersion = $(
             '.starter_field[data-starter-field=\'j\'] select'
         )


### PR DESCRIPTION
## What was changed and why?
## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
