### PR TITLE
Changing deprecated links for plugin versions

### DIFF
--- a/src/main/java/io/openliberty/website/OpenLibertyEndpoint.java
+++ b/src/main/java/io/openliberty/website/OpenLibertyEndpoint.java
@@ -95,8 +95,8 @@ public class OpenLibertyEndpoint extends Application {
         return githubManager.getIssues();
     }
 
-    String mavenUrl="https://search.maven.org/solrsearch/select?q=g:io.openliberty.tools+AND+a:liberty-maven-plugin&core=gav&rows=20&wt=json";
-    String gradleUrl="https://search.maven.org/solrsearch/select?q=g:io.openliberty.tools+AND+a:liberty-gradle-plugin&core=gav&rows=20&wt=json";
+    String mavenUrl="https://central.sonatype.com/solrsearch/select?q=g:io.openliberty.tools+AND+a:liberty-maven-plugin&core=gav&rows=20&wt=json&sort=v+desc";
+    String gradleUrl="https://central.sonatype.com/solrsearch/select?q=g:io.openliberty.tools+AND+a:liberty-gradle-plugin&core=gav&rows=20&wt=json&sort=v+desc";
     @GET
     @Produces({ "application/json" })
     @Path("start/plugin-versions")


### PR DESCRIPTION
## Link to issue being addressed:
https://github.com/OpenLiberty/openliberty.io/issues/4050

## What was changed and why?
Links to obtain plugin versions were deprecated and needed to be updated.

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
