### PR TITLE
Build issue fix

### DIFF
--- a/docker/Dockerfile.draft
+++ b/docker/Dockerfile.draft
@@ -50,7 +50,7 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 compile war:exploded
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:25.0.0.8-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:25.0.0.9-kernel-slim-java8-ibmjava-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY --chown=1001:0 src/main/wlp/server.xml /config/server.xml
@@ -58,7 +58,7 @@ COPY --chown=1001:0 src/main/wlp/server.xml /config/server.xml
 # This script will add the requested XML snippets to enable Liberty features and grow image to be fit-for-purpose 
 # using featureUtility. 
 # Only available in 'kernel-slim'. The 'full' tag already includes all features for convenience.
-RUN features.sh
+RUN bash features.sh
 
 COPY --from=war --chown=1001:0 target/openliberty-website-1.0-SNAPSHOT /config/apps/openliberty.war
 

--- a/docker/ui-only/Dockerfile.ui-only
+++ b/docker/ui-only/Dockerfile.ui-only
@@ -41,7 +41,7 @@ RUN ./mvnw -B -Dhttps.protocols=TLSv1.2 compile war:exploded
 #
 #
 #
-FROM icr.io/appcafe/open-liberty:25.0.0.8-kernel-slim-java8-openj9-ubi as runtime
+FROM icr.io/appcafe/open-liberty:25.0.0.9-kernel-slim-java8-ibmjava-ubi as runtime
 ENV SEC_TLS_TRUSTDEFAULTCERTS true
 
 COPY --chown=1001:0 src/main/wlp/server.xml /config/server.xml
@@ -49,7 +49,7 @@ COPY --chown=1001:0 src/main/wlp/server.xml /config/server.xml
 # This script will add the requested XML snippets to enable Liberty features and grow image to be fit-for-purpose 
 # using featureUtility. 
 # Only available in 'kernel-slim'. The 'full' tag already includes all features for convenience.
-RUN features.sh
+RUN bash features.sh
 
 COPY --from=war --chown=1001:0 target/openliberty-website-1.0-SNAPSHOT /config/apps/openliberty.war
 


### PR DESCRIPTION
## Link to issue being addressed:
Switched to different java 8 to fix the container image builds

Step 22/24 : RUN [features.sh](http://features.sh/)
---> Running in 02993410d5fa
Deprecation notice: IBM expects the last version of the UBI-based Open Liberty container images in Docker Hub ('openliberty/open-liberty') to be 25.0.0.3. To continue to receive updates and security fixes after 25.0.0.3, you must switch to using the images from the IBM Container Registry (ICR). To switch, simply update 'FROM openliberty/open-liberty' in your Dockerfiles to 'FROM [icr.io/appcafe/open-liberty](http://icr.io/appcafe/open-liberty)'. The same image tags from Docker Hub are also available in ICR. Ubuntu-based Liberty container images will continue to be available from Docker Hub. For more information, see https://ibm.biz/ol-ubi-containers-dh-deprecation

SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
SNIPPETS_TARGET=/config/configDropins/overrides
SNIPPETS_TARGET_DEFAULTS=/config/configDropins/defaults
mkdir -p /config/configDropins/overrides
mkdir -p /config/configDropins/defaults
'[' -n '' ']'
'[' '' == client ']'
'[' '' == embedded ']'
[[ -n '' ]]
'[' '' == true ']'
'[' '' == true ']'
featureUtility installServerFeatures --acceptLicense defaultServer --noCache
SHA512 MessageDigest not available
The command '/bin/sh -c [features.sh](http://features.sh/)' returned a non-zero code: 21

## What was changed and why?

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
