### PR TITLE
Update_prod

### DIFF
--- a/src/main/content/certifications.html
+++ b/src/main/content/certifications.html
@@ -11,52 +11,47 @@ permalink: /certifications/
 
 <div id="article_container" class="container-fluid">
   <article class="post" aria-label="article">
-      <header id="post_header">
-          <div class="container">
-              <h1 id="post_title">{% t certifications.certification_title %}</h1>
-              <p id="cert_description">{% t certifications.certification_desc %}</p>
-          </div>
-      </header>
-      <div id="article_body" class="container">
-        <h1 id="TCKs">{% t certifications.olio_tck_results %}</h1>
-        <ul>
-          {% assign certifications = site.pages | where: 'layout', 'certification' | sort: "url" %}
-          {% assign previous_cert_url_parts = "" %}
-          {% assign sameParent = true %}
-          {% for cert in certifications %}
-            {% assign cert_url_parts = cert.url | split: '/' %}
-            {% assign counter = 1 %}
-            {% for cert_url_part in cert_url_parts offset:2 %}
-              {% assign counter = counter | plus: 1 %}
-              {% if cert_url_part == previous_cert_url_parts[counter] and sameParent %}
-                {% continue %}
-              {% endif %}
-              {% if counter == 2 %}
-                <h2 style="margin-left: -20px; margin-bottom:-20px">{{ cert_url_part | upcase }}</h2>
-                {% if cert_url_parts.size == 3%}
-                  <br>
-                {% endif %} 
-                {% continue %}
-              {% endif %} 
-              {% if counter == 3 %}
-                <br>
-                {% continue %}
-              {% endif %} 
-            {% endfor %}
-            {% assign previous_cert_url_parts = cert_url_parts %}
-            {% assign sameParent = true %}
-            {% assign h2_start = cert.content | split: '<h2' %}
-            {% assign h2_end = h2_start[1] | split: '>' %}
-            {% assign h2_content_array = h2_end[1] | split: '</h2' %}
-            {% assign h2_content = h2_content_array[0] %}
+    <header id="post_header">
+      <div class="container">
+        <h1 id="post_title">{% t certifications.certification_title %}</h1>
+        <p id="cert_description">{% t certifications.certification_desc %}</p>
+      </div>
+    </header>
+    <div id="article_body" class="container">
+      <h1 id="TCKs">{% t certifications.olio_tck_results %}</h1>
+      <ul>
+      {% assign certifications = site.pages | where: 'layout', 'certification' %}
+
+      {% assign grouped_certs = certifications | group_by_exp: 'page', 'page.spec' %}
+      {% assign grouped_certs = grouped_certs | sort: "name" %}
+     
+      {% for group in grouped_certs %}
+      {% assign last_version = "" %}
+        <h2 style="margin-left: -20px; margin-bottom:-20px">{{ group.name}}</h2>
+        {% assign url_sorted = group.items | sort: 'url' %}
+        {% assign sorted_certs = url_sorted | sort: 'version' | reverse %}      
+          {% for cert in sorted_certs %}
+          {% if cert.version != last_version %}
+          <br/>
+          {% endif %}
+
+          {% assign h2_start = cert.content | split: '<h2' %}
+          {% assign h2_end = h2_start[1] | split: '>' %}
+          {% assign h2_content_array = h2_end[1] | split: '</h2' %}
+          {% assign h2_content = h2_content_array[0] %}
             <li>
               <a href="{{ cert.url }}" title={% if h2_content != nill and h2_content != empty %} "{{ h2_content }}" {% endif %}>
                 {{cert.url | remove_first: '/certifications/'}}
               </a>
             </li>
+            {% assign last_version = cert.version %}
+          {% endfor %}
           {% endfor %}
         </ul>
-      </div>
+     
+    </div>
   </article>
+</div>
   <br />
 </div>
+


### PR DESCRIPTION
## Link to issue being addressed:
[List certifications in descending order](https://github.com/OpenLiberty/openliberty.io/issues/3430)

## What was changed and why?

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
