### PR TITLE
Add margintop to body content when nav bar appears

### DIFF
--- a/src/main/content/antora_ui/src/js/10-navscroll.js
+++ b/src/main/content/antora_ui/src/js/10-navscroll.js
@@ -96,6 +96,7 @@ var navScroll = (function() {
 
     // adjust docs toolbar and nav position
     $(".toolbar").css("top", nav_height + "px");
+    $(".doc").css("margin-top", nav_height + "px")
     if (window.outerWidth < 1024) {
       $(".nav-container").css(
         "top",
@@ -136,6 +137,7 @@ var navScroll = (function() {
 
     // adjust docs toolbar and nav position
     $(".toolbar").css("top", "0px");
+    $(".doc").css("margin-top", "0px");
     if (window.outerWidth < 1024) {
       $(".nav-container").css("top", $(".toolbar").outerHeight() + "px");
       $(".nav").css("top", "");


### PR DESCRIPTION
## Link to issue being addressed:
#4136
## What was changed and why?
Added margintop to body content when nav bar appears
## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
