### PR TITLE
Ruby jekyll staging

### DIFF
--- a/src/main/content/antora_ui/gulp.d/tasks/pack.js
+++ b/src/main/content/antora_ui/gulp.d/tasks/pack.js
@@ -1,10 +1,10 @@
 'use strict'
 
 const vfs = require('vinyl-fs')
-const zip = require('gulp-vinyl-zip')
+const zip = require('gulp-zip')
 
 module.exports = (src, dest, bundleName) => () =>
   vfs
     .src('**/*', { base: src, cwd: src })
-    .pipe(zip.zip(`${bundleName}-bundle.zip`))
+    .pipe(zip(`${bundleName}-bundle.zip`))
     .pipe(vfs.dest(dest))

--- a/src/main/content/antora_ui/package-lock.json
+++ b/src/main/content/antora_ui/package-lock.json
@@ -10095,10 +10095,14 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
-      "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }

--- a/src/main/content/antora_ui/package-lock.json
+++ b/src/main/content/antora_ui/package-lock.json
@@ -21,7 +21,7 @@
         "gulp-postcss": "~9.0",
         "gulp-sass": "^5.1.0",
         "gulp-uglify": "~3.0",
-        "gulp-vinyl-zip": "~2.1 >=2.1.2",
+        "gulp-zip": "~5.1",
         "handlebars": "^4.7.9",
         "highlight.js": "~10.7",
         "js-yaml": "^4.1.1",
@@ -3503,36 +3503,6 @@
         "es5-ext": "~0.10.14"
       }
     },
-    "node_modules/event-stream": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-      "integrity": "sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==",
-      "dev": true,
-      "dependencies": {
-        "duplexer": "~0.1.1",
-        "from": "~0",
-        "map-stream": "~0.1.0",
-        "pause-stream": "0.0.11",
-        "split": "0.3",
-        "stream-combiner": "~0.0.4",
-        "through": "~2.3.1"
-      }
-    },
-    "node_modules/event-stream/node_modules/map-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-      "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==",
-      "dev": true
-    },
-    "node_modules/event-stream/node_modules/stream-combiner": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-      "integrity": "sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==",
-      "dev": true,
-      "dependencies": {
-        "duplexer": "~0.1.1"
-      }
-    },
     "node_modules/events": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/events/-/events-2.1.0.tgz",
@@ -3862,6 +3832,7 @@
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "pend": "~1.2.0"
       }
@@ -4085,12 +4056,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/from": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
-      "dev": true
     },
     "node_modules/from2": {
       "version": "2.3.0",
@@ -5060,30 +5025,56 @@
         "xtend": "~4.0.1"
       }
     },
-    "node_modules/gulp-vinyl-zip": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.3.tgz",
-      "integrity": "sha512-wOHNPddyZ45il4wNz3Bk9ChpEq5FK/P76SSkqAMCLVZSOVtLBiDIVXDbYWDlfZpoYEjZQl+28I+Uzmmr6pSnBQ==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+    "node_modules/gulp-zip": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/gulp-zip/-/gulp-zip-5.1.0.tgz",
+      "integrity": "sha512-XZr/y91IliK/SpR74g3TkZejGkGEmK7CSDjSghT1jXshgO+dFvpLIz9w9fpuwkew6i7k4F+G24TubNgq1ISzEw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "event-stream": "3.3.4",
-        "queue": "^4.2.1",
-        "through2": "^2.0.3",
-        "vinyl": "^2.0.2",
-        "vinyl-fs": "^3.0.3",
-        "yauzl": "^2.2.1",
-        "yazl": "^2.2.1"
+        "get-stream": "^5.2.0",
+        "plugin-error": "^1.0.1",
+        "through2": "^3.0.1",
+        "vinyl": "^2.1.0",
+        "yazl": "^2.5.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "gulp": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "gulp": {
+          "optional": true
+        }
       }
     },
-    "node_modules/gulp-vinyl-zip/node_modules/through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+    "node_modules/gulp-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gulp-zip/node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/gulp/node_modules/convert-source-map": {
@@ -8065,15 +8056,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/pause-stream": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
-      "dev": true,
-      "dependencies": {
-        "through": "~2.3"
-      }
-    },
     "node_modules/pbkdf2": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.5.tgz",
@@ -8096,7 +8078,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -9069,15 +9052,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.x"
-      }
-    },
-    "node_modules/queue": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/queue/-/queue-4.5.1.tgz",
-      "integrity": "sha512-AMD7w5hRXcFSb8s9u38acBZ+309u6GsiibP4/0YacJeaurRshogB7v/ZcVPxP5gD5+zIw6ixRHdutiYUJfwKHw==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "~2.0.0"
       }
     },
     "node_modules/queue-microtask": {
@@ -10344,18 +10318,6 @@
       "dev": true,
       "license": "CC0-1.0",
       "optional": true
-    },
-    "node_modules/split": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-      "integrity": "sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==",
-      "dev": true,
-      "dependencies": {
-        "through": "2"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -12280,6 +12242,7 @@
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"

--- a/src/main/content/antora_ui/package.json
+++ b/src/main/content/antora_ui/package.json
@@ -28,7 +28,7 @@
     "gulp-postcss": "~9.0",
     "gulp-sass": "^5.1.0",
     "gulp-uglify": "~3.0",
-    "gulp-vinyl-zip": "~2.1 >=2.1.2",
+    "gulp-zip": "~5.1",
     "handlebars": "^4.7.9",
     "highlight.js": "~10.7",
     "js-yaml": "^4.1.1",


### PR DESCRIPTION
## Link to issue being addressed:

- Address https://github.com/OpenLiberty/openliberty.io/pull/4271
- Eliminated gulp-vinyl-zip@2.5.0 deprecation warning

## What was changed and why?

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
