### PR TITLE
Fix undesired scroll logic

### DIFF
--- a/src/main/content/_assets/js/builds.js
+++ b/src/main/content/_assets/js/builds.js
@@ -1516,6 +1516,9 @@ $(document).ready(function () {
 
             // Set the click event for each tab link
             $tab.click(function (e) {
+                //prevent page scroll up more than desired
+                e.preventDefault();
+            
                 // Change url when tab is clicked so that page can be bookmarked
                 window.location.hash = this.hash;
 


### PR DESCRIPTION
## Link to issue being addressed:
https://github.com/OpenLiberty/start.openliberty.io/issues/367

## What was changed and why?
Page was scrolling up more than desired in tabs of start page: Add to Existing Application and Download Package. 

## Tested using browser:
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Chrome (Desktop)

## Did you test accessibility:
- [ ] IBM Equal Access Accessibilty Checker
- [ ] Jaws (only relevant for new UX flows)
