### PR TITLE
Update copyright in footer to 2025

### DIFF
--- a/src/main/content/_i18n/en.yml
+++ b/src/main/content/_i18n/en.yml
@@ -29,7 +29,7 @@ pages:
   support: Support
   blog: Blog
 footer:
-  copyright: Copyright IBM Corp. 2017, 2024
+  copyright: Copyright IBM Corp. 2017, 2025
   privacy_policy: Privacy policy
   license: License
   logos: Logos

--- a/src/main/content/_i18n/ja.yml
+++ b/src/main/content/_i18n/ja.yml
@@ -29,7 +29,7 @@ pages:
   support: サポート
   blog: ブログ
 footer:
-  copyright: Copyright IBM Corp. 2017, 2024
+  copyright: Copyright IBM Corp. 2017, 2025
   privacy_policy: プライバシー・ポリシー
   license: ライセンス
   logos: ロゴ

--- a/src/main/content/_i18n/zh-Hans.yml
+++ b/src/main/content/_i18n/zh-Hans.yml
@@ -29,7 +29,7 @@ pages:
   support: 支持
   blog: 博客
 footer:
-  copyright: Copyright IBM Corp. 2017, 2024
+  copyright: Copyright IBM Corp. 2017, 2025
   privacy_policy: 隐私策略
   license: 许可证
   logos: 洛戈斯

--- a/src/main/content/antora_ui/src/partials/footer-content.hbs
+++ b/src/main/content/antora_ui/src/partials/footer-content.hbs
@@ -16,7 +16,7 @@
 
     <div id="footer_bottom_container" class="footer_container container-fluid">
         <div id="footer_bottom_left_section">
-            <p id="footer_copyright">&copy; Copyright IBM Corp. 2017, 2024</p>
+            <p id="footer_copyright">&copy; Copyright IBM Corp. 2017, 2025</p>
             <p class="vertical_bar">|</p>
             <a id="footer_privacy_policy_link" href="https://www.ibm.com/privacy/" target="_blank" rel="noopener" class="left_footer_link">Privacy policy</a>
             <p class="vertical_bar">|</p>


### PR DESCRIPTION
## What was changed and why?
Link to the issue https://github.com/OpenLiberty/openliberty.io/issues/3963

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
