### PR TITLE
adding scroll margin top to docs heading

### DIFF
--- a/src/main/content/antora_ui/src/css/doc.css
+++ b/src/main/content/antora_ui/src/css/doc.css
@@ -620,3 +620,12 @@ kbd,
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
 }
+
+.doc h1[id],
+.doc h2[id],
+.doc h3[id],
+.doc h4[id],
+.doc h5[id],
+.doc h6[id] {
+  scroll-margin-top: calc(var(--navbar-height) + var(--toolbar-height) + 1rem);
+}


### PR DESCRIPTION
## Link to issue being addressed:
https://github.com/OpenLiberty/openliberty.io/issues/4136

## What was changed and why?

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
