### PR TITLE
Change aria-label of footer links

### DIFF
--- a/src/main/content/_includes/footer.html
+++ b/src/main/content/_includes/footer.html
@@ -31,7 +31,7 @@
             <a id="footer_logos_link" href="https://github.com/OpenLiberty/logos" target="_blank" rel="noopener" class="left_footer_link">{% t footer.logos %}</a>
         </div>
         <div id="footer_bottom_right_section">
-            <a id="footer_get_started_link" href="/start" aria-label="Open Liberty Docs" class="right_footer_link blue_link_light_background">{% t pages.start %}</a>
+            <a id="footer_get_started_link" href="/start" aria-label="Open Liberty Get Started" class="right_footer_link blue_link_light_background">{% t pages.start %}</a>
             <a id="footer_guides_link" href="/guides" aria-label="Open Liberty Docs" class="right_footer_link blue_link_light_background">{% t pages.guides %}</a>
             <a id="footer_docs_link" href="/docs" aria-label="Open Liberty Docs" class="right_footer_link blue_link_light_background">{% t pages.docs %}</a>
             <a id="footer_support_link" href="/support" aria-label="Open Liberty Support" class="right_footer_link blue_link_light_background">{% t pages.support %}</a>

--- a/src/main/content/_includes/footer.html
+++ b/src/main/content/_includes/footer.html
@@ -32,7 +32,7 @@
         </div>
         <div id="footer_bottom_right_section">
             <a id="footer_get_started_link" href="/start" aria-label="Open Liberty Get Started" class="right_footer_link blue_link_light_background">{% t pages.start %}</a>
-            <a id="footer_guides_link" href="/guides" aria-label="Open Liberty Docs" class="right_footer_link blue_link_light_background">{% t pages.guides %}</a>
+            <a id="footer_guides_link" href="/guides" aria-label="Open Liberty Guides" class="right_footer_link blue_link_light_background">{% t pages.guides %}</a>
             <a id="footer_docs_link" href="/docs" aria-label="Open Liberty Docs" class="right_footer_link blue_link_light_background">{% t pages.docs %}</a>
             <a id="footer_support_link" href="/support" aria-label="Open Liberty Support" class="right_footer_link blue_link_light_background">{% t pages.support %}</a>
             <a id="footer_blog_link" href="/blog" aria-label="Open Liberty Blog" class="right_footer_link blue_link_light_background">{% t pages.blog %}</a>

--- a/src/main/content/antora_ui/src/partials/footer-content.hbs
+++ b/src/main/content/antora_ui/src/partials/footer-content.hbs
@@ -25,7 +25,7 @@
             <a id="footer_logos_link" href="https://github.com/OpenLiberty/logos" target="_blank" rel="noopener" class="left_footer_link">Logos</a>
         </div>      
         <div id="footer_bottom_right_section">
-            <a id="footer_get_started_link" href="/start" aria-label="Open Liberty Docs" class="right_footer_link blue_link_light_background">Get Started</a>
+            <a id="footer_get_started_link" href="/start" aria-label="Open Liberty Get Started" class="right_footer_link blue_link_light_background">Get Started</a>
             <a id="footer_guides_link" href="/guides" aria-label="Open Liberty Docs" class="right_footer_link blue_link_light_background">Guides</a>
             <a id="footer_docs_link" href="/docs" aria-label="Open Liberty Docs" class="right_footer_link blue_link_light_background">Docs</a>
             <a id="footers_support_link" href="/support" aria-label="Open Liberty Support" class="right_footer_link blue_link_light_background">Support</a>

--- a/src/main/content/antora_ui/src/partials/footer-content.hbs
+++ b/src/main/content/antora_ui/src/partials/footer-content.hbs
@@ -26,7 +26,7 @@
         </div>      
         <div id="footer_bottom_right_section">
             <a id="footer_get_started_link" href="/start" aria-label="Open Liberty Get Started" class="right_footer_link blue_link_light_background">Get Started</a>
-            <a id="footer_guides_link" href="/guides" aria-label="Open Liberty Docs" class="right_footer_link blue_link_light_background">Guides</a>
+            <a id="footer_guides_link" href="/guides" aria-label="Open Liberty Guides" class="right_footer_link blue_link_light_background">Guides</a>
             <a id="footer_docs_link" href="/docs" aria-label="Open Liberty Docs" class="right_footer_link blue_link_light_background">Docs</a>
             <a id="footers_support_link" href="/support" aria-label="Open Liberty Support" class="right_footer_link blue_link_light_background">Support</a>
             <a id="footer_blog_link" href="/blog" aria-label="Open Liberty Blog" class="right_footer_link blue_link_light_background">Blog</a>


### PR DESCRIPTION
## What was changed and why?
Resolving accessibility errors found because of aria-label names for footer links
Link to the issue [here](https://github.com/OpenLiberty/openliberty.io/issues/3927)

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
