### PR TITLE
Bringing styling improvements to cookie consent

### DIFF
--- a/src/main/content/_assets/css/openliberty.scss
+++ b/src/main/content/_assets/css/openliberty.scss
@@ -626,19 +626,15 @@ footer {
 
 
 #teconsent {
-    height: 40px;
-    background-color: rgb(255, 255, 255);
-    z-index: 2147483647;
-    bottom: 0px;
-    right: 0px;
-    margin: 0px;
-    padding: 0px 16px;
-    line-height: 40px;
     vertical-align: middle;
-    box-shadow: rgba(0, 0, 0, 0.1) 0px 0px 10px 3px;
     float: right;
-    margin-bottom: 10px;
-    margin-left: 10px;
+    display:contents !important;
+    a{
+        font-size: 11px;
+        color: #6F7878;
+        display: inline-block;
+        line-height: 1.5;
+    }
 }
 
 

--- a/src/main/content/_includes/footer.html
+++ b/src/main/content/_includes/footer.html
@@ -30,7 +30,6 @@
             <p class="vertical_bar">|</p>
             <a id="footer_logos_link" href="https://github.com/OpenLiberty/logos" target="_blank" rel="noopener" class="left_footer_link">{% t footer.logos %}</a>
             <p class="vertical_bar">|</p>
-            <!-- <a id="footer_logos_link" href="https://github.com/OpenLiberty/logos" target="_blank" rel="noopener" class="left_footer_link">{% t footer.logos %}</a> -->
             <span id="teconsent" style="display:none"></span>
         </div>
         <div id="footer_bottom_right_section">

--- a/src/main/content/_includes/head.html
+++ b/src/main/content/_includes/head.html
@@ -81,13 +81,9 @@
     window._ibmAnalytics = {
         "settings": {
             "name": "Openliberty-io-website",
-            // "isSpa": false,
             "tealiumProfileName": "ibm-web-app"
         },
         "digitalData.page.services.google.enabled": true
-        // "onLoad": [
-        //     ["ibmStats.pageview", []]
-        // ]
     };
     digitalData = {
         "page": {

--- a/src/main/content/antora_ui/src/partials/footer-content.hbs
+++ b/src/main/content/antora_ui/src/partials/footer-content.hbs
@@ -24,7 +24,6 @@
             <p class="vertical_bar">|</p>
             <a id="footer_logos_link" href="https://github.com/OpenLiberty/logos" target="_blank" rel="noopener" class="left_footer_link">Logos</a>
             <p class="vertical_bar">|</p>
-            {{!-- <a id="footer_logos_link" href="https://github.com/OpenLiberty/logos" target="_blank" rel="noopener" class="left_footer_link">Cookies preference</a> --}}
             <span id="teconsent" style="display:none"></span>
         </div>      
         <div id="footer_bottom_right_section">

--- a/src/main/content/antora_ui/src/partials/head-scripts.hbs
+++ b/src/main/content/antora_ui/src/partials/head-scripts.hbs
@@ -9,7 +9,6 @@
         window._ibmAnalytics = {
             "settings": {
                 "name": "Openliberty-io-website",
-                {{!-- "isSpa": false, --}}
                 "tealiumProfileName": "ibm-web-app"
             },
             "digitalData.page.services.google.enabled": true

--- a/src/main/content/antora_ui/src/sass/openliberty.scss
+++ b/src/main/content/antora_ui/src/sass/openliberty.scss
@@ -591,19 +591,15 @@ footer {
 
 
 #teconsent {
-    height: 40px;
-    background-color: rgb(255, 255, 255);
-    z-index: 2147483647;
-    bottom: 0px;
-    right: 0px;
-    margin: 0px;
-    padding: 0px 16px;
-    line-height: 40px;
     vertical-align: middle;
-    box-shadow: rgba(0, 0, 0, 0.1) 0px 0px 10px 3px;
     float: right;
-    margin-bottom: 10px;
-    margin-left: 10px;
+    display:contents !important;
+    a{
+        font-size: 11px;
+        color: #6F7878;
+        display: inline-block;
+        line-height: 1.5;
+    }
 }
 
 


### PR DESCRIPTION
## What was changed and why?
Link to the issue [here](https://github.ibm.com/websphere/openliberty.io-team/issues/24).

Attaching before and after images below.

Before:
<img width="610" alt="Screenshot 2025-03-25 at 3 19 13 PM" src="https://github.com/user-attachments/assets/5de6624f-fadb-432f-9ea4-78c595571791" />

After:
<img width="460" alt="Screenshot 2025-03-25 at 3 18 38 PM" src="https://github.com/user-attachments/assets/8e83cd4b-91cc-4cf0-9023-ec4389b490ea" />

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
