### PR TITLE
fixed footer link click issue

### DIFF
--- a/src/main/content/_assets/css/openliberty.scss
+++ b/src/main/content/_assets/css/openliberty.scss
@@ -531,6 +531,8 @@ footer {
 
     #footer_bottom_left_section, #footer_bottom_right_section {
         display: inline-block;
+        position: sticky;
+        z-index: auto;
     }
 
     #footer_bottom_right_section {


### PR DESCRIPTION
## What was changed and why?
Added a z-index to the footer css because one of the div from the content was overlapping on top of this div.

Link to the issue https://github.com/OpenLiberty/openliberty.io/issues/3960
## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
